### PR TITLE
implement read-only offline pwa

### DIFF
--- a/apps/app/playwright.self-hosted.config.ts
+++ b/apps/app/playwright.self-hosted.config.ts
@@ -13,13 +13,13 @@ const productionTestServer =
   `./node_modules/.bin/concurrently --kill-others ` +
   `"turso dev --db-file serial-test-self-hosted.db --port ${SELF_HOSTED_TURSO_PORT}" ` +
   `"./node_modules/.bin/dotenv -e .env.test.self-hosted -- node --import tsx src/server/db/migrate.ts && ` +
-  `./node_modules/.bin/dotenv -e .env.test.self-hosted -- env CI=1 ./node_modules/.bin/vite preview --port ${SELF_HOSTED_APP_PORT} --strictPort"`;
+  `./node_modules/.bin/dotenv -e .env.test.self-hosted -- env CI=1 NODE_ENV=production PORT=${SELF_HOSTED_APP_PORT} pnpm start"`;
 
 const bootstrapProductionTestServer =
   `./node_modules/.bin/concurrently --kill-others ` +
   `"turso dev --db-file serial-test-self-hosted-bootstrap.db --port ${SELF_HOSTED_BOOTSTRAP_TURSO_PORT}" ` +
   `"./node_modules/.bin/dotenv -e .env.test.self-hosted -- node --import tsx src/server/db/migrate.ts && ` +
-  `./node_modules/.bin/dotenv -e .env.test.self-hosted -- env CI=1 ./node_modules/.bin/vite preview --port ${SELF_HOSTED_BOOTSTRAP_APP_PORT} --strictPort"`;
+  `./node_modules/.bin/dotenv -e .env.test.self-hosted -- env CI=1 NODE_ENV=production PORT=${SELF_HOSTED_BOOTSTRAP_APP_PORT} pnpm start"`;
 
 const bootstrapDevelopmentTestServer =
   `./node_modules/.bin/concurrently --kill-others ` +

--- a/apps/app/scripts/test-e2e-cleanup.ts
+++ b/apps/app/scripts/test-e2e-cleanup.ts
@@ -150,10 +150,10 @@ function assertExpectedServices(processes: ProcessRow[], ports: number[]) {
   const [appPort, tursoPort, rssPort, bootstrapAppPort, bootstrapTursoPort] =
     ports;
   const expectedFragments = [
-    `vite preview --port ${appPort}`,
+    `NODE_ENV=production PORT=${appPort} pnpm start`,
     `turso dev --db-file serial-test-self-hosted.db --port ${tursoPort}`,
     `rss-server.ts ${rssPort}`,
-    `vite preview --port ${bootstrapAppPort}`,
+    `NODE_ENV=production PORT=${bootstrapAppPort} pnpm start`,
     `turso dev --db-file serial-test-self-hosted-bootstrap.db --port ${bootstrapTursoPort}`,
   ];
   const missingFragments = expectedFragments.filter(

--- a/apps/app/src/app/_app.feeds.tsx
+++ b/apps/app/src/app/_app.feeds.tsx
@@ -49,12 +49,21 @@ import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
 import { useQuickCreateViewMutation } from "~/lib/data/views/mutations";
 import { IS_DEMO_INSTANCE } from "~/lib/demo";
 import { useShiftSelect } from "~/lib/hooks/useShiftSelect";
+import { OfflineMutationBoundary } from "~/components/OfflineMutationBoundary";
 
 export const Route = createFileRoute("/_app/feeds")({
   component: ManageFeedsPage,
 });
 
 function ManageFeedsPage() {
+  return (
+    <OfflineMutationBoundary>
+      <ManageFeedsPageContent />
+    </OfflineMutationBoundary>
+  );
+}
+
+function ManageFeedsPageContent() {
   const { feeds } = useFeeds();
   const { feedCategories } = useFeedCategories();
   const { contentCategories } = useContentCategories();

--- a/apps/app/src/app/_app.feeds.tsx
+++ b/apps/app/src/app/_app.feeds.tsx
@@ -50,6 +50,7 @@ import { useQuickCreateViewMutation } from "~/lib/data/views/mutations";
 import { IS_DEMO_INSTANCE } from "~/lib/demo";
 import { useShiftSelect } from "~/lib/hooks/useShiftSelect";
 import { OfflineMutationBoundary } from "~/components/OfflineMutationBoundary";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export const Route = createFileRoute("/_app/feeds")({
   component: ManageFeedsPage,
@@ -64,6 +65,7 @@ function ManageFeedsPage() {
 }
 
 function ManageFeedsPageContent() {
+  const canMutate = useCanMutate();
   const { feeds } = useFeeds();
   const { feedCategories } = useFeedCategories();
   const { contentCategories } = useContentCategories();
@@ -233,6 +235,7 @@ function ManageFeedsPageContent() {
   };
 
   const handleDelete = () => {
+    if (!canMutate) return;
     const feedIds = Array.from(selectedFeedIds);
     const count = feedIds.length;
     setShowDeleteDialog(false);
@@ -329,6 +332,7 @@ function ManageFeedsPageContent() {
   });
 
   const handleEditSave = () => {
+    if (!canMutate) return;
     const feedIds = Array.from(selectedFeedIds);
     const count = feedIds.length;
     const sharedCategories = getSharedCategories();
@@ -705,7 +709,7 @@ function ManageFeedsPageContent() {
             variant="destructive"
             className="flex-1"
             onClick={handleDelete}
-            disabled={isDeletingFeeds}
+            disabled={!canMutate || isDeletingFeeds}
           >
             {isDeletingFeeds ? "Deleting..." : "Delete"}
           </Button>
@@ -745,6 +749,7 @@ function ManageFeedsPageContent() {
               className="flex-1"
               onClick={handleEditSave}
               disabled={
+                !canMutate ||
                 isAssigningCategory ||
                 isRemovingCategory ||
                 isAssigningView ||

--- a/apps/app/src/app/_app.import.tsx
+++ b/apps/app/src/app/_app.import.tsx
@@ -39,7 +39,7 @@ import { useImportDropStore } from "~/lib/data/import-drop";
 import { useImportResults, useLoadingMode } from "~/lib/data/loading-machine";
 import { dataRequestActions } from "~/lib/data/directRequests";
 import { IS_DEMO_INSTANCE } from "~/lib/demo";
-import { OfflineMutationBoundary } from "~/components/OfflineMutationBoundary";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 function ImportedFeedStatus({
   feedUrl,
@@ -101,14 +101,7 @@ const IMPORT_MODE_OPTIONS: Array<CardRadioOption<ImportMode>> = [
 ];
 
 function EditFeedsPage() {
-  return (
-    <OfflineMutationBoundary>
-      <EditFeedsPageContent />
-    </OfflineMutationBoundary>
-  );
-}
-
-function EditFeedsPageContent() {
+  const canMutate = useCanMutate();
   const inputElementRef = useRef<HTMLInputElement | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
@@ -289,7 +282,7 @@ function EditFeedsPageContent() {
   }
 
   return (
-    <div>
+    <fieldset className="contents" disabled={!canMutate}>
       <div className="mx-auto max-w-2xl p-6">
         <h2 className="font-sans text-lg">Import Feeds</h2>
         {!isPostImportScreen && (
@@ -600,6 +593,6 @@ function EditFeedsPageContent() {
           </div>
         </div>
       )}
-    </div>
+    </fieldset>
   );
 }

--- a/apps/app/src/app/_app.import.tsx
+++ b/apps/app/src/app/_app.import.tsx
@@ -39,6 +39,7 @@ import { useImportDropStore } from "~/lib/data/import-drop";
 import { useImportResults, useLoadingMode } from "~/lib/data/loading-machine";
 import { dataRequestActions } from "~/lib/data/directRequests";
 import { IS_DEMO_INSTANCE } from "~/lib/demo";
+import { OfflineMutationBoundary } from "~/components/OfflineMutationBoundary";
 
 function ImportedFeedStatus({
   feedUrl,
@@ -100,6 +101,14 @@ const IMPORT_MODE_OPTIONS: Array<CardRadioOption<ImportMode>> = [
 ];
 
 function EditFeedsPage() {
+  return (
+    <OfflineMutationBoundary>
+      <EditFeedsPageContent />
+    </OfflineMutationBoundary>
+  );
+}
+
+function EditFeedsPageContent() {
   const inputElementRef = useRef<HTMLInputElement | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 

--- a/apps/app/src/app/_app.read.$id.tsx
+++ b/apps/app/src/app/_app.read.$id.tsx
@@ -44,6 +44,7 @@ import { useBookmarkValue } from "~/lib/data/bookmarks";
 import { BookmarkReader } from "~/components/content-reader/BookmarkReader";
 import { ContentRendererFallback } from "~/components/content-renderer/ContentRendererFallback";
 import { getArticleWidthLayout } from "~/components/content-reader/articleWidth";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 import {
   contentDestination,
   resolveContentItem,
@@ -91,6 +92,7 @@ function FeedReader({
   id: string;
   hasRefreshedFeedItem: boolean;
 }) {
+  const canMutate = useCanMutate();
   useRetentionPin("feed-item", id);
 
   const [articleStyle] = useFlagState("ARTICLE_STYLE");
@@ -187,7 +189,7 @@ function FeedReader({
     detectTruncatedContent(feedItem.content, feedItem.contentSnippet);
 
   const handleAlertResponse = (openLocation: "serial" | "origin") => {
-    if (!feedId) return;
+    if (!feedId || !canMutate) return;
 
     const categoryIds = feedCategories
       .filter((fc) => fc.feedId === feedId)
@@ -270,11 +272,15 @@ function FeedReader({
             <div className="mt-4 flex gap-2">
               <Button
                 variant="outline"
+                disabled={!canMutate}
                 onClick={() => handleAlertResponse("serial")}
               >
                 No, view in reader
               </Button>
-              <Button onClick={() => handleAlertResponse("origin")}>
+              <Button
+                disabled={!canMutate}
+                onClick={() => handleAlertResponse("origin")}
+              >
                 Yes, open in website
               </Button>
             </div>

--- a/apps/app/src/app/_app.tags.tsx
+++ b/apps/app/src/app/_app.tags.tsx
@@ -203,6 +203,7 @@ function ManageTagsPageContent() {
   };
 
   const handleDelete = async () => {
+    if (!canMutate) return;
     const ids = Array.from(selectedTagIds);
     const count = ids.length;
     setShowDeleteDialog(false);
@@ -412,7 +413,7 @@ function ManageTagsPageContent() {
             variant="destructive"
             className="flex-1"
             onClick={handleDelete}
-            disabled={isDeletingTag}
+            disabled={!canMutate || isDeletingTag}
           >
             {isDeletingTag ? "Deleting..." : "Delete"}
           </Button>

--- a/apps/app/src/app/_app.tags.tsx
+++ b/apps/app/src/app/_app.tags.tsx
@@ -29,18 +29,30 @@ import { useViews } from "~/lib/data/views";
 import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
 import { useShiftSelect } from "~/lib/hooks/useShiftSelect";
 import { useShortcut } from "~/lib/hooks/useShortcut";
+import { OfflineMutationBoundary } from "~/components/OfflineMutationBoundary";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export const Route = createFileRoute("/_app/tags")({
   component: ManageTagsPage,
 });
 
 function ManageTagsPage() {
+  return (
+    <OfflineMutationBoundary>
+      <ManageTagsPageContent />
+    </OfflineMutationBoundary>
+  );
+}
+
+function ManageTagsPageContent() {
+  const canMutate = useCanMutate();
   const { contentCategories } = useContentCategories();
   const { feedCategories } = useFeedCategories();
   const { feeds } = useFeeds();
   const { views } = useViews();
   const { launchDialog } = useDialogStore();
   useShortcut("a", (event) => {
+    if (!canMutate) return;
     event.preventDefault();
     launchDialog("add-content-category");
   });

--- a/apps/app/src/app/_app.tsx
+++ b/apps/app/src/app/_app.tsx
@@ -21,6 +21,7 @@ import { useDialogStore } from "~/components/feed/dialogStore";
 import { DemoBanner } from "~/components/DemoBanner";
 import { ClientPerformanceProfiler } from "~/components/debug/ClientPerformanceProfiler";
 import { ImpersonationBanner } from "~/components/ImpersonationBanner";
+import { OfflineBanner } from "~/components/OfflineBanner";
 import { ReleaseNotifier } from "~/components/releases/ReleaseNotifier";
 import { SidebarInset, SidebarProvider } from "~/components/ui/sidebar";
 import { InitialClientQueries } from "~/lib/data/InitialClientQueries";
@@ -262,6 +263,7 @@ function RootLayout() {
           <div className="flex h-svh flex-col overflow-hidden">
             <ImpersonationBanner />
             <DemoBanner />
+            <OfflineBanner />
             <SidebarProvider
               className="h-auto min-h-0 flex-1"
               style={

--- a/apps/app/src/app/_app.views.tsx
+++ b/apps/app/src/app/_app.views.tsx
@@ -26,17 +26,29 @@ import {
 import { useShiftSelect } from "~/lib/hooks/useShiftSelect";
 import { useShortcut } from "~/lib/hooks/useShortcut";
 import { VIEW_READ_STATUS } from "~/server/db/constants";
+import { OfflineMutationBoundary } from "~/components/OfflineMutationBoundary";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export const Route = createFileRoute("/_app/views")({
   component: ManageViewsPage,
 });
 
 function ManageViewsPage() {
+  return (
+    <OfflineMutationBoundary>
+      <ManageViewsPageContent />
+    </OfflineMutationBoundary>
+  );
+}
+
+function ManageViewsPageContent() {
+  const canMutate = useCanMutate();
   const { views } = useViews();
   const { feeds } = useFeeds();
   const { contentCategories } = useContentCategories();
   const { launchDialog } = useDialogStore();
   useShortcut("a", (event) => {
+    if (!canMutate) return;
     event.preventDefault();
     launchDialog("add-view");
   });

--- a/apps/app/src/app/_app.views.tsx
+++ b/apps/app/src/app/_app.views.tsx
@@ -166,6 +166,7 @@ function ManageViewsPageContent() {
   };
 
   const handleDelete = async () => {
+    if (!canMutate) return;
     const ids = Array.from(selectedViewIds);
     const count = ids.length;
     setShowDeleteDialog(false);
@@ -383,7 +384,7 @@ function ManageViewsPageContent() {
             variant="destructive"
             className="flex-1"
             onClick={handleDelete}
-            disabled={isDeletingView}
+            disabled={!canMutate || isDeletingView}
           >
             {isDeletingView ? "Deleting..." : "Delete"}
           </Button>

--- a/apps/app/src/app/sw[.]js.ts
+++ b/apps/app/src/app/sw[.]js.ts
@@ -4,6 +4,18 @@ import { createFileRoute } from "@tanstack/react-router";
 
 const SERVICE_WORKER_PATH = path.resolve(process.cwd(), ".output/public/sw.js");
 
+// The generated worker is immutable for the lifetime of a deployed server
+// process, so one read serves every request.
+let serviceWorkerPromise: Promise<string | null> | undefined;
+
+function loadServiceWorker() {
+  serviceWorkerPromise ??= readFile(SERVICE_WORKER_PATH, "utf8").catch(() => {
+    serviceWorkerPromise = undefined;
+    return null;
+  });
+  return serviceWorkerPromise;
+}
+
 export const Route = createFileRoute("/sw.js")({
   server: {
     handlers: {
@@ -12,7 +24,10 @@ export const Route = createFileRoute("/sw.js")({
           return new Response("Not Found", { status: 404 });
         }
 
-        const serviceWorker = await readFile(SERVICE_WORKER_PATH, "utf8");
+        const serviceWorker = await loadServiceWorker();
+        if (serviceWorker === null) {
+          return new Response("Not Found", { status: 404 });
+        }
 
         return new Response(serviceWorker, {
           headers: {

--- a/apps/app/src/app/sw[.]js.ts
+++ b/apps/app/src/app/sw[.]js.ts
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { createFileRoute } from "@tanstack/react-router";
+
+const SERVICE_WORKER_PATH = path.resolve(process.cwd(), ".output/public/sw.js");
+
+export const Route = createFileRoute("/sw.js")({
+  server: {
+    handlers: {
+      GET: async () => {
+        if (process.env.NODE_ENV !== "production") {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const serviceWorker = await readFile(SERVICE_WORKER_PATH, "utf8");
+
+        return new Response(serviceWorker, {
+          headers: {
+            "Cache-Control": "no-cache",
+            "Content-Type": "application/javascript; charset=utf-8",
+            "Service-Worker-Allowed": "/",
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/app/src/components/AddFeedDialog.tsx
+++ b/apps/app/src/components/AddFeedDialog.tsx
@@ -45,6 +45,7 @@ import { VIEW_LAYOUT_ITEM_TYPE } from "~/server/db/constants";
 import { getAssumedFeedPlatform } from "~/server/rss/validateFeedUrl";
 import { useSaveBookmarkMutation } from "~/lib/data/bookmarks/mutations";
 import { BookmarkOrganizationEditor } from "~/components/bookmarks/BookmarkOrganizationEditor";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 function useViewOptions() {
   const { views } = useViews();
@@ -66,6 +67,7 @@ function toggleSelectedId(
 }
 
 export function AddFeedDialog() {
+  const canMutate = useCanMutate();
   const [pendingAction, setPendingAction] = useState<
     "feed" | "bookmark" | null
   >(null);
@@ -89,6 +91,7 @@ export function AddFeedDialog() {
   const launchDialog = useDialogStore((store) => store.launchDialog);
   const location = useLocation();
   useShortcut("a", (event) => {
+    if (!canMutate) return;
     if (
       location.pathname.startsWith("/views") ||
       location.pathname.startsWith("/tags")
@@ -110,7 +113,7 @@ export function AddFeedDialog() {
   };
 
   const handleSelectFeed = async (feed: { url: string }) => {
-    if (pendingAction) return;
+    if (pendingAction || !canMutate) return;
     setPendingAction("feed");
 
     const createFeedPromise = createFeed({
@@ -139,7 +142,7 @@ export function AddFeedDialog() {
   };
 
   const handleSelectBookmark = async (sourceUrl: string) => {
-    if (pendingAction) return;
+    if (pendingAction || !canMutate) return;
     setPendingAction("bookmark");
     try {
       const result = await saveBookmark({ sourceUrl });
@@ -194,7 +197,7 @@ export function AddFeedDialog() {
   }, [isOpen]);
 
   return (
-    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+    <Dialog open={isOpen && canMutate} onOpenChange={onOpenChange}>
       <DialogContent
         ref={dialogContentRef}
         hideClose
@@ -290,6 +293,7 @@ export function EditFeedDialog({
   selectedFeedId: null | number;
   onClose: () => void;
 }) {
+  const canMutate = useCanMutate();
   const [isUpdatingFeed, setIsUpdatingFeed] = useState(false);
   const [isDeletingFeed, setIsDeletingFeed] = useState(false);
   const [hasCopied, setHasCopied] = useState(false);
@@ -387,6 +391,7 @@ export function EditFeedDialog({
           <TooltipTrigger asChild>
             <div className="flex items-center">
               <Switch
+                disabled={!canMutate}
                 checked={feed?.isActive ?? true}
                 onCheckedChange={(checked) => {
                   if (selectedFeedId !== null) {
@@ -407,11 +412,11 @@ export function EditFeedDialog({
       footer={
         <div className="flex gap-2">
           <Button
-            disabled={isDeletingFeed}
+            disabled={!canMutate || isDeletingFeed}
             className="flex-1"
             variant="destructive"
             onClick={async () => {
-              if (selectedFeedId === null) return;
+              if (selectedFeedId === null || !canMutate) return;
 
               setIsDeletingFeed(true);
               try {
@@ -436,9 +441,9 @@ export function EditFeedDialog({
             {isDeletingFeed ? "Deleting..." : "Delete"}
           </Button>
           <Button
-            disabled={isFormDisabled || isUpdatingFeed}
+            disabled={!canMutate || isFormDisabled || isUpdatingFeed}
             onClick={async () => {
-              if (selectedFeedId === null) return;
+              if (selectedFeedId === null || !canMutate) return;
 
               setIsUpdatingFeed(true);
               try {
@@ -524,6 +529,7 @@ export function EditFeedDialog({
             toggleSelectedId(selectedViewIds, setSelectedViewIds, id)
           }
           onCreate={async (viewName) => {
+            if (!canMutate) return;
             try {
               const createdView = await quickCreateView({ name: viewName });
               if (createdView) {
@@ -548,6 +554,7 @@ export function EditFeedDialog({
             toggleSelectedId(selectedCategories, setSelectedCategories, id)
           }
           onCreate={async (tagName) => {
+            if (!canMutate) return;
             try {
               const createdTag = await createContentCategory({
                 name: tagName,

--- a/apps/app/src/components/OfflineBanner.tsx
+++ b/apps/app/src/components/OfflineBanner.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useAtomValue } from "jotai";
+import { useEffect, useState } from "react";
+import { connectionStateAtom } from "~/lib/data/atoms";
+
+const OFFLINE_BANNER_DELAY_MS = 1_000;
+
+export function OfflineBanner() {
+  const connectionState = useAtomValue(connectionStateAtom);
+
+  if (connectionState !== "disconnected") return null;
+
+  return <DelayedOfflineBanner />;
+}
+
+function DelayedOfflineBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setVisible(true), OFFLINE_BANNER_DELAY_MS);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="bg-sidebar text-sidebar-foreground shrink-0 px-4 py-2 text-center text-sm font-medium"
+      role="status"
+    >
+      Offline, some features may be disabled
+    </div>
+  );
+}

--- a/apps/app/src/components/OfflineMutationBoundary.tsx
+++ b/apps/app/src/components/OfflineMutationBoundary.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import type { PropsWithChildren } from "react";
+import { useCanMutate } from "~/lib/data/offline-mutations";
+
+export function OfflineMutationBoundary({ children }: PropsWithChildren) {
+  const canMutate = useCanMutate();
+  return (
+    <fieldset className="contents" disabled={!canMutate}>
+      {children}
+    </fieldset>
+  );
+}

--- a/apps/app/src/components/bookmarks/BookmarkOrganizationEditor.tsx
+++ b/apps/app/src/components/bookmarks/BookmarkOrganizationEditor.tsx
@@ -23,6 +23,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from "~/components/ui/dialog";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 type SaveFeedback = Pick<
   BookmarkSaveResult<unknown>,
@@ -39,6 +40,7 @@ export function BookmarkOrganizationEditor({
   onClose: () => void;
 }) {
   const bookmark = useBookmarkValue(bookmarkId);
+  const canMutate = useCanMutate();
   const { views } = useViews();
   const { contentCategories } = useContentCategories();
   const [selectedViewIds, setSelectedViewIds] = useState<number[]>(
@@ -85,6 +87,7 @@ export function BookmarkOrganizationEditor({
   }
 
   const toggleView = async (viewId: number) => {
+    if (!canMutate) return;
     const assigned = !selectedViewIds.includes(viewId);
     setSelectedViewIds((ids) =>
       assigned ? [...ids, viewId] : ids.filter((id) => id !== viewId),
@@ -99,6 +102,7 @@ export function BookmarkOrganizationEditor({
   };
 
   const toggleTag = async (tagId: number) => {
+    if (!canMutate) return;
     const assigned = !selectedTagIds.includes(tagId);
     setSelectedTagIds((ids) =>
       assigned ? [...ids, tagId] : ids.filter((id) => id !== tagId),
@@ -121,6 +125,7 @@ export function BookmarkOrganizationEditor({
       selectedViewIds={selectedViewIds}
       onToggleView={(id) => void toggleView(id)}
       onCreateView={async (name) => {
+        if (!canMutate) return;
         const createdView = await quickCreateView({ name });
         if (!createdView) return;
         setSelectedViewIds((ids) => [...ids, createdView.id]);
@@ -135,6 +140,7 @@ export function BookmarkOrganizationEditor({
       prioritizedTagIds={prioritizedTagIds}
       onToggleTag={(id) => void toggleTag(id)}
       onCreateTag={async (name) => {
+        if (!canMutate) return;
         const createdTag = await createContentCategory({
           name,
           feedCategorizations: [],
@@ -148,7 +154,9 @@ export function BookmarkOrganizationEditor({
         });
       }}
       isDeleting={isDeleting}
+      disabled={!canMutate}
       onDelete={async () => {
+        if (!canMutate) return;
         await deleteBookmark({ bookmarkId });
         toast.success("Bookmark deleted");
         onClose();

--- a/apps/app/src/components/bookmarks/BookmarkReaderActions.tsx
+++ b/apps/app/src/components/bookmarks/BookmarkReaderActions.tsx
@@ -11,17 +11,19 @@ import { SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
 import { useBookmarkValue } from "~/lib/data/bookmarks";
 import { useUpdateBookmarkStateMutation } from "~/lib/data/bookmarks/mutations";
 import { useShortcut } from "~/lib/hooks/useShortcut";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export function BookmarkReaderActions({ bookmarkId }: { bookmarkId: string }) {
   const bookmark = useBookmarkValue(bookmarkId);
+  const canMutate = useCanMutate();
   const { mutate: updateState } = useUpdateBookmarkStateMutation(bookmarkId);
 
   const toggleSaved = () => {
-    if (!bookmark) return;
+    if (!bookmark || !canMutate) return;
     updateState({ bookmarkId, isSaved: !bookmark.isSaved });
   };
   const toggleRead = () => {
-    if (!bookmark) return;
+    if (!bookmark || !canMutate) return;
     updateState({ bookmarkId, isRead: !bookmark.isRead });
   };
 
@@ -36,6 +38,7 @@ export function BookmarkReaderActions({ bookmarkId }: { bookmarkId: string }) {
         shortcut={SHORTCUT_KEYS.TOGGLE_SAVED}
         variant={bookmark.isSaved ? "secondary" : "outline"}
         aria-label={bookmark.isSaved ? "Unsave" : "Save"}
+        disabled={!canMutate}
         onClick={toggleSaved}
         size="icon md:default"
       >
@@ -52,6 +55,7 @@ export function BookmarkReaderActions({ bookmarkId }: { bookmarkId: string }) {
         shortcut={SHORTCUT_KEYS.TOGGLE_READ}
         variant={bookmark.isRead ? "secondary" : "outline"}
         aria-label={bookmark.isRead ? "Unarchive" : "Archive"}
+        disabled={!canMutate}
         onClick={toggleRead}
         size="icon md:default"
       >

--- a/apps/app/src/components/content-category-dialog/AddContentCategoryDialog.tsx
+++ b/apps/app/src/components/content-category-dialog/AddContentCategoryDialog.tsx
@@ -5,11 +5,13 @@ import { toast } from "sonner";
 import { CategoryFeedsInput } from "./CategoryFeedsInput";
 import { CategoryNameInput } from "./CategoryNameInput";
 import { Button } from "~/components/ui/button";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 import { ControlledResponsiveDialog } from "~/components/ui/responsive-dropdown";
 import { useDialogStore } from "~/components/feed/dialogStore";
 import { useCreateContentCategoryMutation } from "~/lib/data/content-categories/mutations";
 
 export function AddContentCategoryDialog() {
+  const canMutate = useCanMutate();
   const [isAddingContentCategory, setIsAddingContentCategory] = useState(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
   const { mutateAsync: createContentCategory } =
@@ -50,8 +52,9 @@ export function AddContentCategoryDialog() {
           setSelectedFeedIds={setSelectedFeedIds}
         />
         <Button
-          disabled={isDisabled}
+          disabled={!canMutate || isDisabled}
           onClick={() => {
+            if (!canMutate) return;
             setIsAddingContentCategory(true);
 
             try {

--- a/apps/app/src/components/content-category-dialog/BulkAssignFeedsToTagsContent.tsx
+++ b/apps/app/src/components/content-category-dialog/BulkAssignFeedsToTagsContent.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { CategoryFeedsInput } from "./CategoryFeedsInput";
 import { Button } from "~/components/ui/button";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 import { useContentCategories } from "~/lib/data/content-categories";
 import { useUpdateContentCategoryMutation } from "~/lib/data/content-categories/mutations";
 
@@ -14,6 +15,7 @@ export function BulkAssignFeedsToTagsContent({
   selectedTagIds: number[];
   onClose: () => void;
 }) {
+  const canMutate = useCanMutate();
   const [isAssigning, setIsAssigning] = useState(false);
   const [selectedFeedIds, setSelectedFeedIds] = useState<number[]>([]);
   const { mutateAsync: updateContentCategory } =
@@ -21,6 +23,7 @@ export function BulkAssignFeedsToTagsContent({
   const { contentCategories } = useContentCategories();
 
   const handleSave = () => {
+    if (!canMutate) return;
     if (selectedTagIds.length === 0 || selectedFeedIds.length === 0) {
       onClose();
       return;
@@ -65,7 +68,7 @@ export function BulkAssignFeedsToTagsContent({
         <Button
           className="flex-1"
           onClick={handleSave}
-          disabled={isAssigning || selectedFeedIds.length === 0}
+          disabled={!canMutate || isAssigning || selectedFeedIds.length === 0}
         >
           {isAssigning ? "Saving..." : "Assign"}
         </Button>

--- a/apps/app/src/components/content-category-dialog/EditContentCategoryDialogContent.tsx
+++ b/apps/app/src/components/content-category-dialog/EditContentCategoryDialogContent.tsx
@@ -6,6 +6,7 @@ import { CategoryFeedsInput } from "./CategoryFeedsInput";
 import { CategoryNameInput } from "./CategoryNameInput";
 import type { FeedCategorization } from "~/server/api/routers/contentCategoriesRouter";
 import { Button } from "~/components/ui/button";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 import { ControlledResponsiveDialog } from "~/components/ui/responsive-dropdown";
 import {
   useDeleteContentCategoryMutation,
@@ -23,6 +24,7 @@ export function EditContentCategoryDialogContent({
   initialFeedIds: number[];
   onClose: () => void;
 }) {
+  const canMutate = useCanMutate();
   const [isUpdatingContentCategory, setIsUpdatingContentCategory] =
     useState(false);
   const [isDeletingContentCategory, setIsDeletingContentCategory] =
@@ -43,11 +45,11 @@ export function EditContentCategoryDialogContent({
       footer={
         <div className="flex gap-2">
           <Button
-            disabled={isDeletingContentCategory}
+            disabled={!canMutate || isDeletingContentCategory}
             className="flex-1"
             variant="destructive"
             onClick={() => {
-              if (selectedContentCategoryId === null) return;
+              if (!canMutate || selectedContentCategoryId === null) return;
 
               setIsDeletingContentCategory(true);
               try {
@@ -74,9 +76,9 @@ export function EditContentCategoryDialogContent({
             {isDeletingContentCategory ? "Deleting..." : "Delete"}
           </Button>
           <Button
-            disabled={isFormDisabled || isUpdatingContentCategory}
+            disabled={!canMutate || isFormDisabled || isUpdatingContentCategory}
             onClick={() => {
-              if (selectedContentCategoryId === null) return;
+              if (!canMutate || selectedContentCategoryId === null) return;
 
               setIsUpdatingContentCategory(true);
               try {

--- a/apps/app/src/components/content-reader/BookmarkReader.tsx
+++ b/apps/app/src/components/content-reader/BookmarkReader.tsx
@@ -16,6 +16,11 @@ import { Button } from "~/components/ui/button";
 import { barsHiddenAtom } from "~/lib/data/atoms";
 import { useBookmarkValue } from "~/lib/data/bookmarks";
 import {
+  bookmarkCapturesStore,
+  useBookmarkCaptureValue,
+} from "~/lib/data/bookmarks/capture-store";
+import { shouldRetainBookmarkCapture } from "~/lib/data/offline-content";
+import {
   getClosestVisibleElement,
   getElements,
   useArticleNavigation,
@@ -30,14 +35,24 @@ import { orpcRouterClient } from "~/lib/orpc";
 import { getOriginActionLabel } from "~/lib/content/capabilities";
 import { REMOTE_IMAGE_PROPS } from "~/lib/remoteMedia";
 
-const captureCache = new Map<string, DatabasePageCapture>();
-
 export function BookmarkReader({ id }: { id: string }) {
   const bookmark = useBookmarkValue(id);
   const refreshedBookmark = useRefreshBookmark(id);
-  const [capture, setCapture] = useState<
-    DatabasePageCapture | null | undefined
-  >(() => captureCache.get(id));
+  const retainedCapture = useBookmarkCaptureValue(id);
+  const retainCapture = bookmark
+    ? shouldRetainBookmarkCapture(bookmark)
+    : false;
+  const [captureResult, setCaptureResult] = useState<{
+    bookmarkId: string;
+    capture: DatabasePageCapture | null;
+    source: "authoritative" | "failure";
+  }>();
+  const capture =
+    captureResult?.bookmarkId === id
+      ? captureResult.source === "failure"
+        ? (retainedCapture ?? captureResult.capture)
+        : captureResult.capture
+      : retainedCapture;
   const articleRef = useRef<HTMLDivElement>(null);
   const [articleElement, setArticleElement] = useState<HTMLDivElement | null>(
     null,
@@ -51,7 +66,7 @@ export function BookmarkReader({ id }: { id: string }) {
 
   useEffect(() => {
     let active = true;
-    const cachedCapture = captureCache.get(id);
+    const cachedCapture = bookmarkCapturesStore.getState().capturesDict[id];
     void orpcRouterClient.bookmark
       .getCapture({
         bookmarkId: id,
@@ -60,21 +75,45 @@ export function BookmarkReader({ id }: { id: string }) {
       .then((result) => {
         if (!active) return;
         if (result?.status === "capture") {
-          captureCache.set(id, result.capture);
-          setCapture(result.capture);
+          if (retainCapture) {
+            bookmarkCapturesStore.getState().upsert(result.capture);
+          }
+          setCaptureResult({
+            bookmarkId: id,
+            capture: result.capture,
+            source: "authoritative",
+          });
         } else if (result?.status === "not-modified" && cachedCapture) {
-          setCapture(cachedCapture);
+          setCaptureResult({
+            bookmarkId: id,
+            capture: cachedCapture,
+            source: "authoritative",
+          });
         } else {
-          setCapture(null);
+          bookmarkCapturesStore.getState().remove(id);
+          setCaptureResult({
+            bookmarkId: id,
+            capture: null,
+            source: "authoritative",
+          });
         }
       })
       .catch(() => {
-        if (active) setCapture(null);
+        if (active) {
+          setCaptureResult((current) => ({
+            bookmarkId: id,
+            source: "failure",
+            capture:
+              current?.bookmarkId === id
+                ? current.capture
+                : (cachedCapture ?? null),
+          }));
+        }
       });
     return () => {
       active = false;
     };
-  }, [id, bookmark?.captureHash]);
+  }, [id, bookmark?.captureHash, retainCapture]);
 
   useScrollDirection((direction) => setBarsHidden(direction === "down"));
   useEffect(() => () => setBarsHidden(false), [setBarsHidden]);

--- a/apps/app/src/components/content-reader/BookmarkReader.tsx
+++ b/apps/app/src/components/content-reader/BookmarkReader.tsx
@@ -15,6 +15,7 @@ import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { barsHiddenAtom } from "~/lib/data/atoms";
 import { useBookmarkValue } from "~/lib/data/bookmarks";
+import { bookmarksStore } from "~/lib/data/bookmarks/store";
 import {
   bookmarkCapturesStore,
   useBookmarkCaptureValue,
@@ -39,9 +40,6 @@ export function BookmarkReader({ id }: { id: string }) {
   const bookmark = useBookmarkValue(id);
   const refreshedBookmark = useRefreshBookmark(id);
   const retainedCapture = useBookmarkCaptureValue(id);
-  const retainCapture = bookmark
-    ? shouldRetainBookmarkCapture(bookmark)
-    : false;
   const [captureResult, setCaptureResult] = useState<{
     bookmarkId: string;
     capture: DatabasePageCapture | null;
@@ -75,7 +73,10 @@ export function BookmarkReader({ id }: { id: string }) {
       .then((result) => {
         if (!active) return;
         if (result?.status === "capture") {
-          if (retainCapture) {
+          // Retention is judged when the response lands so an archive that
+          // happened mid-flight cannot re-persist the capture.
+          const latestBookmark = bookmarksStore.getState().getBookmark(id);
+          if (latestBookmark && shouldRetainBookmarkCapture(latestBookmark)) {
             bookmarkCapturesStore.getState().upsert(result.capture);
           }
           setCaptureResult({
@@ -113,7 +114,7 @@ export function BookmarkReader({ id }: { id: string }) {
     return () => {
       active = false;
     };
-  }, [id, bookmark?.captureHash, retainCapture]);
+  }, [id, bookmark?.captureHash]);
 
   useScrollDirection((direction) => setBarsHidden(direction === "down"));
   useEffect(() => () => setBarsHidden(false), [setBarsHidden]);

--- a/apps/app/src/components/feed/AppDialogs.tsx
+++ b/apps/app/src/components/feed/AppDialogs.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useDialogStore } from "./dialogStore";
 import { SubscriptionDialog } from "./subscription-dialog/SubscriptionDialog";
 import { UserProfileEditDialog } from "./UserProfileEditDialog";
@@ -7,10 +8,16 @@ import { AddViewDialog } from "~/components/view-dialog";
 import { ConnectionsDialog } from "~/components/ConnectionsDialog";
 import { CustomVideoDialog } from "~/components/CustomVideoDialog";
 import { EditBookmarkDialog } from "~/components/bookmarks/BookmarkOrganizationEditor";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export function AppDialogs() {
+  const canMutate = useCanMutate();
   const { dialog, closeDialog, selectedFeedId, selectedBookmarkId } =
     useDialogStore();
+
+  useEffect(() => {
+    if (!canMutate && dialog) closeDialog();
+  }, [canMutate, closeDialog, dialog]);
 
   return (
     <>

--- a/apps/app/src/components/feed/MarkVisibleAsReadButton.tsx
+++ b/apps/app/src/components/feed/MarkVisibleAsReadButton.tsx
@@ -22,10 +22,12 @@ import { bookmarksStore } from "~/lib/data/bookmarks/store";
 import { setMixedReadValue } from "~/lib/data/mixed-content/mutations";
 import { useLoadMoreItems } from "~/lib/hooks/useLoadMoreItems";
 import { isInboxUnread } from "~/lib/content-status";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 let nextUndoRetentionOwnerId = 0;
 
 export function MarkVisibleAsReadButton() {
+  const canMutate = useCanMutate();
   const [isLoading, setIsLoading] = useState(false);
   const setSelectedItemId = useSetAtom(selectedItemIdAtom);
   const scrollToItem = useScrollToFeedItem();
@@ -45,6 +47,7 @@ export function MarkVisibleAsReadButton() {
   }, [scrollToItem, setSelectedItemId]);
 
   const handleMarkAsRead = async () => {
+    if (!canMutate) return;
     if (!isInboxUnread(contentStatusFilter) || filteredItemIds.length === 0)
       return;
 
@@ -111,7 +114,7 @@ export function MarkVisibleAsReadButton() {
     <div className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2">
       <ButtonWithShortcut
         onClick={handleMarkAsRead}
-        disabled={isLoading}
+        disabled={!canMutate || isLoading}
         className="shadow-lg"
         variant="outline"
         size="default"

--- a/apps/app/src/components/feed/SidebarCategories.tsx
+++ b/apps/app/src/components/feed/SidebarCategories.tsx
@@ -29,8 +29,10 @@ import {
 } from "~/lib/data/navigation/store";
 import { isContentStatusAvailable } from "~/lib/content-status";
 import { Skeleton } from "~/components/ui/skeleton";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export function SidebarCategories() {
+  const canMutate = useCanMutate();
   const [
     selectedContentCategoryForEditing,
     setSelectedContentCategoryForEditing,
@@ -84,6 +86,7 @@ export function SidebarCategories() {
               </Link>
             </SidebarMenuButton>
             <SidebarMenuButton
+              disabled={!canMutate}
               onClick={() => launchDialog("add-content-category")}
             >
               <PlusIcon />

--- a/apps/app/src/components/feed/SidebarFeeds.tsx
+++ b/apps/app/src/components/feed/SidebarFeeds.tsx
@@ -43,6 +43,7 @@ import {
   useNavigationSnapshotStatus,
 } from "~/lib/data/navigation/store";
 import { isContentStatusAvailable } from "~/lib/content-status";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 function useDebouncedState(defaultValue: string, delay: number) {
   const [searchQuery, setSearchQuery] = useState(defaultValue);
@@ -141,6 +142,7 @@ function ActiveFeedSidebarItem({
 }
 
 export function SidebarFeeds() {
+  const canMutate = useCanMutate();
   const [searchQuery, setSearchQuery] = useDebouncedState("", 300);
 
   const [selectedFeedForEditing, setSelectedFeedForEditing] = useState<
@@ -179,6 +181,7 @@ export function SidebarFeeds() {
                 onClick={() => launchDialog("add-feed")}
               >
                 <ButtonWithShortcut
+                  disabled={!canMutate}
                   shortcut="a"
                   variant="ghost"
                   aria-label="Add Feed or Bookmark"
@@ -293,6 +296,7 @@ export function SidebarFeeds() {
             <SidebarMenuButton
               size="default-icon"
               aria-label="Add Feed or Bookmark"
+              disabled={!canMutate}
               onClick={() => launchDialog("add-feed")}
             >
               <PlusIcon />

--- a/apps/app/src/components/feed/SidebarViews.tsx
+++ b/apps/app/src/components/feed/SidebarViews.tsx
@@ -53,6 +53,7 @@ import {
   getViewContentAvailability,
   mixedContentStore,
 } from "~/lib/data/mixed-content/store";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 type ViewOption = ApplicationView & { hasEntries: boolean };
 
@@ -121,6 +122,7 @@ function ViewSidebarItem({
 }
 
 export function SidebarViews() {
+  const canMutate = useCanMutate();
   const [selectedViewForEditing, setSelectedViewForEditing] = useState<
     null | number
   >(null);
@@ -152,6 +154,7 @@ export function SidebarViews() {
   const viewPagesReady = availability.every((value) => value !== undefined);
 
   function handleDragEnd(event: DragEndEvent) {
+    if (!canMutate) return;
     const { active, over } = event;
 
     if (over && active.id !== over.id) {
@@ -183,7 +186,10 @@ export function SidebarViews() {
                 <SettingsIcon size={16} />
               </Link>
             </SidebarMenuButton>
-            <SidebarMenuButton onClick={() => launchDialog("add-view")}>
+            <SidebarMenuButton
+              disabled={!canMutate}
+              onClick={() => launchDialog("add-view")}
+            >
               <PlusIcon />
             </SidebarMenuButton>
           </div>

--- a/apps/app/src/components/feed/ViewFilterChips.tsx
+++ b/apps/app/src/components/feed/ViewFilterChips.tsx
@@ -18,6 +18,7 @@ import {
   getViewContentAvailability,
   mixedContentStore,
 } from "~/lib/data/mixed-content/store";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 const VIEW_FILTER_SKELETON_WIDTHS = ["w-16", "w-22", "w-18", "w-26"];
 
@@ -32,6 +33,7 @@ function ViewFilterChipSkeletons() {
 }
 
 export function ViewFilterChips() {
+  const canMutate = useCanMutate();
   const { views, hasFetchedViews } = useViews();
   const mixedScopes = mixedContentStore.useScopes();
   const [viewFilter] = useAtom(viewFilterIdAtom);
@@ -45,6 +47,7 @@ export function ViewFilterChips() {
     return (
       <Button
         variant="outline"
+        disabled={!canMutate}
         onClick={() => {
           launchDialog("add-view");
         }}

--- a/apps/app/src/components/feed/dialogStore.ts
+++ b/apps/app/src/components/feed/dialogStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { canMutateNow } from "~/lib/data/offline-mutations";
 
 export type DialogType =
   | "add-feed"
@@ -39,14 +40,16 @@ export const useDialogStore = create<DialogStore>((set) => ({
   selectedBookmarkId: null,
   subscriptionView: "overview",
   settingsPane: "main",
-  launchDialog: (dialog, options) =>
+  launchDialog: (dialog, options) => {
+    if (!canMutateNow()) return;
     set({
       dialog,
       subscriptionView: options?.subscriptionView ?? "overview",
       settingsPane: options?.settingsPane ?? "main",
       selectedFeedId: options?.selectedFeedId ?? null,
       selectedBookmarkId: options?.selectedBookmarkId ?? null,
-    }),
+    });
+  },
   closeDialog: () =>
     set({
       dialog: null,

--- a/apps/app/src/components/feed/import/GlobalImportDropzone.tsx
+++ b/apps/app/src/components/feed/import/GlobalImportDropzone.tsx
@@ -5,6 +5,7 @@ import { FileUpIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { getInitialFeedDataFromFiles } from "./utils/getInitialFeedDataFromFileInputElement";
 import { useImportDropStore } from "~/lib/data/import-drop";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 function containsFiles(dataTransfer: DataTransfer) {
   return (
@@ -15,6 +16,7 @@ function containsFiles(dataTransfer: DataTransfer) {
 }
 
 export function GlobalImportDropzone() {
+  const canMutate = useCanMutate();
   const navigate = useNavigate();
   const setPendingResult = useImportDropStore(
     (state) => state.setPendingResult,
@@ -31,6 +33,7 @@ export function GlobalImportDropzone() {
     };
 
     const onDragEnter = (event: DragEvent) => {
+      if (!canMutate) return;
       const dataTransfer = event.dataTransfer;
       if (!dataTransfer || !containsFiles(dataTransfer)) return;
 
@@ -40,6 +43,7 @@ export function GlobalImportDropzone() {
     };
 
     const onDragOver = (event: DragEvent) => {
+      if (!canMutate) return;
       const dataTransfer = event.dataTransfer;
       if (!dataTransfer || !containsFiles(dataTransfer)) return;
 
@@ -59,6 +63,7 @@ export function GlobalImportDropzone() {
     };
 
     const onDrop = async (event: DragEvent) => {
+      if (!canMutate) return;
       const dataTransfer = event.dataTransfer;
       if (!dataTransfer || !containsFiles(dataTransfer)) return;
 
@@ -89,7 +94,7 @@ export function GlobalImportDropzone() {
       window.removeEventListener("drop", onDrop);
       window.removeEventListener("dragend", resetDragState);
     };
-  }, [navigate, setPendingResult]);
+  }, [canMutate, navigate, setPendingResult]);
 
   const isVisible = isDraggingOpml || isProcessing;
 

--- a/apps/app/src/components/feed/read/ArticleImageLightbox.tsx
+++ b/apps/app/src/components/feed/read/ArticleImageLightbox.tsx
@@ -16,8 +16,12 @@ export function ArticleImageLightbox({
   className,
 }: ArticleImageLightboxProps) {
   const [open, setOpen] = useState(false);
+  const [failedSrc, setFailedSrc] = useState<string>();
+  const failed = failedSrc === src;
 
-  const toggle = () => setOpen((prev) => !prev);
+  const toggle = () => {
+    if (!failed) setOpen((prev) => !prev);
+  };
 
   return (
     <div data-lightbox style={{ position: "relative" }}>
@@ -25,17 +29,35 @@ export function ArticleImageLightbox({
         data-lightbox-trigger
         type="button"
         aria-label={alt ? `Open image preview: ${alt}` : "Open image preview"}
-        style={{ display: "block", cursor: "zoom-in" }}
+        aria-disabled={failed}
+        style={{
+          display: "block",
+          width: "100%",
+          cursor: failed ? "default" : "zoom-in",
+        }}
         onClick={toggle}
       >
-        <img
-          src={src}
-          alt={alt}
-          className={className}
-          loading="lazy"
-          decoding="async"
-          referrerPolicy="no-referrer"
-        />
+        {failed ? (
+          <span
+            data-image-fallback
+            role="img"
+            aria-label={alt}
+            className="bg-muted block aspect-square w-full rounded"
+          />
+        ) : (
+          <img
+            src={src}
+            alt={alt}
+            className={className}
+            loading="lazy"
+            decoding="async"
+            referrerPolicy="no-referrer"
+            onError={() => {
+              setFailedSrc(src);
+              setOpen(false);
+            }}
+          />
+        )}
       </button>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogPortal>

--- a/apps/app/src/components/feed/read/ArticleImageLightbox.tsx
+++ b/apps/app/src/components/feed/read/ArticleImageLightbox.tsx
@@ -32,7 +32,6 @@ export function ArticleImageLightbox({
         aria-disabled={failed}
         style={{
           display: "block",
-          width: "100%",
           cursor: failed ? "default" : "zoom-in",
         }}
         onClick={toggle}
@@ -42,7 +41,7 @@ export function ArticleImageLightbox({
             data-image-fallback
             role="img"
             aria-label={alt}
-            className="bg-muted block aspect-square w-full rounded"
+            className="bg-muted block aspect-square size-48 max-w-full rounded"
           />
         ) : (
           <img

--- a/apps/app/src/components/feed/useManagementShortcuts.ts
+++ b/apps/app/src/components/feed/useManagementShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent } from "react";
 import { doesAnyFormElementHaveFocus } from "~/lib/doesAnyFormElementHaveFocus";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export function useFeedManagementShortcuts({
   onEscape,
@@ -18,6 +19,7 @@ export function useFeedManagementShortcuts({
   isDialogOpen: boolean;
   hasSelection: boolean;
 }) {
+  const canMutate = useCanMutate();
   const onKeyDown = useEffectEvent((event: KeyboardEvent) => {
     if (event.repeat) return;
     if (doesAnyFormElementHaveFocus()) return;
@@ -37,17 +39,17 @@ export function useFeedManagementShortcuts({
         }
         break;
       case "e":
-        if (!isDialogOpen && hasSelection) {
+        if (canMutate && !isDialogOpen && hasSelection) {
           onEdit();
         }
         break;
       case "c":
-        if (!isDialogOpen && hasSelection) {
+        if (canMutate && !isDialogOpen && hasSelection) {
           onClear();
         }
         break;
       case "d":
-        if (!isDialogOpen && hasSelection) {
+        if (canMutate && !isDialogOpen && hasSelection) {
           onDelete();
         }
         break;

--- a/apps/app/src/components/feed/view-lists/EmptyStates.tsx
+++ b/apps/app/src/components/feed/view-lists/EmptyStates.tsx
@@ -11,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from "~/components/ui/card";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export function EmptyState() {
   return (
@@ -30,6 +31,7 @@ export function EmptyState() {
 }
 
 export function FeedEmptyState() {
+  const canMutate = useCanMutate();
   const launchDialog = useDialogStore((store) => store.launchDialog);
 
   return (
@@ -51,7 +53,10 @@ export function FeedEmptyState() {
             </CardDescription>
           </CardHeader>
           <CardContent className="flex h-full flex-col justify-end">
-            <Button onClick={() => launchDialog("add-feed")}>
+            <Button
+              disabled={!canMutate}
+              onClick={() => launchDialog("add-feed")}
+            >
               <PlusIcon size={16} />
               <span className="pl-1.5">Add Feed</span>
             </Button>

--- a/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
+++ b/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
@@ -809,7 +809,7 @@ function FeedItemDisplay({
         to={href}
         target={target}
         rel={rel}
-        preload={canOpen && !target ? "intent" : undefined}
+        preload={canOpen && !target && !isOffline ? "intent" : undefined}
         aria-disabled={!canOpen}
         tabIndex={canOpen ? undefined : -1}
         onClick={(event) => {
@@ -934,7 +934,7 @@ function FeedGridItemDisplay({
         to={href}
         target={target}
         rel={rel}
-        preload={canOpen && !target ? "intent" : undefined}
+        preload={canOpen && !target && !isOffline ? "intent" : undefined}
         aria-disabled={!canOpen}
         tabIndex={canOpen ? undefined : -1}
         onClick={(event) => {

--- a/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
+++ b/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
@@ -2,6 +2,7 @@
 
 import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
+import { useAtomValue } from "jotai";
 import {
   ArchiveIcon,
   BookmarkCheckIcon,
@@ -20,7 +21,7 @@ import {
   useSaveToInstapaperMutation,
   useShowInstapaperAction,
 } from "~/lib/data/instapaper";
-import { useFeedItemValue } from "~/lib/data/store";
+import { useFeedItemValue, useHasRetainedFeedItemBody } from "~/lib/data/store";
 import { timeAgo } from "~/lib/utils";
 import { SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
 import { useFeedItemActions } from "~/lib/hooks/useFeedItemActions";
@@ -34,6 +35,13 @@ import {
 import { useDialogStore } from "~/components/feed/dialogStore";
 import { contentDestination } from "~/lib/data/content-items/resolver";
 import { REMOTE_IMAGE_PROPS } from "~/lib/remoteMedia";
+import { connectionStateAtom } from "~/lib/data/atoms";
+import {
+  canOpenContent,
+  hasRetainedFeedBody,
+} from "~/lib/data/offline-content";
+import { useCanMutate } from "~/lib/data/offline-mutations";
+import { useBookmarkCaptureValue } from "~/lib/data/bookmarks/capture-store";
 
 export type ItemSize = "standard" | "large";
 
@@ -316,6 +324,7 @@ function ItemActions({
     useSaveToInstapaperMutation(contentId);
 
   const showShortcuts = useShowShortcuts();
+  const canMutate = useCanMutate();
 
   const isStandardList = layout === "list";
   const isLargeList = layout === "large-list";
@@ -355,7 +364,7 @@ function ItemActions({
         <Button
           size={isGrid ? "icon" : "icon"}
           variant="ghost"
-          disabled={isSavingToInstapaper}
+          disabled={!canMutate || isSavingToInstapaper}
           onClick={handleSaveToInstapaper}
           className={clsx("relative overflow-visible", {
             "h-8 w-8 p-0": isGrid,
@@ -370,6 +379,7 @@ function ItemActions({
       <Button
         size="icon"
         variant="ghost"
+        disabled={!canMutate}
         onClick={handleToggleWatchLater}
         className={clsx("relative overflow-visible", {
           "h-8 w-8 p-0": isGrid,
@@ -385,6 +395,7 @@ function ItemActions({
       <Button
         size="icon"
         variant="ghost"
+        disabled={!canMutate}
         onClick={handleToggleWatched}
         className={clsx("relative overflow-visible", {
           "h-8 w-8 p-0": isGrid,
@@ -505,6 +516,7 @@ function BookmarkActions({
   const { mutate: deleteBookmark } = useDeleteBookmarkMutation();
   const launchDialog = useDialogStore((store) => store.launchDialog);
   const showShortcuts = useShowShortcuts();
+  const canMutate = useCanMutate();
   const isGrid = layout === "grid";
   const isStandardList = layout === "list";
 
@@ -524,6 +536,7 @@ function BookmarkActions({
         size="icon"
         variant="ghost"
         aria-label="Edit Bookmark"
+        disabled={!canMutate}
         className={clsx({ "h-8 w-8 p-0": isGrid })}
         onClick={() =>
           launchDialog("edit-bookmark", { selectedBookmarkId: bookmark.id })
@@ -535,6 +548,7 @@ function BookmarkActions({
         size="icon"
         variant="ghost"
         aria-label={bookmark.isSaved ? "Unsave" : "Save"}
+        disabled={!canMutate}
         className={clsx({ "h-8 w-8 p-0": isGrid })}
         onClick={() =>
           updateState({
@@ -553,6 +567,7 @@ function BookmarkActions({
         size="icon"
         variant="ghost"
         aria-label={bookmark.isRead ? "Unarchive" : "Archive"}
+        disabled={!canMutate}
         className={clsx({ "h-8 w-8 p-0": isGrid })}
         onClick={() =>
           updateState({
@@ -567,6 +582,7 @@ function BookmarkActions({
         size="icon"
         variant="ghost"
         aria-label="Delete Bookmark"
+        disabled={!canMutate}
         className={clsx({ "h-8 w-8 p-0": isGrid })}
         onClick={() => deleteBookmark({ bookmarkId: bookmark.id })}
       >
@@ -593,7 +609,21 @@ function BookmarkItemDisplay({
     entityKind: "bookmark",
     entity: bookmark,
   });
-  const href = destination.href;
+  const connectionState = useAtomValue(connectionStateAtom);
+  const capture = useBookmarkCaptureValue(bookmark.id);
+  const canOpen = canOpenContent({
+    connectionState,
+    contentType: bookmark.contentType,
+    hasBody: capture !== undefined,
+  });
+  const isOffline = connectionState === "disconnected";
+  const href = isOffline ? `/read/${bookmark.id}` : destination.href;
+  const target = isOffline
+    ? undefined
+    : destination.external
+      ? "_blank"
+      : undefined;
+  const rel = target ? "noopener noreferrer" : undefined;
   const isLarge = size === "large";
   const postedAt = getBookmarkAddedAt(bookmark);
 
@@ -603,20 +633,28 @@ function BookmarkItemDisplay({
         data-item-id={bookmark.id}
         data-entity-kind="bookmark"
         onMouseEnter={onSelect}
-        className="group relative flex h-full w-full flex-col"
+        className={clsx(
+          "group relative flex h-full w-full flex-col",
+          !canOpen && "opacity-50",
+        )}
       >
         <Link
           to={href}
-          target={destination.external ? "_blank" : undefined}
-          rel={destination.external ? "noopener noreferrer" : undefined}
-          onClick={
-            destination.external
-              ? undefined
-              : () => captureRootScrollRestoration(bookmark.id)
-          }
+          target={target}
+          rel={rel}
+          aria-disabled={!canOpen}
+          tabIndex={canOpen ? undefined : -1}
+          onClick={(event) => {
+            if (!canOpen) {
+              event.preventDefault();
+              return;
+            }
+            if (!target) captureRootScrollRestoration(bookmark.id);
+          }}
           className={clsx(
             "flex h-full flex-1 flex-col rounded p-2 text-left",
             isSelected && "md:bg-muted",
+            !canOpen && "cursor-not-allowed",
           )}
         >
           <BookmarkThumbnail
@@ -654,21 +692,27 @@ function BookmarkItemDisplay({
         isLarge
           ? "flex-col md:flex-row md:items-center"
           : "items-center md:h-20",
+        !canOpen && "opacity-50",
       )}
     >
       <Link
         to={href}
-        target={destination.external ? "_blank" : undefined}
-        rel={destination.external ? "noopener noreferrer" : undefined}
-        onClick={
-          destination.external
-            ? undefined
-            : () => captureRootScrollRestoration(bookmark.id)
-        }
+        target={target}
+        rel={rel}
+        aria-disabled={!canOpen}
+        tabIndex={canOpen ? undefined : -1}
+        onClick={(event) => {
+          if (!canOpen) {
+            event.preventDefault();
+            return;
+          }
+          if (!target) captureRootScrollRestoration(bookmark.id);
+        }}
         className={clsx(
           "flex w-full flex-1 flex-col gap-4 px-6 pt-4 text-left md:flex-row md:items-center md:rounded md:px-2 md:py-2",
           isLarge ? "pb-1 md:pb-2" : "pb-4 md:h-20 md:py-0",
           isSelected && "md:bg-muted",
+          !canOpen && "cursor-not-allowed",
         )}
       >
         <div
@@ -717,6 +761,8 @@ function FeedItemDisplay({
 }: ItemDisplayProps) {
   const feeds = useFeedsArray();
   const item = useFeedItemValue(contentId);
+  const hasRetainedBody = useHasRetainedFeedItemBody(contentId);
+  const connectionState = useAtomValue(connectionStateAtom);
 
   if (!item) return null;
 
@@ -730,9 +776,19 @@ function FeedItemDisplay({
     destination.renderer !== "origin" &&
     (feed?.openLocation === "serial" || !feed?.openLocation);
 
-  const href = shouldOpenInSerial ? destination.href : item.url;
+  const canOpen = canOpenContent({
+    connectionState,
+    contentType: item.contentType,
+    hasBody: hasRetainedFeedBody(item, hasRetainedBody),
+  });
+  const isOffline = connectionState === "disconnected";
+  const href = isOffline
+    ? `/read/${item.id}`
+    : shouldOpenInSerial
+      ? destination.href
+      : item.url;
 
-  const target = shouldOpenInSerial ? undefined : "_blank";
+  const target = isOffline || shouldOpenInSerial ? undefined : "_blank";
   const rel = shouldOpenInSerial ? undefined : "noopener noreferrer";
 
   const isLarge = size === "large";
@@ -746,22 +802,28 @@ function FeedItemDisplay({
         isLarge
           ? "flex-col md:flex-row md:items-center"
           : "items-center md:h-20",
+        !canOpen && "opacity-50",
       )}
     >
       <Link
         to={href}
         target={target}
         rel={rel}
-        preload={shouldOpenInSerial ? "intent" : undefined}
-        onClick={
-          shouldOpenInSerial
-            ? () => captureRootScrollRestoration(contentId)
-            : undefined
-        }
+        preload={canOpen && !target ? "intent" : undefined}
+        aria-disabled={!canOpen}
+        tabIndex={canOpen ? undefined : -1}
+        onClick={(event) => {
+          if (!canOpen) {
+            event.preventDefault();
+            return;
+          }
+          if (!target) captureRootScrollRestoration(contentId);
+        }}
         className={clsx(
           "flex w-full flex-1 flex-col gap-4 px-6 pt-4 text-left md:flex-row md:items-center md:rounded md:px-2 md:py-2",
           isLarge ? "pb-1 md:pb-2" : "pb-4 md:h-20 md:py-0",
           isSelected && "md:bg-muted",
+          !canOpen && "cursor-not-allowed",
         )}
       >
         {isLarge ? (
@@ -830,6 +892,8 @@ function FeedGridItemDisplay({
 }: GridItemDisplayProps) {
   const feeds = useFeedsArray();
   const item = useFeedItemValue(contentId);
+  const hasRetainedBody = useHasRetainedFeedItemBody(contentId);
+  const connectionState = useAtomValue(connectionStateAtom);
 
   if (!item) return null;
 
@@ -840,9 +904,19 @@ function FeedGridItemDisplay({
   const shouldOpenInSerial =
     feed?.openLocation === "serial" || !feed?.openLocation;
 
-  const href = shouldOpenInSerial ? `/${itemDestination}/${item.id}` : item.url;
+  const canOpen = canOpenContent({
+    connectionState,
+    contentType: item.contentType,
+    hasBody: hasRetainedFeedBody(item, hasRetainedBody),
+  });
+  const isOffline = connectionState === "disconnected";
+  const href = isOffline
+    ? `/read/${item.id}`
+    : shouldOpenInSerial
+      ? `/${itemDestination}/${item.id}`
+      : item.url;
 
-  const target = shouldOpenInSerial ? undefined : "_blank";
+  const target = isOffline || shouldOpenInSerial ? undefined : "_blank";
   const rel = shouldOpenInSerial ? undefined : "noopener noreferrer";
 
   const isLarge = size === "large";
@@ -851,21 +925,29 @@ function FeedGridItemDisplay({
     <article
       data-item-id={contentId}
       onMouseEnter={onSelect}
-      className="group relative flex h-full w-full flex-col"
+      className={clsx(
+        "group relative flex h-full w-full flex-col",
+        !canOpen && "opacity-50",
+      )}
     >
       <Link
         to={href}
         target={target}
         rel={rel}
-        preload={shouldOpenInSerial ? "intent" : undefined}
-        onClick={
-          shouldOpenInSerial
-            ? () => captureRootScrollRestoration(contentId)
-            : undefined
-        }
+        preload={canOpen && !target ? "intent" : undefined}
+        aria-disabled={!canOpen}
+        tabIndex={canOpen ? undefined : -1}
+        onClick={(event) => {
+          if (!canOpen) {
+            event.preventDefault();
+            return;
+          }
+          if (!target) captureRootScrollRestoration(contentId);
+        }}
         className={clsx(
           "flex h-full flex-1 flex-col rounded p-2 text-left",
           isSelected && "md:bg-muted",
+          !canOpen && "cursor-not-allowed",
         )}
       >
         <ItemThumbnail

--- a/apps/app/src/components/feed/view-lists/RenderViewItems.tsx
+++ b/apps/app/src/components/feed/view-lists/RenderViewItems.tsx
@@ -35,6 +35,7 @@ import { useFeedCategories } from "~/lib/data/feed-categories";
 import { useFilteredContentOrder } from "~/lib/data/feed-items";
 import { useFeeds } from "~/lib/data/feeds";
 import { setMixedReadValue } from "~/lib/data/mixed-content/mutations";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 import { useHasInitialData } from "~/lib/data/store";
 import { useFeedItemNavigation } from "~/lib/hooks/useFeedItemNavigation";
 import { useShortcut } from "~/lib/hooks/useShortcut";
@@ -98,6 +99,7 @@ function SectionHeading({
   sectionIndex: number;
   onMarkAsRead?: (sectionIndex: number) => void;
 }) {
+  const canMutate = useCanMutate();
   const contentStatusFilter = useAtomValue(contentStatusFilterAtom);
   const selectedItemId = useAtomValue(selectedItemIdAtom);
   const [isLoading, setIsLoading] = useState(false);
@@ -115,6 +117,7 @@ function SectionHeading({
   }, []);
 
   const handleMarkSectionAsRead = async () => {
+    if (!canMutate) return;
     if (!isInboxUnread(contentStatusFilter) || sectionItems.length === 0)
       return;
 
@@ -175,7 +178,7 @@ function SectionHeading({
               variant="outline"
               size="sm"
               onClick={handleMarkSectionAsRead}
-              disabled={isLoading}
+              disabled={!canMutate || isLoading}
               className="gap-1.5 text-xs"
               shortcut={SHORTCUT_KEYS.MARK_SECTION_READ}
             >

--- a/apps/app/src/components/feed/watch/[id]/ContentActions.tsx
+++ b/apps/app/src/components/feed/watch/[id]/ContentActions.tsx
@@ -21,11 +21,13 @@ import { useFeedItemValue } from "~/lib/data/store";
 import { useMediaQuery } from "~/lib/hooks/use-media-query";
 import { useShortcut } from "~/lib/hooks/useShortcut";
 import { SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export function ContentActions({ contentID }: { contentID: string }) {
   const { view } = useView();
 
   const video = useFeedItemValue(contentID);
+  const canMutate = useCanMutate();
 
   const { mutateAsync: setWatchedValue } =
     useFeedItemsSetWatchedValueMutation(contentID);
@@ -42,7 +44,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
   const shouldHideFullscreenActions = useMediaQuery("(min-aspect-ratio: 4/3)");
 
   const toggleWatchLater = async () => {
-    if (!video) return;
+    if (!video || !canMutate) return;
     await setWatchLaterValue({
       id: video.id,
       feedId: video.feedId,
@@ -55,7 +57,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
   });
 
   const toggleWatched = async () => {
-    if (!video) return;
+    if (!video || !canMutate) return;
     await setWatchedValue({
       id: video.id,
       feedId: video.feedId,
@@ -68,7 +70,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
   });
 
   const handleSaveToInstapaper = async () => {
-    if (!video || !showInstapaperAction) return;
+    if (!video || !showInstapaperAction || !canMutate) return;
     await saveToInstapaper({ feedItemId: video.id });
   };
 
@@ -88,7 +90,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
             variant="outline"
             onClick={handleSaveToInstapaper}
             size="icon"
-            disabled={isSavingToInstapaper}
+            disabled={!canMutate || isSavingToInstapaper}
           >
             <SendIcon size={16} />
           </Button>
@@ -97,6 +99,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
           variant={isWatchLater ? "secondary" : "outline"}
           onClick={toggleWatchLater}
           size="icon"
+          disabled={!canMutate}
         >
           {isWatchLater ? (
             <CheckIcon size={16} />
@@ -108,6 +111,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
           variant={isWatched ? "secondary" : "outline"}
           onClick={toggleWatched}
           size="icon"
+          disabled={!canMutate}
         >
           {isWatched ? (
             <ArchiveRestoreIcon size={16} />
@@ -126,7 +130,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
           shortcut={SHORTCUT_KEYS.SEND_TO_INSTAPAPER}
           variant="outline"
           onClick={handleSaveToInstapaper}
-          disabled={isSavingToInstapaper}
+          disabled={!canMutate || isSavingToInstapaper}
           size="icon md:default"
         >
           <SendIcon size={16} />
@@ -137,6 +141,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
         shortcut={SHORTCUT_KEYS.TOGGLE_SAVED}
         variant={isWatchLater ? "secondary" : "outline"}
         onClick={toggleWatchLater}
+        disabled={!canMutate}
         size="icon md:default"
       >
         {isWatchLater ? (
@@ -152,6 +157,7 @@ export function ContentActions({ contentID }: { contentID: string }) {
         shortcut={SHORTCUT_KEYS.TOGGLE_READ}
         variant={isWatched ? "secondary" : "outline"}
         onClick={toggleWatched}
+        disabled={!canMutate}
         size="icon md:default"
       >
         {isWatched ? (

--- a/apps/app/src/components/view-dialog/AddViewDialog.tsx
+++ b/apps/app/src/components/view-dialog/AddViewDialog.tsx
@@ -8,6 +8,7 @@ import type { ViewLayout } from "~/server/db/constants";
 import type { ContentFilter } from "~/lib/views/contentFilter";
 import type { ViewSection } from "./ViewSectionList";
 import { Button } from "~/components/ui/button";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 import { ControlledResponsiveDialog } from "~/components/ui/responsive-dropdown";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { useDialogStore } from "~/components/feed/dialogStore";
@@ -16,6 +17,7 @@ import { DEFAULT_VIEW_LAYOUT, VIEW_READ_STATUS } from "~/server/db/constants";
 import { DEFAULT_CONTENT_FILTER } from "~/lib/views/contentFilter";
 
 export function AddViewDialog() {
+  const canMutate = useCanMutate();
   const [isAddingView, setIsAddingView] = useState(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
 
@@ -51,6 +53,7 @@ export function AddViewDialog() {
   };
 
   const handleSave = async () => {
+    if (!canMutate) return;
     setIsAddingView(true);
 
     try {
@@ -140,7 +143,7 @@ export function AddViewDialog() {
       </Tabs>
       <div className="mt-6">
         <Button
-          disabled={isDisabled || isAddingView}
+          disabled={!canMutate || isDisabled || isAddingView}
           onClick={handleSave}
           className="w-full"
         >

--- a/apps/app/src/components/view-dialog/BulkEditViewsDialog.tsx
+++ b/apps/app/src/components/view-dialog/BulkEditViewsDialog.tsx
@@ -10,6 +10,7 @@ import {
 import type { ViewLayout } from "~/server/db/constants";
 import type { ContentFilter } from "~/lib/views/contentFilter";
 import { Button } from "~/components/ui/button";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 import { ControlledResponsiveDialog } from "~/components/ui/responsive-dropdown";
 import { useEditViewMutation } from "~/lib/data/views/mutations";
 import { useViews } from "~/lib/data/views";
@@ -32,6 +33,7 @@ export function BulkEditViewsDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const canMutate = useCanMutate();
   const [isUpdating, setIsUpdating] = useState(false);
   const { mutateAsync: editView } = useEditViewMutation();
   const { views } = useViews();
@@ -76,7 +78,7 @@ export function BulkEditViewsDialog({
   }, [open, selectedViewIds, views]);
 
   const handleSave = async () => {
-    if (selectedViewIds.length === 0) return;
+    if (!canMutate || selectedViewIds.length === 0) return;
 
     setIsUpdating(true);
     const count = selectedViewIds.length;
@@ -136,7 +138,11 @@ export function BulkEditViewsDialog({
           >
             Cancel
           </Button>
-          <Button className="flex-1" onClick={handleSave} disabled={isUpdating}>
+          <Button
+            className="flex-1"
+            onClick={handleSave}
+            disabled={!canMutate || isUpdating}
+          >
             {isUpdating ? "Saving..." : "Save"}
           </Button>
         </div>

--- a/apps/app/src/components/view-dialog/EditViewDialog.tsx
+++ b/apps/app/src/components/view-dialog/EditViewDialog.tsx
@@ -9,6 +9,7 @@ import type { ContentFilter } from "~/lib/views/contentFilter";
 import type { ApplicationView } from "~/server/db/schema";
 import type { ViewSection } from "./ViewSectionList";
 import { Button } from "~/components/ui/button";
+import { useCanMutate } from "~/lib/data/offline-mutations";
 import { ControlledResponsiveDialog } from "~/components/ui/responsive-dropdown";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { useFeedCategories } from "~/lib/data/feed-categories";
@@ -48,6 +49,7 @@ export function EditViewDialog({
   selectedViewId: null | number;
   onClose: () => void;
 }) {
+  const canMutate = useCanMutate();
   const [isUpdatingView, setIsUpdatingView] = useState(false);
   const [isDeletingView, setIsDeletingView] = useState(false);
 
@@ -130,7 +132,7 @@ export function EditViewDialog({
   }, [feedIdsInView]);
 
   const handleSave = async () => {
-    if (selectedViewId === null) return;
+    if (!canMutate || selectedViewId === null) return;
 
     setIsUpdatingView(true);
     try {
@@ -175,11 +177,11 @@ export function EditViewDialog({
       footer={
         <div className="flex gap-2">
           <Button
-            disabled={isDeletingView}
+            disabled={!canMutate || isDeletingView}
             className="flex-1"
             variant="destructive"
             onClick={async () => {
-              if (selectedViewId === null) return;
+              if (!canMutate || selectedViewId === null) return;
 
               setIsDeletingView(true);
               try {
@@ -206,7 +208,7 @@ export function EditViewDialog({
             {isDeletingView ? "Deleting..." : "Delete"}
           </Button>
           <Button
-            disabled={isFormDisabled || isUpdatingView}
+            disabled={!canMutate || isFormDisabled || isUpdatingView}
             onClick={handleSave}
             className="flex-1"
           >

--- a/apps/app/src/lib/data/atoms.ts
+++ b/apps/app/src/lib/data/atoms.ts
@@ -7,6 +7,7 @@ import { viewFeedsStore } from "./view-feeds/store";
 import { viewsStore } from "./views/store";
 import { feedsStore } from "./feeds/store";
 import { bookmarksStore } from "./bookmarks/store";
+import { bookmarkCapturesStore } from "./bookmarks/capture-store";
 import { mixedContentStore } from "./mixed-content/store";
 import { navigationSnapshotStore } from "./navigation/store";
 import type { ApplicationView } from "~/server/db/schema";
@@ -39,7 +40,9 @@ export const useClearAllUserData = () => {
   const resetViewFeeds = viewFeedsStore.useReset();
   const resetViews = viewsStore.useReset();
   const setViewsAtom = useSetAtom(viewsAtom);
+  const setConnectionState = useSetAtom(connectionStateAtom);
   const resetBookmarks = bookmarksStore.useReset();
+  const resetBookmarkCaptures = bookmarkCapturesStore.useReset();
   const resetMixedContent = mixedContentStore.useReset();
   const resetNavigationSnapshot = navigationSnapshotStore.useReset();
 
@@ -51,9 +54,11 @@ export const useClearAllUserData = () => {
     resetViewFeeds();
     resetViews();
     resetBookmarks();
+    resetBookmarkCaptures();
     resetMixedContent();
     resetNavigationSnapshot();
     setViewsAtom([]);
+    setConnectionState("unknown");
     // Wipe all persisted state from IndexedDB immediately.
     // The reset() calls handle in-memory state but write through a 2-second
     // throttle — clear() bypasses that so nothing survives sign-out.
@@ -70,6 +75,12 @@ export const articleZoomAtom = atom<number>(1);
 
 export const selectedItemIdAtom = atom<string | null>(null);
 export const altKeyHeldAtom = atom(false);
+
+export type ConnectionState = "unknown" | "connected" | "disconnected";
+export const connectionStateAtom = atom<ConnectionState>("unknown");
+export const isDisconnectedAtom = atom(
+  (get) => get(connectionStateAtom) === "disconnected",
+);
 
 /** When true, the header and footer bars should be hidden (e.g. scrolling down in article view). */
 export const barsHiddenAtom = atom(false);

--- a/apps/app/src/lib/data/atoms.ts
+++ b/apps/app/src/lib/data/atoms.ts
@@ -10,6 +10,7 @@ import { bookmarksStore } from "./bookmarks/store";
 import { bookmarkCapturesStore } from "./bookmarks/capture-store";
 import { mixedContentStore } from "./mixed-content/store";
 import { navigationSnapshotStore } from "./navigation/store";
+import { invalidateOfflineHydration } from "./offline-hydration";
 import type { ApplicationView } from "~/server/db/schema";
 import type { ContentStatusFilter } from "~/lib/content-status";
 import { DEFAULT_CONTENT_STATUS_FILTER } from "~/lib/content-status";
@@ -47,6 +48,8 @@ export const useClearAllUserData = () => {
   const resetNavigationSnapshot = navigationSnapshotStore.useReset();
 
   return () => {
+    // In-flight hydration responses must not repopulate the cleared stores.
+    invalidateOfflineHydration();
     resetFeeds();
     resetFeedItems();
     resetContentCategories();

--- a/apps/app/src/lib/data/bookmarks/capture-store.ts
+++ b/apps/app/src/lib/data/bookmarks/capture-store.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { createStore, useStore } from "zustand";
+import { persist } from "zustand/middleware";
+import { createNormalizedIDBStorage } from "../normalized-idb-storage";
+import { createSelectorHooks } from "../createSelectorHooks";
+import type { DatabasePageCapture } from "~/server/db/schema";
+
+type BookmarkCaptureStore = {
+  capturesDict: Record<string, DatabasePageCapture>;
+  reset: () => void;
+  upsert: (capture: DatabasePageCapture) => void;
+  remove: (bookmarkId: string) => void;
+  removeMany: (bookmarkIds: Iterable<string>) => void;
+};
+
+const vanillaBookmarkCaptureStore = createStore<BookmarkCaptureStore>()(
+  persist(
+    (set, get) => ({
+      capturesDict: {},
+      reset: () => set({ capturesDict: {} }),
+      upsert: (capture) =>
+        set({
+          capturesDict: {
+            ...get().capturesDict,
+            [capture.bookmarkId]: capture,
+          },
+        }),
+      remove: (bookmarkId) => {
+        if (!(bookmarkId in get().capturesDict)) return;
+        const capturesDict = { ...get().capturesDict };
+        delete capturesDict[bookmarkId];
+        set({ capturesDict });
+      },
+      removeMany: (bookmarkIds) => {
+        const capturesDict = { ...get().capturesDict };
+        let changed = false;
+        for (const bookmarkId of bookmarkIds) {
+          if (!(bookmarkId in capturesDict)) continue;
+          delete capturesDict[bookmarkId];
+          changed = true;
+        }
+        if (changed) set({ capturesDict });
+      },
+    }),
+    {
+      name: "serial-bookmark-captures-store",
+      storage: createNormalizedIDBStorage({
+        recordFields: ["capturesDict"],
+      }),
+      partialize: (state) => ({ capturesDict: state.capturesDict }),
+    },
+  ),
+);
+
+export const bookmarkCapturesStore = createSelectorHooks(
+  vanillaBookmarkCaptureStore,
+);
+
+export function useBookmarkCaptureValue(bookmarkId: string) {
+  return useStore(
+    vanillaBookmarkCaptureStore,
+    (state) => state.capturesDict[bookmarkId],
+  );
+}

--- a/apps/app/src/lib/data/bookmarks/mutations.ts
+++ b/apps/app/src/lib/data/bookmarks/mutations.ts
@@ -17,9 +17,11 @@ import {
   setRetainedEntityPins,
 } from "../page-retention";
 import { viewsStore } from "../views/store";
+import { shouldRetainBookmarkCapture } from "../offline-content";
 import { bookmarksStore } from "./store";
+import { bookmarkCapturesStore } from "./capture-store";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
-import { orpc } from "~/lib/orpc";
+import { orpc, orpcRouterClient } from "~/lib/orpc";
 
 const mutationCoordinator =
   new BookmarkMutationCoordinator<ApplicationBookmark>();
@@ -73,19 +75,32 @@ function removeProjectedBookmark(bookmark: ApplicationBookmark) {
 export function useSaveBookmarkMutation() {
   return useMutation(
     orpc.bookmark.save.mutationOptions({
-      onSuccess: (result) => {
+      onSuccess: async (result) => {
         const bookmark = result.bookmark as ApplicationBookmark;
         const previousBookmark = bookmarksStore
           .getState()
           .getBookmark(bookmark.id);
         for (const removedBookmarkId of result.removedBookmarkIds ??
           (result.removedBookmarkId ? [result.removedBookmarkId] : [])) {
+          bookmarkCapturesStore.getState().remove(removedBookmarkId);
           const removedBookmark = bookmarksStore
             .getState()
             .getBookmark(removedBookmarkId);
           if (removedBookmark) removeProjectedBookmark(removedBookmark);
         }
         projectBookmark(bookmark, previousBookmark);
+        if (
+          shouldRetainBookmarkCapture(bookmark) &&
+          bookmark.captureHash &&
+          !bookmarkCapturesStore.getState().capturesDict[bookmark.id]
+        ) {
+          const captureResult = await orpcRouterClient.bookmark
+            .getCapture({ bookmarkId: bookmark.id })
+            .catch(() => null);
+          if (captureResult?.status === "capture") {
+            bookmarkCapturesStore.getState().upsert(captureResult.capture);
+          }
+        }
       },
     }),
   );

--- a/apps/app/src/lib/data/bookmarks/mutations.ts
+++ b/apps/app/src/lib/data/bookmarks/mutations.ts
@@ -76,7 +76,7 @@ function removeProjectedBookmark(bookmark: ApplicationBookmark) {
 // without one (save, unarchive). Retention is re-judged against the live
 // store when the response lands, so a sign-out or opposing mutation that
 // happened mid-flight cannot re-persist the capture.
-async function reacquireRetainedCapture(bookmark: ApplicationBookmark) {
+export async function reacquireRetainedCapture(bookmark: ApplicationBookmark) {
   if (
     !shouldRetainBookmarkCapture(bookmark) ||
     !bookmark.captureHash ||
@@ -214,7 +214,7 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
           projectBookmark(reconciled, currentBookmark);
           // Unarchive and re-save evicted the capture on the way out; the
           // return transition must bring it back for offline reading.
-          void reacquireRetainedCapture(reconciled);
+          reacquireRetainedCapture(reconciled).catch(() => {});
         } finally {
           if (context?.token) releaseOptimisticBookmark(context.token);
         }

--- a/apps/app/src/lib/data/bookmarks/mutations.ts
+++ b/apps/app/src/lib/data/bookmarks/mutations.ts
@@ -115,8 +115,10 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
         const previousBookmark = bookmarksStore
           .getState()
           .getBookmark(bookmarkId);
+        const previousCapture =
+          bookmarkCapturesStore.getState().capturesDict[bookmarkId];
         if (!previousBookmark) {
-          return { previousBookmark, changesMixedProjection };
+          return { previousBookmark, previousCapture, changesMixedProjection };
         }
         const now = new Date();
         const changes = [
@@ -172,7 +174,12 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
           releaseOptimisticBookmark(token);
           throw error;
         }
-        return { previousBookmark, token, changesMixedProjection };
+        return {
+          previousBookmark,
+          previousCapture,
+          token,
+          changesMixedProjection,
+        };
       },
       onSuccess: (bookmark, _input, context) => {
         try {
@@ -209,14 +216,18 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
             context.token &&
             optimisticBookmark
           ) {
-            projectBookmark(
-              mutationCoordinator.rollback(
-                optimisticBookmark,
-                context.previousBookmark,
-                context.token,
-              ),
+            const rolledBackBookmark = mutationCoordinator.rollback(
               optimisticBookmark,
+              context.previousBookmark,
+              context.token,
             );
+            projectBookmark(rolledBackBookmark, optimisticBookmark);
+            if (
+              context.previousCapture &&
+              shouldRetainBookmarkCapture(rolledBackBookmark)
+            ) {
+              bookmarkCapturesStore.getState().upsert(context.previousCapture);
+            }
           }
         } finally {
           if (context?.token) releaseOptimisticBookmark(context.token);

--- a/apps/app/src/lib/data/bookmarks/mutations.ts
+++ b/apps/app/src/lib/data/bookmarks/mutations.ts
@@ -72,6 +72,27 @@ function removeProjectedBookmark(bookmark: ApplicationBookmark) {
   });
 }
 
+// Fetches the capture when a mutation leaves the Bookmark retain-eligible
+// without one (save, unarchive). Retention is re-judged against the live
+// store when the response lands, so a sign-out or opposing mutation that
+// happened mid-flight cannot re-persist the capture.
+async function reacquireRetainedCapture(bookmark: ApplicationBookmark) {
+  if (
+    !shouldRetainBookmarkCapture(bookmark) ||
+    !bookmark.captureHash ||
+    bookmarkCapturesStore.getState().capturesDict[bookmark.id] !== undefined
+  ) {
+    return;
+  }
+  const captureResult = await orpcRouterClient.bookmark
+    .getCapture({ bookmarkId: bookmark.id })
+    .catch(() => null);
+  if (captureResult?.status !== "capture") return;
+  const latestBookmark = bookmarksStore.getState().getBookmark(bookmark.id);
+  if (!latestBookmark || !shouldRetainBookmarkCapture(latestBookmark)) return;
+  bookmarkCapturesStore.getState().upsert(captureResult.capture);
+}
+
 export function useSaveBookmarkMutation() {
   return useMutation(
     orpc.bookmark.save.mutationOptions({
@@ -89,18 +110,7 @@ export function useSaveBookmarkMutation() {
           if (removedBookmark) removeProjectedBookmark(removedBookmark);
         }
         projectBookmark(bookmark, previousBookmark);
-        if (
-          shouldRetainBookmarkCapture(bookmark) &&
-          bookmark.captureHash &&
-          !bookmarkCapturesStore.getState().capturesDict[bookmark.id]
-        ) {
-          const captureResult = await orpcRouterClient.bookmark
-            .getCapture({ bookmarkId: bookmark.id })
-            .catch(() => null);
-          if (captureResult?.status === "capture") {
-            bookmarkCapturesStore.getState().upsert(captureResult.capture);
-          }
-        }
+        await reacquireRetainedCapture(bookmark);
       },
     }),
   );
@@ -202,6 +212,9 @@ export function useUpdateBookmarkStateMutation(bookmarkId: string) {
                 )
               : serverBookmark;
           projectBookmark(reconciled, currentBookmark);
+          // Unarchive and re-save evicted the capture on the way out; the
+          // return transition must bring it back for offline reading.
+          void reacquireRetainedCapture(reconciled);
         } finally {
           if (context?.token) releaseOptimisticBookmark(context.token);
         }

--- a/apps/app/src/lib/data/bookmarks/store.ts
+++ b/apps/app/src/lib/data/bookmarks/store.ts
@@ -3,6 +3,8 @@ import { persist } from "zustand/middleware";
 import { createNormalizedIDBStorage } from "../normalized-idb-storage";
 import { createSelectorHooks } from "../createSelectorHooks";
 import { e2eBookmarkHydrationBeforeRead } from "../e2eFaultControls";
+import { shouldRetainBookmarkCapture } from "../offline-content";
+import { bookmarkCapturesStore } from "./capture-store";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
 
 type PersistedBookmarkStore = {
@@ -39,7 +41,9 @@ function replaceBookmarkEntities(
 }
 
 function removeBookmarkEntities(ids: Iterable<string>) {
-  const removedIds = [...ids].filter((id) => id in bookmarkEntities);
+  const candidateIds = [...ids];
+  bookmarkCapturesStore.getState().removeMany(candidateIds);
+  const removedIds = candidateIds.filter((id) => id in bookmarkEntities);
   if (removedIds.length === 0) return false;
 
   const nextEntities = { ...bookmarkEntities };
@@ -53,6 +57,7 @@ const vanillaBookmarkStore = createStore<BookmarkStore>()(
     (set, get) => ({
       revision: 0,
       reset: () => {
+        bookmarkCapturesStore.getState().reset();
         replaceBookmarkEntities({});
         set({ revision: get().revision + 1 });
       },
@@ -63,6 +68,9 @@ const vanillaBookmarkStore = createStore<BookmarkStore>()(
       getBookmark: (id) => bookmarkEntities[id],
       snapshot: () => bookmarkEntities,
       upsert: (bookmark) => {
+        if (!shouldRetainBookmarkCapture(bookmark)) {
+          bookmarkCapturesStore.getState().remove(bookmark.id);
+        }
         bookmarkEntities = {
           ...bookmarkEntities,
           [bookmark.id]: bookmark,
@@ -73,6 +81,9 @@ const vanillaBookmarkStore = createStore<BookmarkStore>()(
         if (bookmarks.length === 0) return;
         const nextEntities = { ...bookmarkEntities };
         for (const bookmark of bookmarks) {
+          if (!shouldRetainBookmarkCapture(bookmark)) {
+            bookmarkCapturesStore.getState().remove(bookmark.id);
+          }
           nextEntities[bookmark.id] = bookmark;
         }
         bookmarkEntities = nextEntities;

--- a/apps/app/src/lib/data/feed-items/mergeFeedItem.ts
+++ b/apps/app/src/lib/data/feed-items/mergeFeedItem.ts
@@ -1,3 +1,4 @@
+import { retainEligibleFeedBody } from "../offline-content";
 import { applyPendingFeedItemOverrides } from "./pendingMutations";
 import type { ApplicationFeedItem } from "~/server/db/schema";
 
@@ -58,14 +59,16 @@ export function mergeFeedItem(
   const normalizedIncomingItem = normalizeIncomingFeedItem(incomingItem);
 
   if (!existingItem) {
-    return applyPendingFeedItemOverrides(normalizedIncomingItem);
+    const item = applyPendingFeedItemOverrides(normalizedIncomingItem);
+    return retainEligibleFeedBody(undefined, item);
   }
 
   if (!hasMatchingContentHash(existingItem, incomingItem)) {
-    return applyPendingFeedItemOverrides(normalizedIncomingItem);
+    const item = applyPendingFeedItemOverrides(normalizedIncomingItem);
+    return retainEligibleFeedBody(existingItem, item);
   }
 
-  return applyPendingFeedItemOverrides(
+  const item = applyPendingFeedItemOverrides(
     mergeItemMetadata(
       {
         ...existingItem,
@@ -76,4 +79,5 @@ export function mergeFeedItem(
       normalizedIncomingItem,
     ),
   );
+  return retainEligibleFeedBody(existingItem, item);
 }

--- a/apps/app/src/lib/data/feed-items/mergeFeedItem.ts
+++ b/apps/app/src/lib/data/feed-items/mergeFeedItem.ts
@@ -1,4 +1,3 @@
-import { retainEligibleFeedBody } from "../offline-content";
 import { applyPendingFeedItemOverrides } from "./pendingMutations";
 import type { ApplicationFeedItem } from "~/server/db/schema";
 
@@ -58,17 +57,11 @@ export function mergeFeedItem(
 ): ApplicationFeedItem {
   const normalizedIncomingItem = normalizeIncomingFeedItem(incomingItem);
 
-  if (!existingItem) {
-    const item = applyPendingFeedItemOverrides(normalizedIncomingItem);
-    return retainEligibleFeedBody(undefined, item);
+  if (!existingItem || !hasMatchingContentHash(existingItem, incomingItem)) {
+    return applyPendingFeedItemOverrides(normalizedIncomingItem);
   }
 
-  if (!hasMatchingContentHash(existingItem, incomingItem)) {
-    const item = applyPendingFeedItemOverrides(normalizedIncomingItem);
-    return retainEligibleFeedBody(existingItem, item);
-  }
-
-  const item = applyPendingFeedItemOverrides(
+  return applyPendingFeedItemOverrides(
     mergeItemMetadata(
       {
         ...existingItem,
@@ -79,5 +72,4 @@ export function mergeFeedItem(
       normalizedIncomingItem,
     ),
   );
-  return retainEligibleFeedBody(existingItem, item);
 }

--- a/apps/app/src/lib/data/feed-items/mutations.ts
+++ b/apps/app/src/lib/data/feed-items/mutations.ts
@@ -1,9 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
-import { feedItemsStore, useFeedItemState } from "../store";
+import { feedItemsStore, retainFeedItemBody, useFeedItemState } from "../store";
 import { feedCategoriesStore } from "../feed-categories/store";
 import { mixedContentStore } from "../mixed-content/store";
 import { advanceMixedContentMembershipRevision } from "../mixed-content/membershipRevision";
 import { viewsStore } from "../views/store";
+import { canMutateNow } from "../offline-mutations";
 import {
   clearPendingFeedItemOverride,
   setPendingWatchedOverride,
@@ -226,6 +227,7 @@ export async function setBulkWatchedValue({
   items: BulkWatchedItem[];
   isWatched: boolean;
 }) {
+  if (!canMutateNow()) return;
   const contexts = applyOptimisticWatchedValues(items, isWatched);
 
   try {
@@ -264,6 +266,9 @@ export function useFeedItemsSetWatchLaterValueMutation(contentId: string) {
       },
       onSuccess: (serverValue, _variables, context) => {
         resolveOptimisticWatchLaterValue(context, serverValue);
+        if (serverValue.isWatchLater) {
+          void retainFeedItemBody(contentId);
+        }
       },
       onError: (_error, _variables, context) => {
         rollbackOptimisticWatchLaterValue(context);

--- a/apps/app/src/lib/data/feed-items/mutations.ts
+++ b/apps/app/src/lib/data/feed-items/mutations.ts
@@ -24,6 +24,10 @@ export type OptimisticWatchedContext = {
   token: object;
   previousIsWatched: boolean;
   previousIsWatchedUpdatedAt: Date | null;
+  previousRetainedBody?: Pick<
+    ApplicationFeedItem,
+    "content" | "contentHash" | "contentSnippet"
+  >;
 };
 
 export type OptimisticWatchLaterContext = {
@@ -40,7 +44,10 @@ type WatchedServerValue = {
   updatedAt: Date;
 };
 
-function setFeedItemsWithMixedProjection(items: ApplicationFeedItem[]) {
+function setFeedItemsWithMixedProjection(
+  items: ApplicationFeedItem[],
+  retainedBodyItemIds?: ReadonlySet<string>,
+) {
   if (items.length === 0) return;
   const store = feedItemsStore.getState();
   const previousFeedItems = Object.fromEntries(
@@ -53,7 +60,7 @@ function setFeedItemsWithMixedProjection(items: ApplicationFeedItem[]) {
   ) {
     advanceMixedContentMembershipRevision();
   }
-  store.setFeedItems(items);
+  store.setFeedItems(items, undefined, retainedBodyItemIds);
   mixedContentStore.getState().reprojectFeedItems({
     itemIds: items.map((item) => item.id),
     previousFeedItems,
@@ -80,6 +87,14 @@ export function applyOptimisticWatchedValues(
       token,
       previousIsWatched: feedItem.isWatched,
       previousIsWatchedUpdatedAt: feedItem.isWatchedUpdatedAt,
+      previousRetainedBody:
+        store.retainedFeedItemBodyIds[id] === true
+          ? {
+              content: feedItem.content,
+              contentHash: feedItem.contentHash,
+              contentSnippet: feedItem.contentSnippet,
+            }
+          : undefined,
     });
     return [{ ...feedItem, isWatched, isWatchedUpdatedAt }];
   });
@@ -176,6 +191,7 @@ export function settleOptimisticWatchedValues(
     contexts.length === 1 && serverItems.length === 1
       ? serverItems[0]
       : undefined;
+  const restoredBodyItemIds = new Set<string>();
   const updatedItems = contexts.flatMap((context) => {
     if (
       !clearPendingFeedItemOverride(context.itemId, "isWatched", context.token)
@@ -185,17 +201,24 @@ export function settleOptimisticWatchedValues(
     const currentItem = store.feedItemsDict[context.itemId];
     if (!currentItem) return [];
     const serverItem = serverItemsById.get(context.itemId) ?? singleServerItem;
+    if (serverItem) return [{ ...currentItem, ...serverItem }];
+
+    const previousRetainedBody = context.previousRetainedBody;
+    const canRestoreBody =
+      !context.previousIsWatched &&
+      previousRetainedBody !== undefined &&
+      currentItem.contentHash === previousRetainedBody.contentHash;
+    if (canRestoreBody) restoredBodyItemIds.add(context.itemId);
     return [
-      serverItem
-        ? { ...currentItem, ...serverItem }
-        : {
-            ...currentItem,
-            isWatched: context.previousIsWatched,
-            isWatchedUpdatedAt: context.previousIsWatchedUpdatedAt,
-          },
+      {
+        ...currentItem,
+        ...(canRestoreBody ? previousRetainedBody : undefined),
+        isWatched: context.previousIsWatched,
+        isWatchedUpdatedAt: context.previousIsWatchedUpdatedAt,
+      },
     ];
   });
-  setFeedItemsWithMixedProjection(updatedItems);
+  setFeedItemsWithMixedProjection(updatedItems, restoredBodyItemIds);
 }
 
 export function resolveOptimisticWatchLaterValue(

--- a/apps/app/src/lib/data/feed-page-retention.ts
+++ b/apps/app/src/lib/data/feed-page-retention.ts
@@ -7,6 +7,7 @@ import {
   getRetainedPageMetrics,
   selectPersistedPages,
 } from "./page-retention";
+import { hasRetainedFeedBody } from "./offline-content";
 import type { RetainedCursorPage } from "./page-retention";
 import type { ApplicationFeedItem } from "~/server/db/schema";
 
@@ -31,6 +32,7 @@ export type FeedPageRetentionState = {
   retainedFeedPages: Record<string, RetainedFeedPage[]>;
   retainedFeedPageBytes: number;
   pageOwnedFeedItemIds: Record<string, true>;
+  retainedFeedItemBodyIds: Record<string, true>;
 };
 
 function retainedPageBytes(
@@ -107,7 +109,15 @@ export function applyFeedItemPageRetention(
 
   const feedItemsDict = { ...state.feedItemsDict };
   for (const id of Object.keys(pageOwnedFeedItemIds)) {
-    if (retainedEntityIds.has(id) || pinnedEntityIds.has(id)) continue;
+    const item = feedItemsDict[id];
+    if (
+      retainedEntityIds.has(id) ||
+      pinnedEntityIds.has(id) ||
+      (item &&
+        hasRetainedFeedBody(item, state.retainedFeedItemBodyIds[id] === true))
+    ) {
+      continue;
+    }
     delete feedItemsDict[id];
     delete pageOwnedFeedItemIds[id];
   }
@@ -133,6 +143,11 @@ export function applyFeedItemPageRetention(
       (id) => feedItemsDict[id] !== undefined,
     ),
     scopeFeedItemIds,
+    retainedFeedItemBodyIds: Object.fromEntries(
+      Object.keys(state.retainedFeedItemBodyIds)
+        .filter((id) => feedItemsDict[id] !== undefined)
+        .map((id) => [id, true as const]),
+    ),
   };
 }
 
@@ -154,7 +169,12 @@ export function getPersistedFeedItemRetentionState(
   const shouldPersistItem = (id: string) =>
     state.pageOwnedFeedItemIds[id] !== true ||
     persistedPageEntityIds.has(id) ||
-    pinnedEntityIds.has(id);
+    pinnedEntityIds.has(id) ||
+    (state.feedItemsDict[id] !== undefined &&
+      hasRetainedFeedBody(
+        state.feedItemsDict[id],
+        state.retainedFeedItemBodyIds[id] === true,
+      ));
   const feedItemsDict = Object.fromEntries(
     Object.entries(state.feedItemsDict).filter(([id]) => shouldPersistItem(id)),
   );
@@ -171,6 +191,11 @@ export function getPersistedFeedItemRetentionState(
     retainedFeedPageBytes: retainedPageBytes(retainedFeedPages),
     pageOwnedFeedItemIds: Object.fromEntries(
       Object.keys(state.pageOwnedFeedItemIds)
+        .filter((id) => shouldPersistItem(id))
+        .map((id) => [id, true as const]),
+    ),
+    retainedFeedItemBodyIds: Object.fromEntries(
+      Object.keys(state.retainedFeedItemBodyIds)
         .filter((id) => shouldPersistItem(id))
         .map((id) => [id, true as const]),
     ),

--- a/apps/app/src/lib/data/feed-page-retention.ts
+++ b/apps/app/src/lib/data/feed-page-retention.ts
@@ -7,7 +7,10 @@ import {
   getRetainedPageMetrics,
   selectPersistedPages,
 } from "./page-retention";
-import { hasRetainedFeedBody } from "./offline-content";
+import {
+  hasRetainedFeedBody,
+  stripIneligibleFeedBodyForPersistence,
+} from "./offline-content";
 import type { RetainedCursorPage } from "./page-retention";
 import type { ApplicationFeedItem } from "~/server/db/schema";
 
@@ -176,7 +179,9 @@ export function getPersistedFeedItemRetentionState(
         state.retainedFeedItemBodyIds[id] === true,
       ));
   const feedItemsDict = Object.fromEntries(
-    Object.entries(state.feedItemsDict).filter(([id]) => shouldPersistItem(id)),
+    Object.entries(state.feedItemsDict)
+      .filter(([id]) => shouldPersistItem(id))
+      .map(([id, item]) => [id, stripIneligibleFeedBodyForPersistence(item)]),
   );
   return {
     feedItemsDict,

--- a/apps/app/src/lib/data/mixed-content/mutations.ts
+++ b/apps/app/src/lib/data/mixed-content/mutations.ts
@@ -6,6 +6,7 @@ import {
   clearRetainedEntityPins,
   setRetainedEntityPins,
 } from "../page-retention";
+import { canMutateNow } from "../offline-mutations";
 import { isBookmarkProjectionChange } from "./bookmarkProjection";
 import { advanceMixedContentMembershipRevision } from "./membershipRevision";
 import { mixedContentStore } from "./store";
@@ -34,6 +35,9 @@ export async function setMixedReadValue(input: {
   references: MixedContentReference[];
   isRead: boolean;
 }) {
+  if (!canMutateNow()) {
+    return { bookmarkIds: [], feedItems: [] };
+  }
   const targets = partitionMixedReadTargets(input.references);
   const previousBookmarks = targets.bookmarkIds
     .map((id) => bookmarksStore.getState().getBookmark(id))

--- a/apps/app/src/lib/data/normalized-idb-storage.ts
+++ b/apps/app/src/lib/data/normalized-idb-storage.ts
@@ -27,6 +27,8 @@ type NormalizedRoot = {
   arrayLengths: Record<string, number>;
 };
 
+type NormalizedRecordSnapshots = Map<string, Map<string, unknown>>;
+
 function normalizedPrefix(name: string) {
   return `${name}::normalized:v1`;
 }
@@ -92,6 +94,30 @@ export function planNormalizedRecordChanges(
   );
   const deleteIds = Object.keys(previous).filter((id) => !(id in next));
   return { upsertIds, deleteIds };
+}
+
+function planNormalizedRecordSnapshotChanges(
+  previous: ReadonlyMap<string, unknown>,
+  next: Record<string, unknown>,
+) {
+  const upsertIds = Object.entries(next).flatMap(([id, value]) =>
+    Object.is(previous.get(id), value) ? [] : [id],
+  );
+  const deleteIds = [...previous.keys()].filter((id) => !(id in next));
+  return { upsertIds, deleteIds };
+}
+
+function snapshotNormalizedRecords<T>(
+  value: StorageValue<T> | null,
+  recordFields: readonly string[],
+) {
+  const state = stateRecord(value);
+  return new Map(
+    recordFields.map((field) => {
+      const record = isRecord(state[field]) ? state[field] : {};
+      return [field, new Map(Object.entries(record))] as const;
+    }),
+  );
 }
 
 export function planNormalizedArrayChunkChanges(
@@ -202,19 +228,21 @@ async function writeNormalized<T>(input: {
   previous: StorageValue<T> | null;
   next: StorageValue<T>;
   options: NormalizedStorageOptions;
+  recordSnapshots: NormalizedRecordSnapshots;
 }) {
-  const { name, previous, next, options } = input;
+  const { name, previous, next, options, recordSnapshots } = input;
   const previousState = stateRecord(previous);
   const nextState = stateRecord(next);
   const recordFields = new Set(options.recordFields ?? []);
   const arrayFields = new Set(options.arrayFields ?? []);
 
   for (const field of recordFields) {
-    const previousRecord = isRecord(previousState[field])
-      ? previousState[field]
-      : {};
+    const previousRecord = recordSnapshots.get(field) ?? new Map();
     const nextRecord = isRecord(nextState[field]) ? nextState[field] : {};
-    const changes = planNormalizedRecordChanges(previousRecord, nextRecord);
+    const changes = planNormalizedRecordSnapshotChanges(
+      previousRecord,
+      nextRecord,
+    );
     const upserts: Array<[IDBValidKey, unknown]> = changes.upsertIds.map(
       (id) => [recordKey(name, field, id), nextRecord[id]],
     );
@@ -224,6 +252,11 @@ async function writeNormalized<T>(input: {
     // react-doctor-disable-next-line react-doctor/async-await-in-loop
     await writeInBatches(upserts);
     await deleteInBatches(deletions);
+    for (const [index, id] of changes.upsertIds.entries()) {
+      previousRecord.set(id, upserts[index]![1]);
+    }
+    for (const id of changes.deleteIds) previousRecord.delete(id);
+    recordSnapshots.set(field, previousRecord);
   }
 
   const arrayLengths: Record<string, number> = {};
@@ -293,6 +326,9 @@ export function createNormalizedIDBStorage<T>(
   }
 
   let lastValue: StorageValue<T> | null = null;
+  // Stores may replace entities while retaining the dictionary object. Keep
+  // per-entity references outside that mutable state so persistence sees them.
+  let recordSnapshots: NormalizedRecordSnapshots = new Map();
   // Set when a read failed: IDB may still hold records that the diffing
   // write (which believes `previous` is empty) would never delete, and the
   // prefix-scan reader would resurrect them on the next load. The next flush
@@ -343,12 +379,14 @@ export function createNormalizedIDBStorage<T>(
               (key) => typeof key === "string" && key.startsWith(prefix),
             );
             await deleteInBatches(matchingKeys);
+            recordSnapshots = new Map();
           }
           await writeNormalized({
             name: current.name,
             previous: staleKeysPossible ? null : lastValue,
             next: current.value,
             options,
+            recordSnapshots,
           });
           // Cleared only after the rewrite succeeds: a partially-failed
           // rewrite can itself orphan records, so the next flush must sweep
@@ -381,6 +419,10 @@ export function createNormalizedIDBStorage<T>(
         const normalized = await readNormalized<T>(name, options);
         if (normalized) {
           lastValue = normalized;
+          recordSnapshots = snapshotNormalizedRecords(
+            normalized,
+            options.recordFields ?? [],
+          );
           return normalized;
         }
 
@@ -397,6 +439,7 @@ export function createNormalizedIDBStorage<T>(
             previous: null,
             next: legacy,
             options,
+            recordSnapshots,
           });
           // The migrated snapshot is already in hand and fully written; a
           // failure deleting the legacy key must not discard it. The stale
@@ -429,6 +472,7 @@ export function createNormalizedIDBStorage<T>(
       writeTimeout = null;
       pending = null;
       lastValue = null;
+      recordSnapshots = new Map();
       // zustand calls removeItem without awaiting, so a rejection here would
       // surface as an unhandled rejection instead of a recoverable state.
       await withCurrentIndexedDbSchema(async () => {

--- a/apps/app/src/lib/data/offline-content.ts
+++ b/apps/app/src/lib/data/offline-content.ts
@@ -66,9 +66,11 @@ export function stripIneligibleFeedBodyForPersistence(
 }
 
 export function shouldRetainBookmarkCapture(
-  bookmark: Pick<ApplicationBookmark, "contentType" | "isRead">,
+  bookmark: Pick<ApplicationBookmark, "contentType" | "isRead" | "isSaved">,
 ) {
-  return bookmark.contentType === "text" && !bookmark.isRead;
+  return (
+    bookmark.contentType === "text" && bookmark.isSaved && !bookmark.isRead
+  );
 }
 
 export function canOpenOfflineContent(input: {

--- a/apps/app/src/lib/data/offline-content.ts
+++ b/apps/app/src/lib/data/offline-content.ts
@@ -24,7 +24,7 @@ export function retainEligibleFeedBody(
   nextItem: ApplicationFeedItem,
 ) {
   if (nextItem.contentType !== "text" || nextItem.isWatched) {
-    return nextItem.content ? { ...nextItem, content: "" } : nextItem;
+    return nextItem;
   }
   if (
     !nextItem.content &&
@@ -39,6 +39,30 @@ export function retainEligibleFeedBody(
     };
   }
   return nextItem;
+}
+
+// Memoized per entity object so repeated persistence flushes hand the
+// normalized IDB diff a stable stripped identity instead of a fresh clone.
+const strippedBodiesForPersistence = new WeakMap<
+  ApplicationFeedItem,
+  ApplicationFeedItem
+>();
+
+/**
+ * Archived and video bodies must not survive in client persistence. The live
+ * store keeps them so the online reader can render without a refetch; only
+ * the persisted snapshot is stripped.
+ */
+export function stripIneligibleFeedBodyForPersistence(
+  item: ApplicationFeedItem,
+) {
+  if (isEligibleFeedBody(item) || !item.content) return item;
+  let stripped = strippedBodiesForPersistence.get(item);
+  if (!stripped) {
+    stripped = { ...item, content: "" };
+    strippedBodiesForPersistence.set(item, stripped);
+  }
+  return stripped;
 }
 
 export function shouldRetainBookmarkCapture(

--- a/apps/app/src/lib/data/offline-content.ts
+++ b/apps/app/src/lib/data/offline-content.ts
@@ -1,0 +1,65 @@
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import type { ConnectionState } from "./atoms";
+
+export function isEligibleFeedBody(
+  item: Pick<ApplicationFeedItem, "content" | "contentType" | "isWatched">,
+) {
+  return (
+    item.contentType === "text" &&
+    !item.isWatched &&
+    item.content.trim().length > 0
+  );
+}
+
+export function hasRetainedFeedBody(
+  item: Pick<ApplicationFeedItem, "content" | "contentType" | "isWatched">,
+  isRetained: boolean,
+) {
+  return isRetained && isEligibleFeedBody(item);
+}
+
+export function retainEligibleFeedBody(
+  previousItem: ApplicationFeedItem | undefined,
+  nextItem: ApplicationFeedItem,
+) {
+  if (nextItem.contentType !== "text" || nextItem.isWatched) {
+    return nextItem.content ? { ...nextItem, content: "" } : nextItem;
+  }
+  if (
+    !nextItem.content &&
+    previousItem?.contentHash &&
+    previousItem.contentHash === nextItem.contentHash &&
+    isEligibleFeedBody(previousItem)
+  ) {
+    return {
+      ...nextItem,
+      content: previousItem.content,
+      contentSnippet: nextItem.contentSnippet || previousItem.contentSnippet,
+    };
+  }
+  return nextItem;
+}
+
+export function shouldRetainBookmarkCapture(
+  bookmark: Pick<ApplicationBookmark, "contentType" | "isRead">,
+) {
+  return bookmark.contentType === "text" && !bookmark.isRead;
+}
+
+export function canOpenOfflineContent(input: {
+  contentType: "text" | "video";
+  hasBody: boolean;
+}) {
+  return input.contentType === "text" && input.hasBody;
+}
+
+export function canOpenContent(input: {
+  connectionState: ConnectionState;
+  contentType: "text" | "video";
+  hasBody: boolean;
+}) {
+  return (
+    input.connectionState !== "disconnected" || canOpenOfflineContent(input)
+  );
+}

--- a/apps/app/src/lib/data/offline-hydration.ts
+++ b/apps/app/src/lib/data/offline-hydration.ts
@@ -30,10 +30,17 @@ const unavailableCaptures = new Map<string, string | null>();
 // user's content.
 let hydrationEpoch = 0;
 
+// A hydration request that hangs rather than rejecting (dropped mobile
+// radio) must not gate the single-flight run for the browser's own
+// multi-minute fetch timeout.
+const HYDRATION_REQUEST_TIMEOUT_MS = 30_000;
+
 // Page applications coalesce into one hydration run: the retry sets are
 // session-scoped, so concurrent runs would each sweep the whole failed set.
-const pendingFeedItems: ApplicationFeedItem[] = [];
-const pendingBookmarks: ApplicationBookmark[] = [];
+// Pending entities are keyed by id so repeated applications of the same page
+// while a run is gated cannot grow the buffer.
+const pendingFeedItems = new Map<string, ApplicationFeedItem>();
+const pendingBookmarks = new Map<string, ApplicationBookmark>();
 let pendingRun = false;
 let activeHydration: Promise<void> | null = null;
 
@@ -43,9 +50,12 @@ export function invalidateOfflineHydration() {
   failedBookmarkIds.clear();
   unavailableFeedBodies.clear();
   unavailableCaptures.clear();
-  pendingFeedItems.length = 0;
-  pendingBookmarks.length = 0;
+  pendingFeedItems.clear();
+  pendingBookmarks.clear();
   pendingRun = false;
+  // Sever the previous session's run: it exits on its cleared pendingRun
+  // flag, and its own finally must not null out a newer session's run.
+  activeHydration = null;
 }
 
 // Macrotask yield through a MessageChannel rather than setTimeout: the
@@ -154,9 +164,10 @@ async function hydrateFeedItemBodies(itemIds: string[], epoch: number) {
   for (let index = 0; index < itemIds.length; index += FULLTEXT_BATCH_SIZE) {
     const batch = itemIds.slice(index, index + FULLTEXT_BATCH_SIZE);
     try {
-      const items = await orpcRouterClient.initial.requestFullTextForItems({
-        itemIds: batch,
-      });
+      const items = await orpcRouterClient.initial.requestFullTextForItems(
+        { itemIds: batch },
+        { signal: AbortSignal.timeout(HYDRATION_REQUEST_TIMEOUT_MS) },
+      );
       if (epoch !== hydrationEpoch) return;
       const returnedById = new Map(items.map((item) => [item.id, item]));
       for (const id of batch) {
@@ -180,9 +191,10 @@ async function hydrateBookmarkCaptures(bookmarkIds: string[], epoch: number) {
   for (let index = 0; index < bookmarkIds.length; index += CAPTURE_BATCH_SIZE) {
     const batch = bookmarkIds.slice(index, index + CAPTURE_BATCH_SIZE);
     try {
-      const captures = await orpcRouterClient.bookmark.getCaptures({
-        bookmarkIds: batch,
-      });
+      const captures = await orpcRouterClient.bookmark.getCaptures(
+        { bookmarkIds: batch },
+        { signal: AbortSignal.timeout(HYDRATION_REQUEST_TIMEOUT_MS) },
+      );
       if (epoch !== hydrationEpoch) return;
       const returnedIds = new Set(
         captures.map((capture) => capture.bookmarkId),
@@ -248,23 +260,31 @@ export function hydrateOfflineBodiesForPage(page: {
   if (typeof navigator !== "undefined" && navigator.onLine === false) {
     return Promise.resolve();
   }
-  pendingFeedItems.push(...page.feedItems);
-  pendingBookmarks.push(...page.bookmarks);
+  for (const item of page.feedItems) pendingFeedItems.set(item.id, item);
+  for (const bookmark of page.bookmarks) {
+    pendingBookmarks.set(bookmark.id, bookmark);
+  }
   // Even an entity-less page application sweeps once so failed fetches
   // retry; without this the active target's `unchanged` diffs would never
   // trigger a retry.
   pendingRun = true;
-  activeHydration ??= (async () => {
+  if (activeHydration) return activeHydration;
+  const startEpoch = hydrationEpoch;
+  activeHydration = (async () => {
     try {
       while (pendingRun) {
         pendingRun = false;
-        await hydratePendingEntities({
-          feedItems: pendingFeedItems.splice(0),
-          bookmarks: pendingBookmarks.splice(0),
-        });
+        const feedItems = [...pendingFeedItems.values()];
+        const bookmarks = [...pendingBookmarks.values()];
+        pendingFeedItems.clear();
+        pendingBookmarks.clear();
+        await hydratePendingEntities({ feedItems, bookmarks });
       }
     } finally {
-      activeHydration = null;
+      // An unchanged epoch proves this run is still the admitted one; a
+      // bumped epoch means invalidation severed it and may have admitted a
+      // newer run that must not be nulled out.
+      if (hydrationEpoch === startEpoch) activeHydration = null;
     }
   })();
   return activeHydration;

--- a/apps/app/src/lib/data/offline-hydration.ts
+++ b/apps/app/src/lib/data/offline-hydration.ts
@@ -272,7 +272,9 @@ export function hydrateOfflineBodiesForPage(page: {
   const startEpoch = hydrationEpoch;
   activeHydration = (async () => {
     try {
-      while (pendingRun) {
+      // The epoch condition stops a severed run from resurrecting after
+      // invalidation and sweeping concurrently with the newly admitted run.
+      while (pendingRun && hydrationEpoch === startEpoch) {
         pendingRun = false;
         const feedItems = [...pendingFeedItems.values()];
         const bookmarks = [...pendingBookmarks.values()];

--- a/apps/app/src/lib/data/offline-hydration.ts
+++ b/apps/app/src/lib/data/offline-hydration.ts
@@ -2,6 +2,7 @@
 
 import { orpcRouterClient } from "../orpc";
 import { bookmarkCapturesStore } from "./bookmarks/capture-store";
+import { bookmarksStore } from "./bookmarks/store";
 import {
   isEligibleFeedBody,
   shouldRetainBookmarkCapture,
@@ -10,7 +11,31 @@ import { feedItemsStore, retainLoadedFeedItemBodies } from "./store";
 import type { ApplicationFeedItem } from "~/server/db/schema";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
 
+const FULLTEXT_BATCH_SIZE = 500;
 const CAPTURE_BATCH_SIZE = 100;
+
+// Failed requests retry on the next page application even when that page no
+// longer carries the entity (the active target diffs to `unchanged`, so a
+// retry keyed only on page upserts would never fire for it). Ids whose fetch
+// succeeded without yielding content can never hydrate this session and must
+// not be re-requested on every page application.
+const failedFeedItemIds = new Set<string>();
+const failedBookmarkIds = new Set<string>();
+const unavailableFeedItemIds = new Set<string>();
+const unavailableBookmarkIds = new Set<string>();
+
+// Bumped on sign-out so an in-flight response cannot repopulate cleared
+// stores (and, through their persistence, IndexedDB) with the previous
+// user's content.
+let hydrationEpoch = 0;
+
+export function invalidateOfflineHydration() {
+  hydrationEpoch += 1;
+  failedFeedItemIds.clear();
+  failedBookmarkIds.clear();
+  unavailableFeedItemIds.clear();
+  unavailableBookmarkIds.clear();
+}
 
 /**
  * Page-scoped body hydration: only the Saved, Unread text items on the page
@@ -35,7 +60,6 @@ export function planPageBodyHydration(input: {
     }
   }
   const fetchBookmarkIds = input.bookmarks.flatMap((bookmark) =>
-    bookmark.isSaved &&
     bookmark.captureHash &&
     shouldRetainBookmarkCapture(bookmark) &&
     !input.hasBookmarkCapture(bookmark.id)
@@ -45,29 +69,86 @@ export function planPageBodyHydration(input: {
   return { retainLoadedFeedItemIds, fetchFeedItemIds, fetchBookmarkIds };
 }
 
-async function hydrateFeedItemBodies(itemIds: string[]) {
-  if (itemIds.length === 0) return;
-  try {
-    const items = await orpcRouterClient.initial.requestFullTextForItems({
-      itemIds,
-    });
-    feedItemsStore.getState().applyFulltextItems(items);
-  } catch {
-    // No offline outbox: the next page application retries hydration.
+// Failed ids re-enter planning through their current store entities so the
+// original eligibility rules keep applying; ids that stopped qualifying (or
+// already hydrated through a later payload) leave the retry set.
+function takeFeedItemRetries() {
+  const { feedItemsDict } = feedItemsStore.getState();
+  const items: ApplicationFeedItem[] = [];
+  for (const id of [...failedFeedItemIds]) {
+    const item = feedItemsDict[id];
+    const qualifies =
+      item !== undefined &&
+      item.contentType === "text" &&
+      !item.isWatched &&
+      item.isWatchLater;
+    if (!qualifies || isEligibleFeedBody(item)) failedFeedItemIds.delete(id);
+    if (qualifies) items.push(item);
+  }
+  return items;
+}
+
+function takeBookmarkRetries() {
+  const bookmarks: ApplicationBookmark[] = [];
+  for (const id of [...failedBookmarkIds]) {
+    const bookmark = bookmarksStore.getState().getBookmark(id);
+    if (
+      !bookmark?.captureHash ||
+      !shouldRetainBookmarkCapture(bookmark) ||
+      bookmarkCapturesStore.getState().capturesDict[id] !== undefined
+    ) {
+      failedBookmarkIds.delete(id);
+      continue;
+    }
+    bookmarks.push(bookmark);
+  }
+  return bookmarks;
+}
+
+async function hydrateFeedItemBodies(itemIds: string[], epoch: number) {
+  for (let index = 0; index < itemIds.length; index += FULLTEXT_BATCH_SIZE) {
+    const batch = itemIds.slice(index, index + FULLTEXT_BATCH_SIZE);
+    try {
+      const items = await orpcRouterClient.initial.requestFullTextForItems({
+        itemIds: batch,
+      });
+      if (epoch !== hydrationEpoch) return;
+      const returnedById = new Map(items.map((item) => [item.id, item]));
+      for (const id of batch) {
+        failedFeedItemIds.delete(id);
+        if (!returnedById.get(id)?.content.trim()) {
+          unavailableFeedItemIds.add(id);
+        }
+      }
+      feedItemsStore.getState().applyFulltextItems(items);
+    } catch {
+      if (epoch !== hydrationEpoch) return;
+      for (const id of batch) failedFeedItemIds.add(id);
+    }
   }
 }
 
-async function hydrateBookmarkCaptures(bookmarkIds: string[]) {
+async function hydrateBookmarkCaptures(bookmarkIds: string[], epoch: number) {
   for (let index = 0; index < bookmarkIds.length; index += CAPTURE_BATCH_SIZE) {
+    const batch = bookmarkIds.slice(index, index + CAPTURE_BATCH_SIZE);
     try {
       const captures = await orpcRouterClient.bookmark.getCaptures({
-        bookmarkIds: bookmarkIds.slice(index, index + CAPTURE_BATCH_SIZE),
+        bookmarkIds: batch,
       });
+      if (epoch !== hydrationEpoch) return;
+      const returnedIds = new Set(
+        captures.map((capture) => capture.bookmarkId),
+      );
+      for (const id of batch) {
+        failedBookmarkIds.delete(id);
+        if (!returnedIds.has(id)) unavailableBookmarkIds.add(id);
+      }
       for (const capture of captures) {
         bookmarkCapturesStore.getState().upsert(capture);
       }
     } catch {
-      // No offline outbox: the next page application retries hydration.
+      if (epoch !== hydrationEpoch) return;
+      for (const id of batch) failedBookmarkIds.add(id);
     }
   }
 }
@@ -77,19 +158,27 @@ export async function hydrateOfflineBodiesForPage(page: {
   bookmarks: readonly ApplicationBookmark[];
 }) {
   if (typeof navigator !== "undefined" && navigator.onLine === false) return;
+  const epoch = hydrationEpoch;
   // Hydration must not lengthen the page-application task it follows.
   await new Promise((resolve) => setTimeout(resolve, 0));
+  if (epoch !== hydrationEpoch) return;
   const plan = planPageBodyHydration({
-    feedItems: page.feedItems,
-    bookmarks: page.bookmarks,
+    feedItems: [...page.feedItems, ...takeFeedItemRetries()],
+    bookmarks: [...page.bookmarks, ...takeBookmarkRetries()],
     hasRetainedFeedBody: (id) =>
       feedItemsStore.getState().retainedFeedItemBodyIds[id] === true,
     hasBookmarkCapture: (id) =>
       bookmarkCapturesStore.getState().capturesDict[id] !== undefined,
   });
   retainLoadedFeedItemBodies(plan.retainLoadedFeedItemIds);
+  const fetchFeedItemIds = [...new Set(plan.fetchFeedItemIds)].filter(
+    (id) => !unavailableFeedItemIds.has(id),
+  );
+  const fetchBookmarkIds = [...new Set(plan.fetchBookmarkIds)].filter(
+    (id) => !unavailableBookmarkIds.has(id),
+  );
   await Promise.all([
-    hydrateFeedItemBodies(plan.fetchFeedItemIds),
-    hydrateBookmarkCaptures(plan.fetchBookmarkIds),
+    hydrateFeedItemBodies(fetchFeedItemIds, epoch),
+    hydrateBookmarkCaptures(fetchBookmarkIds, epoch),
   ]);
 }

--- a/apps/app/src/lib/data/offline-hydration.ts
+++ b/apps/app/src/lib/data/offline-hydration.ts
@@ -17,24 +17,49 @@ const CAPTURE_BATCH_SIZE = 100;
 // Failed requests retry on the next page application even when that page no
 // longer carries the entity (the active target diffs to `unchanged`, so a
 // retry keyed only on page upserts would never fire for it). Ids whose fetch
-// succeeded without yielding content can never hydrate this session and must
-// not be re-requested on every page application.
+// succeeded without yielding content are recorded with the content hash they
+// were fetched under: they must not be re-requested on every page
+// application, but a changed hash means new server content and unblocks them.
 const failedFeedItemIds = new Set<string>();
 const failedBookmarkIds = new Set<string>();
-const unavailableFeedItemIds = new Set<string>();
-const unavailableBookmarkIds = new Set<string>();
+const unavailableFeedBodies = new Map<string, string | null>();
+const unavailableCaptures = new Map<string, string | null>();
 
 // Bumped on sign-out so an in-flight response cannot repopulate cleared
 // stores (and, through their persistence, IndexedDB) with the previous
 // user's content.
 let hydrationEpoch = 0;
 
+// Page applications coalesce into one hydration run: the retry sets are
+// session-scoped, so concurrent runs would each sweep the whole failed set.
+const pendingFeedItems: ApplicationFeedItem[] = [];
+const pendingBookmarks: ApplicationBookmark[] = [];
+let pendingRun = false;
+let activeHydration: Promise<void> | null = null;
+
 export function invalidateOfflineHydration() {
   hydrationEpoch += 1;
   failedFeedItemIds.clear();
   failedBookmarkIds.clear();
-  unavailableFeedItemIds.clear();
-  unavailableBookmarkIds.clear();
+  unavailableFeedBodies.clear();
+  unavailableCaptures.clear();
+  pendingFeedItems.length = 0;
+  pendingBookmarks.length = 0;
+  pendingRun = false;
+}
+
+// Macrotask yield through a MessageChannel rather than setTimeout: the
+// single-flight run must survive mocked timers, and a message task defers
+// off the page-application task just the same.
+function yieldToNextTask() {
+  return new Promise<void>((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => {
+      channel.port1.close();
+      resolve();
+    };
+    channel.port2.postMessage(null);
+  });
 }
 
 /**
@@ -105,6 +130,26 @@ function takeBookmarkRetries() {
   return bookmarks;
 }
 
+// Blocked while the server-side hash matches the one the empty fetch saw; a
+// changed hash means regenerated content, so the block lifts. A permanently
+// blocked id also leaves the retry set so it cannot linger there.
+function filterUnavailable(
+  ids: string[],
+  unavailable: Map<string, string | null>,
+  failed: Set<string>,
+  currentHash: (id: string) => string | null,
+) {
+  return [...new Set(ids)].filter((id) => {
+    if (!unavailable.has(id)) return true;
+    if (unavailable.get(id) === currentHash(id)) {
+      failed.delete(id);
+      return false;
+    }
+    unavailable.delete(id);
+    return true;
+  });
+}
+
 async function hydrateFeedItemBodies(itemIds: string[], epoch: number) {
   for (let index = 0; index < itemIds.length; index += FULLTEXT_BATCH_SIZE) {
     const batch = itemIds.slice(index, index + FULLTEXT_BATCH_SIZE);
@@ -117,7 +162,10 @@ async function hydrateFeedItemBodies(itemIds: string[], epoch: number) {
       for (const id of batch) {
         failedFeedItemIds.delete(id);
         if (!returnedById.get(id)?.content.trim()) {
-          unavailableFeedItemIds.add(id);
+          unavailableFeedBodies.set(
+            id,
+            feedItemsStore.getState().feedItemsDict[id]?.contentHash ?? null,
+          );
         }
       }
       feedItemsStore.getState().applyFulltextItems(items);
@@ -141,7 +189,12 @@ async function hydrateBookmarkCaptures(bookmarkIds: string[], epoch: number) {
       );
       for (const id of batch) {
         failedBookmarkIds.delete(id);
-        if (!returnedIds.has(id)) unavailableBookmarkIds.add(id);
+        if (!returnedIds.has(id)) {
+          unavailableCaptures.set(
+            id,
+            bookmarksStore.getState().getBookmark(id)?.captureHash ?? null,
+          );
+        }
       }
       for (const capture of captures) {
         bookmarkCapturesStore.getState().upsert(capture);
@@ -153,14 +206,13 @@ async function hydrateBookmarkCaptures(bookmarkIds: string[], epoch: number) {
   }
 }
 
-export async function hydrateOfflineBodiesForPage(page: {
+async function hydratePendingEntities(page: {
   feedItems: readonly ApplicationFeedItem[];
   bookmarks: readonly ApplicationBookmark[];
 }) {
-  if (typeof navigator !== "undefined" && navigator.onLine === false) return;
   const epoch = hydrationEpoch;
   // Hydration must not lengthen the page-application task it follows.
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await yieldToNextTask();
   if (epoch !== hydrationEpoch) return;
   const plan = planPageBodyHydration({
     feedItems: [...page.feedItems, ...takeFeedItemRetries()],
@@ -171,14 +223,49 @@ export async function hydrateOfflineBodiesForPage(page: {
       bookmarkCapturesStore.getState().capturesDict[id] !== undefined,
   });
   retainLoadedFeedItemBodies(plan.retainLoadedFeedItemIds);
-  const fetchFeedItemIds = [...new Set(plan.fetchFeedItemIds)].filter(
-    (id) => !unavailableFeedItemIds.has(id),
+  const fetchFeedItemIds = filterUnavailable(
+    plan.fetchFeedItemIds,
+    unavailableFeedBodies,
+    failedFeedItemIds,
+    (id) => feedItemsStore.getState().feedItemsDict[id]?.contentHash ?? null,
   );
-  const fetchBookmarkIds = [...new Set(plan.fetchBookmarkIds)].filter(
-    (id) => !unavailableBookmarkIds.has(id),
+  const fetchBookmarkIds = filterUnavailable(
+    plan.fetchBookmarkIds,
+    unavailableCaptures,
+    failedBookmarkIds,
+    (id) => bookmarksStore.getState().getBookmark(id)?.captureHash ?? null,
   );
   await Promise.all([
     hydrateFeedItemBodies(fetchFeedItemIds, epoch),
     hydrateBookmarkCaptures(fetchBookmarkIds, epoch),
   ]);
+}
+
+export function hydrateOfflineBodiesForPage(page: {
+  feedItems: readonly ApplicationFeedItem[];
+  bookmarks: readonly ApplicationBookmark[];
+}): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.onLine === false) {
+    return Promise.resolve();
+  }
+  pendingFeedItems.push(...page.feedItems);
+  pendingBookmarks.push(...page.bookmarks);
+  // Even an entity-less page application sweeps once so failed fetches
+  // retry; without this the active target's `unchanged` diffs would never
+  // trigger a retry.
+  pendingRun = true;
+  activeHydration ??= (async () => {
+    try {
+      while (pendingRun) {
+        pendingRun = false;
+        await hydratePendingEntities({
+          feedItems: pendingFeedItems.splice(0),
+          bookmarks: pendingBookmarks.splice(0),
+        });
+      }
+    } finally {
+      activeHydration = null;
+    }
+  })();
+  return activeHydration;
 }

--- a/apps/app/src/lib/data/offline-hydration.ts
+++ b/apps/app/src/lib/data/offline-hydration.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { orpcRouterClient } from "../orpc";
+import { bookmarkCapturesStore } from "./bookmarks/capture-store";
+import {
+  isEligibleFeedBody,
+  shouldRetainBookmarkCapture,
+} from "./offline-content";
+import { feedItemsStore, retainLoadedFeedItemBodies } from "./store";
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+
+const CAPTURE_BATCH_SIZE = 100;
+
+/**
+ * Page-scoped body hydration: only the Saved, Unread text items on the page
+ * that was just applied. Unfetched library pages are never scanned.
+ */
+export function planPageBodyHydration(input: {
+  feedItems: readonly ApplicationFeedItem[];
+  bookmarks: readonly ApplicationBookmark[];
+  hasRetainedFeedBody: (id: string) => boolean;
+  hasBookmarkCapture: (id: string) => boolean;
+}) {
+  const retainLoadedFeedItemIds: string[] = [];
+  const fetchFeedItemIds: string[] = [];
+  for (const item of input.feedItems) {
+    if (item.contentType !== "text" || item.isWatched || !item.isWatchLater) {
+      continue;
+    }
+    if (!isEligibleFeedBody(item)) {
+      fetchFeedItemIds.push(item.id);
+    } else if (!input.hasRetainedFeedBody(item.id)) {
+      retainLoadedFeedItemIds.push(item.id);
+    }
+  }
+  const fetchBookmarkIds = input.bookmarks.flatMap((bookmark) =>
+    bookmark.isSaved &&
+    bookmark.captureHash &&
+    shouldRetainBookmarkCapture(bookmark) &&
+    !input.hasBookmarkCapture(bookmark.id)
+      ? [bookmark.id]
+      : [],
+  );
+  return { retainLoadedFeedItemIds, fetchFeedItemIds, fetchBookmarkIds };
+}
+
+async function hydrateFeedItemBodies(itemIds: string[]) {
+  if (itemIds.length === 0) return;
+  try {
+    const items = await orpcRouterClient.initial.requestFullTextForItems({
+      itemIds,
+    });
+    feedItemsStore.getState().applyFulltextItems(items);
+  } catch {
+    // No offline outbox: the next page application retries hydration.
+  }
+}
+
+async function hydrateBookmarkCaptures(bookmarkIds: string[]) {
+  for (let index = 0; index < bookmarkIds.length; index += CAPTURE_BATCH_SIZE) {
+    try {
+      const captures = await orpcRouterClient.bookmark.getCaptures({
+        bookmarkIds: bookmarkIds.slice(index, index + CAPTURE_BATCH_SIZE),
+      });
+      for (const capture of captures) {
+        bookmarkCapturesStore.getState().upsert(capture);
+      }
+    } catch {
+      // No offline outbox: the next page application retries hydration.
+    }
+  }
+}
+
+export async function hydrateOfflineBodiesForPage(page: {
+  feedItems: readonly ApplicationFeedItem[];
+  bookmarks: readonly ApplicationBookmark[];
+}) {
+  if (typeof navigator !== "undefined" && navigator.onLine === false) return;
+  // Hydration must not lengthen the page-application task it follows.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const plan = planPageBodyHydration({
+    feedItems: page.feedItems,
+    bookmarks: page.bookmarks,
+    hasRetainedFeedBody: (id) =>
+      feedItemsStore.getState().retainedFeedItemBodyIds[id] === true,
+    hasBookmarkCapture: (id) =>
+      bookmarkCapturesStore.getState().capturesDict[id] !== undefined,
+  });
+  retainLoadedFeedItemBodies(plan.retainLoadedFeedItemIds);
+  await Promise.all([
+    hydrateFeedItemBodies(plan.fetchFeedItemIds),
+    hydrateBookmarkCaptures(plan.fetchBookmarkIds),
+  ]);
+}

--- a/apps/app/src/lib/data/offline-mutations.ts
+++ b/apps/app/src/lib/data/offline-mutations.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { getDefaultStore, useAtomValue } from "jotai";
+import { connectionStateAtom } from "./atoms";
+import type { ConnectionState } from "./atoms";
+
+export function canMutate(connectionState: ConnectionState) {
+  return connectionState !== "disconnected";
+}
+
+export function canMutateNow() {
+  return canMutate(getDefaultStore().get(connectionStateAtom));
+}
+
+export function useCanMutate() {
+  return canMutate(useAtomValue(connectionStateAtom));
+}

--- a/apps/app/src/lib/data/reconciliationPage.ts
+++ b/apps/app/src/lib/data/reconciliationPage.ts
@@ -2,6 +2,7 @@ import { getDefaultStore } from "jotai";
 import { bookmarksStore } from "./bookmarks/store";
 import { getMixedContentMembershipRevision } from "./mixed-content/membershipRevision";
 import { getMixedScopeKey, mixedContentStore } from "./mixed-content/store";
+import { hydrateOfflineBodiesForPage } from "./offline-hydration";
 import { feedItemsStore } from "./store";
 import { viewsStore } from "./views/store";
 import {
@@ -52,6 +53,10 @@ export function applyReconciliationFirstPage(page: ActiveFirstPageResult) {
   }
   feedItemsStore.getState().setFeedItems(feedItemUpserts);
   bookmarksStore.getState().upsertMany(bookmarkUpserts);
+  void hydrateOfflineBodiesForPage({
+    feedItems: feedItemUpserts,
+    bookmarks: bookmarkUpserts,
+  });
 
   const pageResult = mixedContentStore.getState().reconcileFirstPage({
     scope: page.target.scope,

--- a/apps/app/src/lib/data/store.ts
+++ b/apps/app/src/lib/data/store.ts
@@ -19,6 +19,11 @@ import {
   reconcileScopeMembershipsForItems,
 } from "./scopeMembership";
 import { refreshNavigationSnapshotSafely } from "./navigation/store";
+import {
+  hasRetainedFeedBody,
+  isEligibleFeedBody,
+  retainEligibleFeedBody,
+} from "./offline-content";
 import type {
   RetainedFeedPage,
   RetainFeedItemPageInput,
@@ -40,11 +45,16 @@ function mergeFeedItemIntoOrder(
   feedItemsOrder: string[],
   existingIds: Set<string>,
   incomingItem: IncomingFeedItem,
+  retainedFeedItemBodyIds: Record<string, true>,
 ) {
-  feedItemsDict[incomingItem.id] = mergeFeedItem(
+  const mergedItem = mergeFeedItem(
     feedItemsDict[incomingItem.id],
     incomingItem,
   );
+  feedItemsDict[incomingItem.id] = mergedItem;
+  if (!isEligibleFeedBody(mergedItem)) {
+    delete retainedFeedItemBodyIds[incomingItem.id];
+  }
 
   if (!existingIds.has(incomingItem.id)) {
     feedItemsOrder.push(incomingItem.id);
@@ -72,6 +82,7 @@ export type ApplicationStore = {
   retainedFeedPages: Record<string, RetainedFeedPage[]>;
   retainedFeedPageBytes: number;
   pageOwnedFeedItemIds: Record<string, true>;
+  retainedFeedItemBodyIds: Record<string, true>;
   retainFeedItemPage: (input: RetainFeedItemPageInput) => void;
   feedStatusDict: Record<number, FetchFeedsStatus>;
   setFeedItemsDict: (itemsDict: Record<string, ApplicationFeedItem>) => void;
@@ -119,6 +130,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
           retainedFeedPages: {},
           retainedFeedPageBytes: 0,
           pageOwnedFeedItemIds: {},
+          retainedFeedItemBodyIds: {},
           feedStatusDict: {},
           hasInitialData: false,
           viewFeedIds: {},
@@ -135,6 +147,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
       retainedFeedPages: {},
       retainedFeedPageBytes: 0,
       pageOwnedFeedItemIds: {},
+      retainedFeedItemBodyIds: {},
       retainFeedItemPage: (input) =>
         set(applyFeedItemPageRetention(get(), input)),
       feedStatusDict: {},
@@ -146,15 +159,22 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
       setFeedItem: (id, item) => {
         const state = get();
         const previousItem = state.feedItemsDict[id];
+        const retainedItem = retainEligibleFeedBody(previousItem, item);
+        const retainedFeedItemBodyIds = {
+          ...state.retainedFeedItemBodyIds,
+        };
+        if (!isEligibleFeedBody(retainedItem)) {
+          delete retainedFeedItemBodyIds[id];
+        }
         const projectionChanged = hasFeedItemListProjectionChanged(
           previousItem,
-          item,
+          retainedItem,
         );
 
         // Feed-item entities are normalized by id. Replacing just this entry
         // keeps progress and full-text patches O(1), while Zustand's item
         // selector still observes the new entity object.
-        state.feedItemsDict[id] = item;
+        state.feedItemsDict[id] = retainedItem;
 
         set({
           feedItemsDict: state.feedItemsDict,
@@ -162,8 +182,12 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
             ? state.feedItemProjectionRevision + 1
             : state.feedItemProjectionRevision,
           scopeFeedItemIds: projectionChanged
-            ? reconcileScopeMembershipsForItem(state.scopeFeedItemIds, item)
+            ? reconcileScopeMembershipsForItem(
+                state.scopeFeedItemIds,
+                retainedItem,
+              )
             : state.scopeFeedItemIds,
+          retainedFeedItemBodyIds,
         });
       },
       setFeedItems: (items, retention) => {
@@ -172,17 +196,30 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
         const state = get();
         const feedItemsDict = state.feedItemsDict;
         const projectionChangedItems: ApplicationFeedItem[] = [];
+        const retainedFeedItemBodyIds = {
+          ...state.retainedFeedItemBodyIds,
+        };
 
         for (const item of items) {
+          const retainedItem = retainEligibleFeedBody(
+            state.feedItemsDict[item.id],
+            item,
+          );
           if (
-            hasFeedItemListProjectionChanged(state.feedItemsDict[item.id], item)
+            hasFeedItemListProjectionChanged(
+              state.feedItemsDict[item.id],
+              retainedItem,
+            )
           ) {
-            projectionChangedItems.push(item);
+            projectionChangedItems.push(retainedItem);
           }
           // Feed-item entities are normalized by id. Mutating only changed
           // entries keeps batch cost proportional to the incoming page or
           // optimistic selection instead of cloning the whole library.
-          feedItemsDict[item.id] = item;
+          feedItemsDict[item.id] = retainedItem;
+          if (!isEligibleFeedBody(retainedItem)) {
+            delete retainedFeedItemBodyIds[item.id];
+          }
         }
 
         const scopeFeedItemIds =
@@ -200,6 +237,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
               ? state.feedItemProjectionRevision + 1
               : state.feedItemProjectionRevision,
           scopeFeedItemIds,
+          retainedFeedItemBodyIds,
         };
         set(
           retention
@@ -218,15 +256,25 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
       applyFulltextItems: (items) => {
         const feedItemsDict = get().feedItemsDict;
         const pendingFulltext = new Set(get().pendingFulltextItems);
+        const retainedFeedItemBodyIds = {
+          ...get().retainedFeedItemBodyIds,
+        };
 
         for (const item of items) {
           const existing = feedItemsDict[item.id];
-          if (existing) {
+          if (
+            existing &&
+            existing.contentType === "text" &&
+            !existing.isWatched
+          ) {
             feedItemsDict[item.id] = {
               ...existing,
               content: item.content,
               contentSnippet: item.contentSnippet,
             };
+            if (item.content.trim()) {
+              retainedFeedItemBodyIds[item.id] = true;
+            }
           }
           pendingFulltext.delete(item.id);
         }
@@ -234,6 +282,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
         set({
           feedItemsDict,
           pendingFulltextItems: Array.from(pendingFulltext),
+          retainedFeedItemBodyIds,
         });
       },
 
@@ -294,6 +343,9 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
           const feedStatusDict = { ...get().feedStatusDict };
           const feedItemsDict = { ...get().feedItemsDict };
           const feedItemsOrder = [...get().feedItemsOrder];
+          const retainedFeedItemBodyIds = {
+            ...get().retainedFeedItemBodyIds,
+          };
           let incomingFeedItems: ApplicationFeedItem[] = [];
 
           if (incomingChunk.type === "feed-status") {
@@ -308,6 +360,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
                 feedItemsOrder,
                 existingIds,
                 item,
+                retainedFeedItemBodyIds,
               );
             });
           }
@@ -316,6 +369,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
             feedItemsDict: feedItemsDict,
             feedItemsOrder,
             feedStatusDict: feedStatusDict,
+            retainedFeedItemBodyIds,
             scopeFeedItemIds:
               incomingFeedItems.length > 0
                 ? reconcileScopeMembershipsForItems(
@@ -358,6 +412,9 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
         const mergeFeedItems = (items: ApplicationFeedItem[]) => {
           const feedItemsDict = { ...get().feedItemsDict };
           const feedItemsOrder = [...get().feedItemsOrder];
+          const retainedFeedItemBodyIds = {
+            ...get().retainedFeedItemBodyIds,
+          };
           const existingIds = new Set(feedItemsOrder);
 
           items.forEach((item) => {
@@ -366,12 +423,14 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
               feedItemsOrder,
               existingIds,
               item,
+              retainedFeedItemBodyIds,
             );
           });
 
           set({
             feedItemsDict,
             feedItemsOrder,
+            retainedFeedItemBodyIds,
             scopeFeedItemIds: reconcileScopeMembershipsForItems(
               get().scopeFeedItemIds,
               getMergedFeedItems(feedItemsDict, items),
@@ -419,7 +478,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
     {
       name: "serial-application-store",
       storage: createNormalizedIDBStorage({
-        recordFields: ["feedItemsDict"],
+        recordFields: ["feedItemsDict", "retainedFeedItemBodyIds"],
         arrayFields: ["feedItemsOrder"],
       }),
       version: 1,
@@ -434,6 +493,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
           retainedFeedPages: persistedState.retainedFeedPages ?? {},
           retainedFeedPageBytes: persistedState.retainedFeedPageBytes ?? 0,
           pageOwnedFeedItemIds: persistedState.pageOwnedFeedItemIds ?? {},
+          retainedFeedItemBodyIds: persistedState.retainedFeedItemBodyIds ?? {},
         };
 
         // Cross-reference hydrated feed items against the feeds store's
@@ -472,6 +532,11 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
             }
             merged.feedItemsDict = newDict;
             merged.feedItemsOrder = order.filter((id) => !orphanedSet.has(id));
+            merged.retainedFeedItemBodyIds = Object.fromEntries(
+              Object.entries(merged.retainedFeedItemBodyIds).filter(
+                ([id]) => !orphanedSet.has(id),
+              ),
+            );
           }
         }
 
@@ -482,6 +547,38 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
 );
 
 export const feedItemsStore = createSelectorHooks(vanillaApplicationStore);
+
+export function retainLoadedFeedItemBody(itemId: string) {
+  const state = feedItemsStore.getState();
+  const item = state.feedItemsDict[itemId];
+  if (!item || !isEligibleFeedBody(item)) return false;
+  feedItemsStore.setState({
+    retainedFeedItemBodyIds: {
+      ...state.retainedFeedItemBodyIds,
+      [itemId]: true,
+    },
+  });
+  return true;
+}
+
+export async function retainFeedItemBody(itemId: string) {
+  const state = feedItemsStore.getState();
+  const item = state.feedItemsDict[itemId];
+  if (
+    !item ||
+    item.contentType !== "text" ||
+    item.isWatched ||
+    hasRetainedFeedBody(item, state.retainedFeedItemBodyIds[itemId] === true) ||
+    (typeof navigator !== "undefined" && navigator.onLine === false)
+  ) {
+    return;
+  }
+  if (retainLoadedFeedItemBody(itemId)) return;
+  const items = await orpcRouterClient.initial.requestFullTextForItems({
+    itemIds: [itemId],
+  });
+  feedItemsStore.getState().applyFulltextItems(items);
+}
 
 export const useFeedItemsListProjection = () => {
   const revision = useStore(
@@ -512,6 +609,12 @@ export const useFeedItemValue = (id: string) => {
   return useStore(
     feedItemsStore,
     useShallow((store) => store.feedItemsDict[id]),
+  );
+};
+export const useHasRetainedFeedItemBody = (id: string) => {
+  return useStore(
+    feedItemsStore,
+    (store) => store.retainedFeedItemBodyIds[id] === true,
   );
 };
 export const useSetFeedItemValue = (id: string) => {

--- a/apps/app/src/lib/data/store.ts
+++ b/apps/app/src/lib/data/store.ts
@@ -90,6 +90,7 @@ export type ApplicationStore = {
   setFeedItems: (
     items: ApplicationFeedItem[],
     retention?: RetainFeedItemPageInput,
+    retainedBodyItemIds?: ReadonlySet<string>,
   ) => void;
   fetchFeedItemsForFeed: (feedId: number) => Promise<void>;
   fetchNewData: () => Promise<void>;
@@ -190,7 +191,7 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
           retainedFeedItemBodyIds,
         });
       },
-      setFeedItems: (items, retention) => {
+      setFeedItems: (items, retention, retainedBodyItemIds) => {
         if (items.length === 0) return;
 
         const state = get();
@@ -217,7 +218,12 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
           // entries keeps batch cost proportional to the incoming page or
           // optimistic selection instead of cloning the whole library.
           feedItemsDict[item.id] = retainedItem;
-          if (!isEligibleFeedBody(retainedItem)) {
+          if (
+            retainedBodyItemIds?.has(item.id) &&
+            isEligibleFeedBody(retainedItem)
+          ) {
+            retainedFeedItemBodyIds[item.id] = true;
+          } else if (!isEligibleFeedBody(retainedItem)) {
             delete retainedFeedItemBodyIds[item.id];
           }
         }

--- a/apps/app/src/lib/data/store.ts
+++ b/apps/app/src/lib/data/store.ts
@@ -268,17 +268,14 @@ const vanillaApplicationStore = createStore<ApplicationStore>()(
 
         for (const item of items) {
           const existing = feedItemsDict[item.id];
-          if (
-            existing &&
-            existing.contentType === "text" &&
-            !existing.isWatched
-          ) {
-            feedItemsDict[item.id] = {
+          if (existing) {
+            const updated = {
               ...existing,
               content: item.content,
               contentSnippet: item.contentSnippet,
             };
-            if (item.content.trim()) {
+            feedItemsDict[item.id] = updated;
+            if (isEligibleFeedBody(updated)) {
               retainedFeedItemBodyIds[item.id] = true;
             }
           }
@@ -565,6 +562,21 @@ export function retainLoadedFeedItemBody(itemId: string) {
     },
   });
   return true;
+}
+
+export function retainLoadedFeedItemBodies(itemIds: readonly string[]) {
+  const state = feedItemsStore.getState();
+  const eligibleIds = itemIds.filter((itemId) => {
+    const item = state.feedItemsDict[itemId];
+    return item !== undefined && isEligibleFeedBody(item);
+  });
+  if (eligibleIds.length === 0) return;
+  feedItemsStore.setState({
+    retainedFeedItemBodyIds: {
+      ...state.retainedFeedItemBodyIds,
+      ...Object.fromEntries(eligibleIds.map((itemId) => [itemId, true])),
+    },
+  });
 }
 
 export async function retainFeedItemBody(itemId: string) {

--- a/apps/app/src/lib/data/subscriptionConnection.ts
+++ b/apps/app/src/lib/data/subscriptionConnection.ts
@@ -1,9 +1,37 @@
+import { getDefaultStore } from "jotai";
+import { connectionStateAtom } from "./atoms";
+
 let connected = false;
 
 export function isDataSubscriptionConnected() {
   return connected;
 }
 
-export function setDataSubscriptionConnected(nextConnected: boolean) {
-  connected = nextConnected;
+export function initializeDataSubscriptionConnection(isOnline: boolean) {
+  if (!isOnline) {
+    connected = false;
+    getDefaultStore().set(connectionStateAtom, "disconnected");
+  }
+}
+
+export function markDataSubscriptionConnected() {
+  connected = true;
+  getDefaultStore().set(connectionStateAtom, "connected");
+}
+
+export function markDataSubscriptionFailed({
+  isOnline,
+  isVisible,
+}: {
+  isOnline: boolean;
+  isVisible: boolean;
+}) {
+  connected = false;
+  if (!isOnline || isVisible) {
+    getDefaultStore().set(connectionStateAtom, "disconnected");
+  }
+}
+
+export function markDataSubscriptionPaused() {
+  connected = false;
 }

--- a/apps/app/src/lib/data/subscriptionCoordinator.ts
+++ b/apps/app/src/lib/data/subscriptionCoordinator.ts
@@ -10,6 +10,7 @@ import { viewsStore } from "./views/store";
 import { isBookmarkProjectionChange } from "./mixed-content/bookmarkProjection";
 import { advanceMixedContentMembershipRevision } from "./mixed-content/membershipRevision";
 import { refreshNavigationSnapshotSafely } from "./navigation/store";
+import { hydrateOfflineBodiesForPage } from "./offline-hydration";
 import { hasFeedItemListProjectionChanged } from "./feed-items/listProjection";
 import type { LoadedMixedScope } from "./mixed-content/store";
 import type { PublishedChunk } from "~/server/api/publisher";
@@ -50,6 +51,7 @@ export function applyRequestedMixedContentPage(input: {
     replacesScope: input.replacesScope,
   });
   mixedContentStore.getState().applyPage(input);
+  void hydrateOfflineBodiesForPage(input.page);
 }
 
 export function applyPublishedChunks(

--- a/apps/app/src/lib/data/useDataSubscription.ts
+++ b/apps/app/src/lib/data/useDataSubscription.ts
@@ -130,6 +130,9 @@ export function useDataSubscription() {
             }
           }
           if (!connSignal.aborted && !signal.aborted) {
+            // Reconciliation must learn of the drop before the retry sleep,
+            // not after it when the finally runs.
+            dataReconciliation.sseConnectionChanged(false);
             markDataSubscriptionFailed({
               isOnline: navigator.onLine !== false,
               isVisible: document.visibilityState === "visible",

--- a/apps/app/src/lib/data/useDataSubscription.ts
+++ b/apps/app/src/lib/data/useDataSubscription.ts
@@ -90,9 +90,10 @@ export function useDataSubscription() {
         }
 
         const conn = new AbortController();
+        const connSignal = conn.signal;
         connectionController = conn;
         const { signal: connectionSignal, cleanup: cleanupConnectionSignal } =
-          combineAbortSignals([signal, conn.signal]);
+          combineAbortSignals([signal, connSignal]);
 
         try {
           retryDelayRef.current = INITIAL_RETRY_DELAY;
@@ -107,7 +108,7 @@ export function useDataSubscription() {
           dataReconciliation.sseConnectionChanged(true);
 
           for await (const payload of iterator as AsyncIterable<PublishedChunk>) {
-            if (conn.signal.aborted) break;
+            if (connSignal.aborted) break;
 
             // Buffer the chunk and schedule a flush via RAF
             chunkBufferRef.current.push(payload);
@@ -115,7 +116,7 @@ export function useDataSubscription() {
               rafIdRef.current = requestAnimationFrame(flushBuffer);
             }
           }
-          if (!conn.signal.aborted && !signal.aborted) {
+          if (!connSignal.aborted && !signal.aborted) {
             markDataSubscriptionFailed({
               isOnline: navigator.onLine !== false,
               isVisible: document.visibilityState === "visible",
@@ -128,7 +129,7 @@ export function useDataSubscription() {
           if (controller.signal.aborted) break;
 
           // Skip backoff for visibility-triggered reconnects
-          if (conn.signal.aborted) {
+          if (connSignal.aborted) {
             markDataSubscriptionPaused();
             continue;
           }

--- a/apps/app/src/lib/data/useDataSubscription.ts
+++ b/apps/app/src/lib/data/useDataSubscription.ts
@@ -15,10 +15,11 @@ import {
 import { dataReconciliation } from "./reconciliation";
 import type { PublishedChunk } from "~/server/api/publisher";
 
-// Exponential backoff configuration
+// Retry quickly at first so a brief disconnect recovers within a second,
+// then back off so an extended offline session doesn't hot-spin on mobile.
 const INITIAL_RETRY_DELAY = 1000; // 1 second
-const MAX_RETRY_DELAY = 30000; // 30 seconds
-const BACKOFF_MULTIPLIER = 2;
+const EXTENDED_RETRY_DELAY = 5000; // 5 seconds
+const EXTENDED_RETRY_AFTER_MS = 60_000; // 1 minute of continuous failure
 
 function waitForAbortableDelay(delay: number, signal: AbortSignal) {
   return new Promise<void>((resolve) => {
@@ -50,7 +51,7 @@ function waitForVisibilityChange(signal: AbortSignal) {
  */
 export function useDataSubscription() {
   const abortControllerRef = useRef<AbortController | null>(null);
-  const retryDelayRef = useRef(INITIAL_RETRY_DELAY);
+  const failingSinceRef = useRef<number | null>(null);
 
   // Buffer chunks and flush via requestAnimationFrame for micro-batching
   const chunkBufferRef = useRef<PublishedChunk[]>([]);
@@ -96,14 +97,13 @@ export function useDataSubscription() {
           combineAbortSignals([signal, connSignal]);
 
         try {
-          retryDelayRef.current = INITIAL_RETRY_DELAY;
-
           // Each reconnect depends on the prior connection closing.
           // oxlint-disable-next-line react-doctor/async-await-in-loop
           const iterator = await orpcRouterClient.initial.subscribe(
             {},
             { signal: connectionSignal },
           );
+          failingSinceRef.current = null;
           markDataSubscriptionConnected();
           dataReconciliation.sseConnectionChanged(true);
 
@@ -141,14 +141,12 @@ export function useDataSubscription() {
 
           console.error("Subscription error, retrying...", error);
 
-          // Wait with exponential backoff before retrying
-          await waitForAbortableDelay(retryDelayRef.current, controller.signal);
-
-          // Increase retry delay for next attempt
-          retryDelayRef.current = Math.min(
-            retryDelayRef.current * BACKOFF_MULTIPLIER,
-            MAX_RETRY_DELAY,
-          );
+          failingSinceRef.current ??= Date.now();
+          const retryDelay =
+            Date.now() - failingSinceRef.current >= EXTENDED_RETRY_AFTER_MS
+              ? EXTENDED_RETRY_DELAY
+              : INITIAL_RETRY_DELAY;
+          await waitForAbortableDelay(retryDelay, controller.signal);
         } finally {
           markDataSubscriptionPaused();
           dataReconciliation.sseConnectionChanged(false);

--- a/apps/app/src/lib/data/useDataSubscription.ts
+++ b/apps/app/src/lib/data/useDataSubscription.ts
@@ -6,7 +6,12 @@ import { orpcRouterClient } from "../orpc";
 import { combineAbortSignals } from "./combineAbortSignals";
 import { loadingActor } from "./loading-machine";
 import { shouldAlwaysKeepSSEConnectionAlive } from "./atoms";
-import { setDataSubscriptionConnected } from "./subscriptionConnection";
+import {
+  initializeDataSubscriptionConnection,
+  markDataSubscriptionConnected,
+  markDataSubscriptionFailed,
+  markDataSubscriptionPaused,
+} from "./subscriptionConnection";
 import { dataReconciliation } from "./reconciliation";
 import type { PublishedChunk } from "~/server/api/publisher";
 
@@ -66,6 +71,7 @@ export function useDataSubscription() {
     const controller = new AbortController();
     const { signal } = controller;
     abortControllerRef.current = controller;
+    initializeDataSubscriptionConnection(navigator.onLine !== false);
 
     // Per-connection controller — aborted on visibility change to force
     // a reconnect without tearing down the entire subscription lifecycle.
@@ -97,7 +103,7 @@ export function useDataSubscription() {
             {},
             { signal: connectionSignal },
           );
-          setDataSubscriptionConnected(true);
+          markDataSubscriptionConnected();
           dataReconciliation.sseConnectionChanged(true);
 
           for await (const payload of iterator as AsyncIterable<PublishedChunk>) {
@@ -109,15 +115,28 @@ export function useDataSubscription() {
               rafIdRef.current = requestAnimationFrame(flushBuffer);
             }
           }
+          if (!conn.signal.aborted && !signal.aborted) {
+            markDataSubscriptionFailed({
+              isOnline: navigator.onLine !== false,
+              isVisible: document.visibilityState === "visible",
+            });
+          }
         } catch (error) {
-          setDataSubscriptionConnected(false);
           dataReconciliation.sseConnectionChanged(false);
           dataReconciliation.subscriptionAttemptFailed();
 
           if (controller.signal.aborted) break;
 
           // Skip backoff for visibility-triggered reconnects
-          if (conn.signal.aborted) continue;
+          if (conn.signal.aborted) {
+            markDataSubscriptionPaused();
+            continue;
+          }
+
+          markDataSubscriptionFailed({
+            isOnline: navigator.onLine !== false,
+            isVisible: document.visibilityState === "visible",
+          });
 
           console.error("Subscription error, retrying...", error);
 
@@ -130,7 +149,7 @@ export function useDataSubscription() {
             MAX_RETRY_DELAY,
           );
         } finally {
-          setDataSubscriptionConnected(false);
+          markDataSubscriptionPaused();
           dataReconciliation.sseConnectionChanged(false);
           cleanupConnectionSignal();
         }
@@ -175,9 +194,16 @@ export function useDataSubscription() {
       dataReconciliation.environmentChanged();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
-    const handleNetworkChange = () => dataReconciliation.environmentChanged();
-    window.addEventListener("online", handleNetworkChange);
-    window.addEventListener("offline", handleNetworkChange);
+    const handleOnline = () => dataReconciliation.environmentChanged();
+    const handleOffline = () => {
+      markDataSubscriptionFailed({
+        isOnline: false,
+        isVisible: document.visibilityState === "visible",
+      });
+      dataReconciliation.environmentChanged();
+    };
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
 
     // Recompute connection logic when the keep-alive atom changes
     const unsubscribeAtom = getDefaultStore().sub(
@@ -191,11 +217,11 @@ export function useDataSubscription() {
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
-      window.removeEventListener("online", handleNetworkChange);
-      window.removeEventListener("offline", handleNetworkChange);
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
       unsubscribeAtom();
       controller.abort();
-      setDataSubscriptionConnected(false);
+      markDataSubscriptionPaused();
       dataReconciliation.sseConnectionChanged(false);
       // Cancel any pending RAF flush
       if (rafIdRef.current !== null) {

--- a/apps/app/src/lib/data/useDataSubscription.ts
+++ b/apps/app/src/lib/data/useDataSubscription.ts
@@ -79,6 +79,15 @@ export function useDataSubscription() {
     let connectionController: AbortController | null = null;
     let paused = false;
 
+    async function delayBeforeRetry() {
+      failingSinceRef.current ??= Date.now();
+      const retryDelay =
+        Date.now() - failingSinceRef.current >= EXTENDED_RETRY_AFTER_MS
+          ? EXTENDED_RETRY_DELAY
+          : INITIAL_RETRY_DELAY;
+      await waitForAbortableDelay(retryDelay, controller.signal);
+    }
+
     async function runSubscriptionLoop() {
       while (!signal.aborted) {
         // Wait while the page is hidden — no point holding an SSE
@@ -103,12 +112,16 @@ export function useDataSubscription() {
             {},
             { signal: connectionSignal },
           );
-          failingSinceRef.current = null;
           markDataSubscriptionConnected();
           dataReconciliation.sseConnectionChanged(true);
 
           for await (const payload of iterator as AsyncIterable<PublishedChunk>) {
             if (connSignal.aborted) break;
+
+            // Only a connection that actually delivers data clears the
+            // failure clock; an accepted-then-dropped stream keeps it, so
+            // flapping still escalates to the extended delay.
+            failingSinceRef.current = null;
 
             // Buffer the chunk and schedule a flush via RAF
             chunkBufferRef.current.push(payload);
@@ -121,6 +134,9 @@ export function useDataSubscription() {
               isOnline: navigator.onLine !== false,
               isVisible: document.visibilityState === "visible",
             });
+            // A cleanly ended stream reconnects on the same pacing as an
+            // errored one instead of re-dialing in a tight loop.
+            await delayBeforeRetry();
           }
         } catch (error) {
           dataReconciliation.sseConnectionChanged(false);
@@ -141,12 +157,7 @@ export function useDataSubscription() {
 
           console.error("Subscription error, retrying...", error);
 
-          failingSinceRef.current ??= Date.now();
-          const retryDelay =
-            Date.now() - failingSinceRef.current >= EXTENDED_RETRY_AFTER_MS
-              ? EXTENDED_RETRY_DELAY
-              : INITIAL_RETRY_DELAY;
-          await waitForAbortableDelay(retryDelay, controller.signal);
+          await delayBeforeRetry();
         } finally {
           markDataSubscriptionPaused();
           dataReconciliation.sseConnectionChanged(false);

--- a/apps/app/src/lib/hooks/useContentItemActions.ts
+++ b/apps/app/src/lib/hooks/useContentItemActions.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback } from "react";
+import { useAtomValue } from "jotai";
 import { useRouter } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { useFeedItemActions } from "./useFeedItemActions";
@@ -8,10 +9,16 @@ import { useBookmarkValue } from "~/lib/data/bookmarks";
 import { useUpdateBookmarkStateMutation } from "~/lib/data/bookmarks/mutations";
 import { captureRootScrollRestoration } from "~/lib/root-scroll-restoration";
 import { contentDestination } from "~/lib/data/content-items/resolver";
+import { useBookmarkCaptureValue } from "~/lib/data/bookmarks/capture-store";
+import { connectionStateAtom } from "~/lib/data/atoms";
+import { canOpenContent } from "~/lib/data/offline-content";
+import { canMutateNow } from "~/lib/data/offline-mutations";
 
 export function useContentItemActions(itemId: string) {
   const router = useRouter();
   const bookmark = useBookmarkValue(itemId);
+  const capture = useBookmarkCaptureValue(itemId);
+  const connectionState = useAtomValue(connectionStateAtom);
   const feedItemActions = useFeedItemActions(itemId);
   const { mutate: updateBookmarkState } =
     useUpdateBookmarkStateMutation(itemId);
@@ -19,11 +26,13 @@ export function useContentItemActions(itemId: string) {
   const markAsRead = useCallback(() => {
     if (!bookmark) return feedItemActions.markAsRead();
     if (bookmark.isRead) return;
+    if (!canMutateNow()) return;
     updateBookmarkState({ bookmarkId: bookmark.id, isRead: true });
   }, [bookmark, feedItemActions, updateBookmarkState]);
 
   const toggleRead = useCallback(() => {
     if (!bookmark) return feedItemActions.toggleRead();
+    if (!canMutateNow()) return false;
     updateBookmarkState({
       bookmarkId: bookmark.id,
       isRead: !bookmark.isRead,
@@ -33,25 +42,41 @@ export function useContentItemActions(itemId: string) {
 
   const toggleWatchLater = useCallback(() => {
     if (!bookmark) return feedItemActions.toggleWatchLater();
+    if (!canMutateNow()) return false;
     updateBookmarkState({
       bookmarkId: bookmark.id,
       isSaved: !bookmark.isSaved,
     });
+    return true;
   }, [bookmark, feedItemActions, updateBookmarkState]);
 
   const openItem = useCallback(() => {
     if (!bookmark) return feedItemActions.openItem();
+    if (
+      !canOpenContent({
+        connectionState,
+        contentType: bookmark.contentType,
+        hasBody: capture !== undefined,
+      })
+    ) {
+      return;
+    }
     const destination = contentDestination({
       entityKind: "bookmark",
       entity: bookmark,
     });
-    if (!destination.external) {
+    if (connectionState === "disconnected" || !destination.external) {
       captureRootScrollRestoration(itemId);
-      void router.navigate({ to: destination.href });
+      void router.navigate({
+        to:
+          connectionState === "disconnected"
+            ? `/read/${bookmark.id}`
+            : destination.href,
+      });
       return;
     }
     window.open(destination.href, "_blank", "noopener,noreferrer");
-  }, [bookmark, feedItemActions, itemId, router]);
+  }, [bookmark, capture, connectionState, feedItemActions, itemId, router]);
 
   const openOriginal = useCallback(() => {
     if (!bookmark) return feedItemActions.openOriginal();

--- a/apps/app/src/lib/hooks/useDebouncedSaveBookmarkProgress.ts
+++ b/apps/app/src/lib/hooks/useDebouncedSaveBookmarkProgress.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { getShortcutKeys, SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
 import { useBookmarkValue } from "~/lib/data/bookmarks";
 import { useUpdateBookmarkStateMutation } from "~/lib/data/bookmarks/mutations";
+import { canMutateNow } from "~/lib/data/offline-mutations";
 
 const NAV_KEYS = new Set([
   ...getShortcutKeys(SHORTCUT_KEYS.ARROW_UP),
@@ -32,6 +33,7 @@ export function useDebouncedSaveBookmarkProgress({
 
   const save = useCallback(() => {
     if (!bookmarkRef.current) return;
+    if (!canMutateNow()) return;
     const { progress, duration } = getProgressRef.current();
     if (progress < 0 || duration <= 0) return;
     mutateRef.current({ bookmarkId, progress, duration });

--- a/apps/app/src/lib/hooks/useDebouncedSaveProgress.ts
+++ b/apps/app/src/lib/hooks/useDebouncedSaveProgress.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useSetProgressMutation } from "~/lib/data/feed-items/mutations";
 import { getShortcutKeys, SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
 import { useFeedItemValue } from "~/lib/data/store";
+import { canMutateNow } from "~/lib/data/offline-mutations";
 
 const NAV_KEYS = new Set([
   ...getShortcutKeys(SHORTCUT_KEYS.ARROW_UP),
@@ -36,6 +37,7 @@ export function useDebouncedSaveProgress({
   const save = useCallback(() => {
     const item = feedItemRef.current;
     if (!item) return;
+    if (!canMutateNow()) return;
     const { progress, duration } = getProgressRef.current();
     if (progress >= 0 && duration > 0) {
       mutateRef.current({

--- a/apps/app/src/lib/hooks/useFeedItemActions.ts
+++ b/apps/app/src/lib/hooks/useFeedItemActions.ts
@@ -110,7 +110,12 @@ export function useFeedItemActions(itemId: string) {
     const shouldOpenInSerial =
       feed?.openLocation === "serial" || !feed?.openLocation;
 
-    if (connectionState === "disconnected" || shouldOpenInSerial) {
+    // While disconnected, canOpen has restricted opening to retained text
+    // bodies, which only the reader can render.
+    if (connectionState === "disconnected") {
+      captureRootScrollRestoration(itemId);
+      void router.navigate({ to: `/read/${item.id}` });
+    } else if (shouldOpenInSerial) {
       captureRootScrollRestoration(itemId);
       void router.navigate({ to: `/${itemDestination}/${item.id}` });
     } else {

--- a/apps/app/src/lib/hooks/useFeedItemActions.ts
+++ b/apps/app/src/lib/hooks/useFeedItemActions.ts
@@ -1,10 +1,15 @@
 "use client";
 
 import { useCallback } from "react";
+import { useAtomValue } from "jotai";
 import { useRouter } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { orpcRouterClient } from "../orpc";
-import { useFeedItemValue } from "../data/store";
+import {
+  retainFeedItemBody,
+  useFeedItemValue,
+  useHasRetainedFeedItemBody,
+} from "../data/store";
 import {
   applyOptimisticWatchedValue,
   applyOptimisticWatchLaterValue,
@@ -15,15 +20,24 @@ import {
 } from "../data/feed-items/mutations";
 import { useFeeds as useFeedsArray } from "../data/feeds/store";
 import { captureRootScrollRestoration } from "~/lib/root-scroll-restoration";
+import { connectionStateAtom } from "~/lib/data/atoms";
+import {
+  canOpenContent,
+  hasRetainedFeedBody,
+} from "~/lib/data/offline-content";
+import { canMutateNow } from "~/lib/data/offline-mutations";
 
 export function useFeedItemActions(itemId: string) {
   const router = useRouter();
   const feeds = useFeedsArray();
   const item = useFeedItemValue(itemId);
+  const hasRetainedBody = useHasRetainedFeedItemBody(itemId);
+  const connectionState = useAtomValue(connectionStateAtom);
 
   const markAsRead = useCallback(() => {
     if (!item) return;
     if (item.isWatched) return;
+    if (!canMutateNow()) return;
 
     const context = applyOptimisticWatchedValue(itemId, true);
     void orpcRouterClient.feedItem
@@ -40,6 +54,7 @@ export function useFeedItemActions(itemId: string) {
 
   const toggleRead = useCallback(() => {
     if (!item) return false;
+    if (!canMutateNow()) return false;
 
     const newIsWatched = !item.isWatched;
     const context = applyOptimisticWatchedValue(itemId, newIsWatched);
@@ -58,7 +73,8 @@ export function useFeedItemActions(itemId: string) {
   }, [item, itemId]);
 
   const toggleWatchLater = useCallback(() => {
-    if (!item) return;
+    if (!item) return false;
+    if (!canMutateNow()) return false;
 
     const context = applyOptimisticWatchLaterValue(itemId, !item.isWatchLater);
     void orpcRouterClient.feedItem
@@ -69,25 +85,38 @@ export function useFeedItemActions(itemId: string) {
       })
       .then((serverValue) => {
         resolveOptimisticWatchLaterValue(context, serverValue);
+        if (serverValue.isWatchLater) {
+          void retainFeedItemBody(itemId);
+        }
       })
       .catch(() => rollbackOptimisticWatchLaterValue(context));
+    return true;
   }, [item, itemId]);
 
   const openItem = useCallback(() => {
     if (!item) return;
+    if (
+      !canOpenContent({
+        connectionState,
+        contentType: item.contentType,
+        hasBody: hasRetainedFeedBody(item, hasRetainedBody),
+      })
+    ) {
+      return;
+    }
 
     const feed = feeds.find((f) => f.id === item.feedId);
     const itemDestination = item.platform === "website" ? "read" : "watch";
     const shouldOpenInSerial =
       feed?.openLocation === "serial" || !feed?.openLocation;
 
-    if (shouldOpenInSerial) {
+    if (connectionState === "disconnected" || shouldOpenInSerial) {
       captureRootScrollRestoration(itemId);
-      router.navigate({ to: `/${itemDestination}/${item.id}` });
+      void router.navigate({ to: `/${itemDestination}/${item.id}` });
     } else {
       window.open(item.url, "_blank", "noopener noreferrer");
     }
-  }, [item, feeds, itemId, router]);
+  }, [item, feeds, itemId, router, connectionState, hasRetainedBody]);
 
   const openOriginal = useCallback(() => {
     if (!item?.url) return;

--- a/apps/app/src/lib/hooks/useFeedItemNavigation.ts
+++ b/apps/app/src/lib/hooks/useFeedItemNavigation.ts
@@ -32,6 +32,7 @@ import {
   useShowInstapaperAction,
 } from "~/lib/data/instapaper";
 import { getNextRootItemId } from "~/lib/root-scroll-restoration";
+import { canMutateNow } from "~/lib/data/offline-mutations";
 
 interface SectionInfo {
   size: number;
@@ -588,7 +589,7 @@ export function useFeedItemNavigation(
   useShortcut(getShortcutKey(SHORTCUT_KEYS.TOGGLE_SAVED), () => {
     if (pathname !== "/" || !selectedItemId) return;
 
-    selectedItemActions.toggleWatchLater();
+    if (!selectedItemActions.toggleWatchLater()) return;
     const idx = items.indexOf(selectedItemId);
     selectItemAfterCurrentItemLeavesView(idx);
   });
@@ -607,7 +608,14 @@ export function useFeedItemNavigation(
   });
 
   useShortcut(getShortcutKey(SHORTCUT_KEYS.SEND_TO_INSTAPAPER), () => {
-    if (pathname !== "/" || !selectedItemId || !showInstapaperAction) return;
+    if (
+      pathname !== "/" ||
+      !selectedItemId ||
+      !showInstapaperAction ||
+      !canMutateNow()
+    ) {
+      return;
+    }
 
     void saveToInstapaper({ feedItemId: selectedItemId });
     const idx = items.indexOf(selectedItemId);

--- a/apps/app/src/lib/hooks/useRefreshFeedItem.ts
+++ b/apps/app/src/lib/hooks/useRefreshFeedItem.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { mergeFeedItem } from "~/lib/data/feed-items/mergeFeedItem";
-import { feedItemsStore } from "~/lib/data/store";
+import { feedItemsStore, retainLoadedFeedItemBody } from "~/lib/data/store";
 import { orpcRouterClient } from "~/lib/orpc";
 
 export function useRefreshFeedItem(id: string | undefined) {
@@ -30,6 +30,7 @@ export function useRefreshFeedItem(id: string | undefined) {
         feedItemsStore
           .getState()
           .setFeedItem(id, mergeFeedItem(currentItem, item));
+        retainLoadedFeedItemBody(id);
       })
       .catch((error) => {
         console.error("Error refreshing feed item:", error);

--- a/apps/app/src/lib/hooks/useSaveBookmarkVideoProgress.ts
+++ b/apps/app/src/lib/hooks/useSaveBookmarkVideoProgress.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useBookmarkValue } from "~/lib/data/bookmarks";
 import { useUpdateBookmarkStateMutation } from "~/lib/data/bookmarks/mutations";
+import { canMutateNow } from "~/lib/data/offline-mutations";
 
 const SAVE_INTERVAL_MS = 30_000;
 
@@ -25,6 +26,7 @@ export function useSaveBookmarkVideoProgress(input: {
 
   const save = useCallback(() => {
     if (!bookmarkRef.current) return;
+    if (!canMutateNow()) return;
     const progress = getProgressRef.current();
     if (progress.progress < 0 || progress.duration <= 0) return;
     mutateRef.current({

--- a/apps/app/src/lib/hooks/useSaveProgress.ts
+++ b/apps/app/src/lib/hooks/useSaveProgress.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useSetProgressMutation } from "~/lib/data/feed-items/mutations";
+import { canMutateNow } from "~/lib/data/offline-mutations";
 import { useFeedItemValue } from "~/lib/data/store";
 
 const SAVE_INTERVAL_MS = 30_000;
@@ -30,6 +31,7 @@ export function useSaveProgress({
   const save = useCallback(() => {
     const item = feedItemRef.current;
     if (!item) return;
+    if (!canMutateNow()) return;
     const { progress, duration } = getProgressRef.current();
     if (progress >= 0 && duration > 0) {
       mutateRef.current({

--- a/apps/app/src/lib/pwa/navigation-cache.ts
+++ b/apps/app/src/lib/pwa/navigation-cache.ts
@@ -1,0 +1,13 @@
+export function normalizeNavigationResponse(response: Response) {
+  if (!response.redirected) return response;
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+export function getCacheableNavigationResponse(response: Response) {
+  if (!response.ok) return null;
+  return normalizeNavigationResponse(response);
+}

--- a/apps/app/src/lib/pwa/navigation-cache.ts
+++ b/apps/app/src/lib/pwa/navigation-cache.ts
@@ -7,7 +7,34 @@ export function normalizeNavigationResponse(response: Response) {
   });
 }
 
-export function getCacheableNavigationResponse(response: Response) {
-  if (!response.ok) return null;
+function responsePathname(response: Response) {
+  // Synthetic responses (tests, constructed fallbacks) have an empty URL and
+  // carry no redirect risk.
+  if (!response.url) return null;
+  return new URL(response.url).pathname;
+}
+
+/**
+ * A navigation response may only be cached under the path that produced it.
+ * An unauthenticated fetch of `/` resolves at `/auth/sign-in`; caching that
+ * HTML under the requested path would serve the sign-in shell as the offline
+ * fallback after the user signs back in.
+ */
+export function isCacheableNavigationResponse(
+  requestUrl: string,
+  response: Response,
+) {
+  if (!response.ok) return false;
+  const finalPathname = responsePathname(response);
+  return (
+    finalPathname === null || finalPathname === new URL(requestUrl).pathname
+  );
+}
+
+export function getCacheableNavigationResponse(
+  requestUrl: string,
+  response: Response,
+) {
+  if (!isCacheableNavigationResponse(requestUrl, response)) return null;
   return normalizeNavigationResponse(response);
 }

--- a/apps/app/src/routeTree.gen.ts
+++ b/apps/app/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './app/__root'
+import { Route as SwDotjsRouteImport } from './app/sw[.]js'
 import { Route as SitemapRouteImport } from './app/sitemap'
 import { Route as MaintenanceRouteImport } from './app/maintenance'
 import { Route as AuthRouteImport } from './app/auth'
@@ -42,6 +43,11 @@ import { Route as AppAdminInvitesRouteImport } from './app/_app.admin.invites'
 import { Route as AppAdminInfoRouteImport } from './app/_app.admin.info'
 import { Route as AppAdminUserIdRouteImport } from './app/_app.admin.user.$id'
 
+const SwDotjsRoute = SwDotjsRouteImport.update({
+  id: '/sw.js',
+  path: '/sw.js',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SitemapRoute = SitemapRouteImport.update({
   id: '/sitemap',
   path: '/sitemap',
@@ -208,6 +214,7 @@ export interface FileRoutesByFullPath {
   '/auth': typeof AuthRouteWithChildren
   '/maintenance': typeof MaintenanceRoute
   '/sitemap': typeof SitemapRoute
+  '/sw.js': typeof SwDotjsRoute
   '/debug': typeof AppDebugRoute
   '/feeds': typeof AppFeedsRoute
   '/import': typeof AppImportRoute
@@ -240,6 +247,7 @@ export interface FileRoutesByTo {
   '/auth': typeof AuthRouteWithChildren
   '/maintenance': typeof MaintenanceRoute
   '/sitemap': typeof SitemapRoute
+  '/sw.js': typeof SwDotjsRoute
   '/debug': typeof AppDebugRoute
   '/feeds': typeof AppFeedsRoute
   '/import': typeof AppImportRoute
@@ -275,6 +283,7 @@ export interface FileRoutesById {
   '/auth': typeof AuthRouteWithChildren
   '/maintenance': typeof MaintenanceRoute
   '/sitemap': typeof SitemapRoute
+  '/sw.js': typeof SwDotjsRoute
   '/_app/debug': typeof AppDebugRoute
   '/_app/feeds': typeof AppFeedsRoute
   '/_app/import': typeof AppImportRoute
@@ -311,6 +320,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/maintenance'
     | '/sitemap'
+    | '/sw.js'
     | '/debug'
     | '/feeds'
     | '/import'
@@ -343,6 +353,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/maintenance'
     | '/sitemap'
+    | '/sw.js'
     | '/debug'
     | '/feeds'
     | '/import'
@@ -377,6 +388,7 @@ export interface FileRouteTypes {
     | '/auth'
     | '/maintenance'
     | '/sitemap'
+    | '/sw.js'
     | '/_app/debug'
     | '/_app/feeds'
     | '/_app/import'
@@ -412,6 +424,7 @@ export interface RootRouteChildren {
   AuthRoute: typeof AuthRouteWithChildren
   MaintenanceRoute: typeof MaintenanceRoute
   SitemapRoute: typeof SitemapRoute
+  SwDotjsRoute: typeof SwDotjsRoute
   ApiHealthRoute: typeof ApiHealthRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiDemoProvisionRoute: typeof ApiDemoProvisionRoute
@@ -424,6 +437,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/sw.js': {
+      id: '/sw.js'
+      path: '/sw.js'
+      fullPath: '/sw.js'
+      preLoaderRoute: typeof SwDotjsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/sitemap': {
       id: '/sitemap'
       path: '/sitemap'
@@ -712,6 +732,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthRoute: AuthRouteWithChildren,
   MaintenanceRoute: MaintenanceRoute,
   SitemapRoute: SitemapRoute,
+  SwDotjsRoute: SwDotjsRoute,
   ApiHealthRoute: ApiHealthRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiDemoProvisionRoute: ApiDemoProvisionRoute,

--- a/apps/app/src/server/api/routers/bookmarkRouter.ts
+++ b/apps/app/src/server/api/routers/bookmarkRouter.ts
@@ -3,6 +3,7 @@ import { protectedProcedure } from "~/server/orpc/base";
 import {
   deleteBookmark,
   getBookmarkCapture,
+  getBookmarkCaptures,
   saveBookmarkFromApp,
   setBookmarkTag,
   setBookmarkView,
@@ -98,6 +99,20 @@ export const getCapture = protectedProcedure
       database: context.db,
       userId: context.user.id,
       ...input,
+    }),
+  );
+
+export const getCaptures = protectedProcedure
+  .input(
+    z.object({
+      bookmarkIds: z.array(bookmarkIdSchema).min(1).max(100),
+    }),
+  )
+  .handler(({ context, input }) =>
+    getBookmarkCaptures({
+      database: context.db,
+      userId: context.user.id,
+      bookmarkIds: input.bookmarkIds,
     }),
   );
 

--- a/apps/app/src/server/bookmarks/service.ts
+++ b/apps/app/src/server/bookmarks/service.ts
@@ -602,6 +602,25 @@ export async function getBookmarkCapture(input: {
   return { status: "capture" as const, capture: row.capture };
 }
 
+export async function getBookmarkCaptures(input: {
+  database: BookmarkDatabase;
+  userId: string;
+  bookmarkIds: string[];
+}) {
+  if (input.bookmarkIds.length === 0) return [];
+  const rows = await input.database
+    .select({ capture: pageCaptures })
+    .from(bookmarks)
+    .innerJoin(pageCaptures, eq(pageCaptures.bookmarkId, bookmarks.id))
+    .where(
+      and(
+        inArray(bookmarks.id, input.bookmarkIds),
+        eq(bookmarks.userId, input.userId),
+      ),
+    );
+  return rows.map(({ capture }) => capture);
+}
+
 export async function updateBookmarkState(input: {
   database: BookmarkDatabase;
   userId: string;

--- a/apps/app/src/sw.ts
+++ b/apps/app/src/sw.ts
@@ -18,6 +18,30 @@ import {
 
 declare let self: ServiceWorkerGlobalScope;
 
+const NAVIGATION_CACHE_NAME = "navigation-cache";
+
+function normalizeNavigationResponse(response: Response) {
+  if (!response.redirected) return response;
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+async function warmNavigationCache() {
+  const response = await fetch(
+    new Request("/", {
+      credentials: "include",
+      headers: { Accept: "text/html" },
+      redirect: "follow",
+    }),
+  );
+  if (!response.ok) return;
+  const cache = await caches.open(NAVIGATION_CACHE_NAME);
+  await cache.put("/", normalizeNavigationResponse(response));
+}
+
 // Take control of all open clients as soon as the SW activates, and warm
 // the navigation cache so offline works even before the user's first
 // SW-controlled navigation. Without clients.claim(), the first page load
@@ -33,12 +57,9 @@ self.addEventListener("activate", (event) => {
       // build output, so precacheAndRoute never caches any document. Warm
       // the navigation cache with the root page so there's always *something*
       // to serve when the user opens the app offline.
-      caches.open("navigation-cache").then((cache) =>
-        cache.add("/").catch(() => {
-          // Non-critical — the next real navigation will populate the cache
-          // via the NetworkFirst handler.
-        }),
-      ),
+      warmNavigationCache().catch(() => {
+        // Non-critical. The next real navigation will populate the cache.
+      }),
     ]),
   );
 });
@@ -52,8 +73,14 @@ precacheAndRoute(self.__WB_MANIFEST);
 
 // Navigation requests - NetworkFirst with 3s timeout for fresh content with offline fallback
 const navigationHandler = new NetworkFirst({
-  cacheName: "navigation-cache",
+  cacheName: NAVIGATION_CACHE_NAME,
   networkTimeoutSeconds: 3,
+  plugins: [
+    {
+      cacheWillUpdate: ({ response }) =>
+        Promise.resolve(normalizeNavigationResponse(response)),
+    },
+  ],
 });
 
 registerRoute(new NavigationRoute(navigationHandler));
@@ -67,7 +94,7 @@ registerRoute(new NavigationRoute(navigationHandler));
 setCatchHandler(async ({ request }) => {
   if (request.destination === "document") {
     // Layer 1: try the runtime navigation cache (SSR HTML with hydration data)
-    const cache = await caches.open("navigation-cache");
+    const cache = await caches.open(NAVIGATION_CACHE_NAME);
     // ignoreVary prevents mismatches between the warm-up request's headers
     // (Accept: */*) and the real navigation request's headers (Accept:
     // text/html,...) when the server sends a Vary header.
@@ -172,9 +199,9 @@ self.addEventListener("message", (event) => {
   // cached data after ~7 days of inactivity, so the activate-time warm-up
   // alone isn't enough — each online visit needs to reset that clock.
   if (event.data && event.data.type === "WARM_NAVIGATION_CACHE") {
-    void caches.open("navigation-cache").then((cache) =>
-      cache.add("/").catch(() => {
-        // Non-critical — the NetworkFirst handler will cache on next navigation.
+    event.waitUntil(
+      warmNavigationCache().catch(() => {
+        // Non-critical. The NetworkFirst handler will cache a later navigation.
       }),
     );
   }

--- a/apps/app/src/sw.ts
+++ b/apps/app/src/sw.ts
@@ -15,26 +15,23 @@ import {
   NetworkFirst,
   StaleWhileRevalidate,
 } from "workbox-strategies";
-import {
-  getCacheableNavigationResponse,
-  normalizeNavigationResponse,
-} from "~/lib/pwa/navigation-cache";
+import { getCacheableNavigationResponse } from "~/lib/pwa/navigation-cache";
 
 declare let self: ServiceWorkerGlobalScope;
 
 const NAVIGATION_CACHE_NAME = "navigation-cache";
 
 async function warmNavigationCache() {
-  const response = await fetch(
-    new Request("/", {
-      credentials: "include",
-      headers: { Accept: "text/html" },
-      redirect: "follow",
-    }),
-  );
-  if (!response.ok) return;
+  const request = new Request("/", {
+    credentials: "include",
+    headers: { Accept: "text/html" },
+    redirect: "follow",
+  });
+  const response = await fetch(request);
+  const cacheable = getCacheableNavigationResponse(request.url, response);
+  if (!cacheable) return;
   const cache = await caches.open(NAVIGATION_CACHE_NAME);
-  await cache.put("/", normalizeNavigationResponse(response));
+  await cache.put("/", cacheable);
 }
 
 // Take control of all open clients as soon as the SW activates, and warm
@@ -72,8 +69,8 @@ const navigationHandler = new NetworkFirst({
   networkTimeoutSeconds: 3,
   plugins: [
     {
-      cacheWillUpdate: ({ response }) =>
-        Promise.resolve(getCacheableNavigationResponse(response)),
+      cacheWillUpdate: ({ request, response }) =>
+        Promise.resolve(getCacheableNavigationResponse(request.url, response)),
     },
   ],
 });

--- a/apps/app/src/sw.ts
+++ b/apps/app/src/sw.ts
@@ -15,19 +15,14 @@ import {
   NetworkFirst,
   StaleWhileRevalidate,
 } from "workbox-strategies";
+import {
+  getCacheableNavigationResponse,
+  normalizeNavigationResponse,
+} from "~/lib/pwa/navigation-cache";
 
 declare let self: ServiceWorkerGlobalScope;
 
 const NAVIGATION_CACHE_NAME = "navigation-cache";
-
-function normalizeNavigationResponse(response: Response) {
-  if (!response.redirected) return response;
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  });
-}
 
 async function warmNavigationCache() {
   const response = await fetch(
@@ -78,7 +73,7 @@ const navigationHandler = new NetworkFirst({
   plugins: [
     {
       cacheWillUpdate: ({ response }) =>
-        Promise.resolve(normalizeNavigationResponse(response)),
+        Promise.resolve(getCacheableNavigationResponse(response)),
     },
   ],
 });

--- a/apps/app/tests/e2e/fixtures/seed-db.ts
+++ b/apps/app/tests/e2e/fixtures/seed-db.ts
@@ -203,6 +203,19 @@ export async function setFeedItemAsYouTubeVideo(
   client.close();
 }
 
+export async function setFeedItemAsVideo(
+  tursoPort: number,
+  id: string,
+  videoId: string,
+) {
+  const { db, client } = getDb(tursoPort);
+  await db
+    .update(schema.feedItems)
+    .set({ contentId: videoId, contentType: "video" })
+    .where(eq(schema.feedItems.id, id));
+  client.close();
+}
+
 export async function seedBookmarkProjectionData(
   tursoPort: number,
   email: string,

--- a/apps/app/tests/e2e/fixtures/seed-db.ts
+++ b/apps/app/tests/e2e/fixtures/seed-db.ts
@@ -175,6 +175,19 @@ export async function setFeedItemContent(
   client.close();
 }
 
+export async function setFeedItemWatchLater(
+  tursoPort: number,
+  id: string,
+  isWatchLater: boolean,
+) {
+  const { db, client } = getDb(tursoPort);
+  await db
+    .update(schema.feedItems)
+    .set({ isWatchLater, isWatchLaterUpdatedAt: new Date() })
+    .where(eq(schema.feedItems.id, id));
+  client.close();
+}
+
 export async function setFeedItemAsYouTubeVideo(
   tursoPort: number,
   id: string,

--- a/apps/app/tests/e2e/self-hosted/article-progress.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/article-progress.spec.ts
@@ -266,7 +266,7 @@ test.describe("article progress tracking", () => {
     await setFeedItemContent(
       SELF_HOSTED_TURSO_PORT,
       feedItemId,
-      `<a href="https://example.com/image-target"><img src="/icon-192x192.png" alt="Keyboard preview"></a>
+      `<a href="https://example.com/image-target"><img src="/icon-192.png" alt="Keyboard preview"></a>
        <a href="https://example.com/article">Ordinary reader link</a>`,
     );
 

--- a/apps/app/tests/e2e/self-hosted/bookmark-app-flow.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/bookmark-app-flow.spec.ts
@@ -67,18 +67,16 @@ test.describe("Bookmark Serial-app flow", () => {
     });
     await expect(externalLink).toHaveAttribute("target", "_blank");
     await expect(externalLink).toHaveAttribute("rel", "noopener noreferrer");
-    const remoteImage = page.getByAltText("Reader image");
-    await expect(remoteImage).toHaveAttribute("referrerpolicy", "no-referrer");
-    await expect(remoteImage).toHaveAttribute("loading", "lazy");
     const remoteImageTrigger = page.getByRole("button", {
       name: "Open image preview: Reader image",
     });
     await expect(
+      remoteImageTrigger.locator("[data-image-fallback]"),
+    ).toBeVisible();
+    await expect(remoteImageTrigger).toHaveAttribute("aria-disabled", "true");
+    await expect(
       page.locator('a[href="https://example.com/image-target"]'),
     ).toHaveCount(0);
-    await remoteImageTrigger.click();
-    await expect(page.getByRole("dialog")).toBeVisible();
-    await page.keyboard.press("Escape");
     await expect(page.getByRole("dialog")).toHaveCount(0);
     await expect(page.locator("[data-article-video-embed]")).toBeVisible();
     await expect(page.getByTitle("YouTube video player")).toHaveAttribute(

--- a/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
@@ -10,6 +10,7 @@ import {
   seedBookmarkProjectionData,
   seedMultipleArticleData,
   setFeedItemAsVideo,
+  setFeedItemWatchLater,
 } from "../fixtures/seed-db";
 import type { Page } from "@playwright/test";
 
@@ -279,6 +280,97 @@ test("reloads a retained Bookmark capture through the production service worker"
       page.getByText("Offline, some features may be disabled"),
     ).toBeVisible();
     await expect(page.getByRole("button", { name: "Archive" })).toBeDisabled();
+  } finally {
+    await context.setOffline(false);
+    await cleanupUser(SELF_HOSTED_TURSO_PORT, email);
+  }
+});
+
+test("opens pre-saved content offline after passive hydration alone", async ({
+  page,
+  context,
+}) => {
+  test.setTimeout(60_000);
+  const { feedItemId, email, password } = await seedArticleData(
+    SELF_HOSTED_TURSO_PORT,
+    SELF_HOSTED_APP_PORT,
+  );
+  // Saved before the session starts, so only page-scoped hydration after the
+  // view-matrix cells apply can retain the body and fetch the capture.
+  await setFeedItemWatchLater(SELF_HOSTED_TURSO_PORT, feedItemId, true);
+  const { bookmarkId } = await seedBookmarkProjectionData(
+    SELF_HOSTED_TURSO_PORT,
+    email,
+    feedItemId,
+  );
+
+  try {
+    await signIn({ page, email, password });
+    await prepareControlledShell(page);
+
+    // No interaction with either item: poll persistence until deferred
+    // hydration lands, flushing the throttled IDB writer each attempt.
+    await expect
+      .poll(
+        async () => {
+          await page.evaluate(() =>
+            window.dispatchEvent(new Event("pagehide")),
+          );
+          return getFeedBodyPersistence(page, feedItemId);
+        },
+        { timeout: 20_000 },
+      )
+      .toEqual({
+        hasBody: true,
+        isWatchLater: true,
+        isWatched: false,
+        retained: true,
+      });
+    await expect
+      .poll(
+        async () => {
+          await page.evaluate(() =>
+            window.dispatchEvent(new Event("pagehide")),
+          );
+          return hasBookmarkCapture(page, bookmarkId);
+        },
+        { timeout: 20_000 },
+      )
+      .toBe(true);
+
+    await context.setOffline(true);
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByText("Offline, some features may be disabled"),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole("tab", { name: "Saved" }).click();
+    const savedFeedCard = page.locator(`article[data-item-id="${feedItemId}"]`);
+    await expect(savedFeedCard.getByRole("link")).toHaveAttribute(
+      "aria-disabled",
+      "false",
+    );
+    await savedFeedCard.getByRole("link").click();
+    await expect(page).toHaveURL(new RegExp(`/read/${feedItemId}$`));
+    await expect(page.getByText("Paragraph 1:")).toBeVisible();
+
+    await page.goBack();
+    await expect(
+      page.getByText("Offline, some features may be disabled"),
+    ).toBeVisible({ timeout: 15_000 });
+    await page.getByRole("tab", { name: "Saved" }).click();
+    const savedBookmarkCard = page.locator(
+      `article[data-item-id="${bookmarkId}"][data-entity-kind="bookmark"]`,
+    );
+    await expect(savedBookmarkCard.getByRole("link")).toHaveAttribute(
+      "aria-disabled",
+      "false",
+    );
+    await savedBookmarkCard.getByRole("link").click();
+    await expect(page).toHaveURL(new RegExp(`/read/${bookmarkId}$`));
+    await expect(page.getByText("Captured Bookmark body")).toBeVisible({
+      timeout: 15_000,
+    });
   } finally {
     await context.setOffline(false);
     await cleanupUser(SELF_HOSTED_TURSO_PORT, email);

--- a/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
@@ -4,118 +4,275 @@ import {
   SELF_HOSTED_APP_PORT,
   SELF_HOSTED_TURSO_PORT,
 } from "../fixtures/ports";
-import { cleanupUser, seedArticleData } from "../fixtures/seed-db";
+import {
+  cleanupUser,
+  seedArticleData,
+  seedBookmarkProjectionData,
+  seedMultipleArticleData,
+  setFeedItemAsVideo,
+} from "../fixtures/seed-db";
+import type { Page } from "@playwright/test";
 
 test.skip(
   process.env.SERIAL_CLIENT_PERFORMANCE_PRODUCTION !== "1",
   "The offline PWA check requires the production service worker.",
 );
 
-test("reloads a controlled authenticated reader from retained content while offline", async ({
+async function prepareControlledShell(page: Page) {
+  await page.evaluate(() => navigator.serviceWorker.ready);
+  if (
+    !(await page.evaluate(() => Boolean(navigator.serviceWorker.controller)))
+  ) {
+    await page.reload();
+    await page.evaluate(() => navigator.serviceWorker.ready);
+  }
+  await expect
+    .poll(() =>
+      page.evaluate(() => Boolean(navigator.serviceWorker.controller)),
+    )
+    .toBe(true);
+
+  await page.evaluate(() => {
+    navigator.serviceWorker.controller?.postMessage({
+      type: "WARM_NAVIGATION_CACHE",
+    });
+  });
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        const cache = await caches.open("navigation-cache");
+        const response = await cache.match("/", { ignoreVary: true });
+        return response
+          ? { redirected: response.redirected, status: response.status }
+          : null;
+      }),
+    )
+    .toEqual({ redirected: false, status: 200 });
+}
+
+async function getFeedBodyPersistence(page: Page, itemId: string) {
+  return page.evaluate(async (id) => {
+    const itemKey =
+      `serial-application-store::normalized:v1::record:feedItemsDict:` +
+      encodeURIComponent(id);
+    const retainedBodyKey =
+      `serial-application-store::normalized:v1::record:retainedFeedItemBodyIds:` +
+      encodeURIComponent(id);
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open("keyval-store");
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve(request.result);
+    });
+    try {
+      return await new Promise<{
+        hasBody: boolean;
+        isWatchLater: boolean | undefined;
+        isWatched: boolean | undefined;
+        retained: boolean;
+      }>((resolve, reject) => {
+        const transaction = database.transaction("keyval", "readonly");
+        const store = transaction.objectStore("keyval");
+        const itemRequest = store.get(itemKey);
+        const retainedBodyRequest = store.get(retainedBodyKey);
+        transaction.onerror = () => reject(transaction.error);
+        transaction.oncomplete = () => {
+          const item = itemRequest.result as
+            | {
+                content?: string;
+                isWatchLater?: boolean;
+                isWatched?: boolean;
+              }
+            | undefined;
+          resolve({
+            hasBody: item?.content?.includes("Paragraph 1:") === true,
+            isWatchLater: item?.isWatchLater,
+            isWatched: item?.isWatched,
+            retained: retainedBodyRequest.result === true,
+          });
+        };
+      });
+    } finally {
+      database.close();
+    }
+  }, itemId);
+}
+
+async function hasBookmarkCapture(page: Page, bookmarkId: string) {
+  return page.evaluate(async (id) => {
+    const captureKey =
+      `serial-bookmark-captures-store::normalized:v1::record:capturesDict:` +
+      encodeURIComponent(id);
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open("keyval-store");
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => resolve(request.result);
+    });
+    try {
+      return await new Promise<boolean>((resolve, reject) => {
+        const transaction = database.transaction("keyval", "readonly");
+        const request = transaction.objectStore("keyval").get(captureKey);
+        transaction.onerror = () => reject(transaction.error);
+        transaction.oncomplete = () =>
+          resolve(
+            request.result?.contentHtml?.includes("Captured Bookmark body") ===
+              true,
+          );
+      });
+    } finally {
+      database.close();
+    }
+  }, bookmarkId);
+}
+
+test("keeps only retained text interactive and read-only after an offline reload", async ({
   page,
   context,
 }) => {
+  test.setTimeout(60_000);
+  const { feedItemIds, email, password } = await seedMultipleArticleData(
+    SELF_HOSTED_TURSO_PORT,
+    SELF_HOSTED_APP_PORT,
+    3,
+  );
+  const [retainedItemId, unavailableItemId, videoItemId] = feedItemIds;
+  if (!retainedItemId || !unavailableItemId || !videoItemId) {
+    throw new Error("Offline PWA fixture did not create three feed items");
+  }
+  await setFeedItemAsVideo(SELF_HOSTED_TURSO_PORT, videoItemId, "M7lc1UVf-VE");
+
+  try {
+    await signIn({ page, email, password });
+    const retainedCard = page.locator(
+      `article[data-item-id="${retainedItemId}"]`,
+    );
+    const unavailableCard = page.locator(
+      `article[data-item-id="${unavailableItemId}"]`,
+    );
+    const videoCard = page.locator(`article[data-item-id="${videoItemId}"]`);
+    await expect(retainedCard).toBeVisible({ timeout: 15_000 });
+    await expect(unavailableCard).toBeVisible();
+    await expect(videoCard).toBeVisible();
+
+    await prepareControlledShell(page);
+
+    // Save without opening the reader. The mutation must retain its body.
+    await retainedCard.getByRole("link").hover();
+    await page.keyboard.press("s");
+    await expect(retainedCard).toHaveCount(0);
+    await page.evaluate(() => window.dispatchEvent(new Event("pagehide")));
+    await expect
+      .poll(() => getFeedBodyPersistence(page, retainedItemId))
+      .toEqual({
+        hasBody: true,
+        isWatchLater: true,
+        isWatched: false,
+        retained: true,
+      });
+
+    await context.setOffline(true);
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByText("Offline, some features may be disabled"),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const offlineUnavailableCard = page.locator(
+      `article[data-item-id="${unavailableItemId}"]`,
+    );
+    const offlineVideoCard = page.locator(
+      `article[data-item-id="${videoItemId}"]`,
+    );
+    for (const candidateCard of [offlineUnavailableCard, offlineVideoCard]) {
+      await expect(candidateCard).toHaveClass(/opacity-50/);
+      await expect(candidateCard.getByRole("link")).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+    }
+
+    // The selected-card shortcut cannot create an optimistic offline write.
+    await offlineUnavailableCard.getByRole("link").hover();
+    await page.keyboard.press("s");
+    await expect
+      .poll(() => getFeedBodyPersistence(page, unavailableItemId))
+      .toMatchObject({ isWatchLater: false, retained: false });
+    const offlineUrl = page.url();
+    await offlineUnavailableCard.getByRole("link").click({ force: true });
+    await expect(page).toHaveURL(offlineUrl);
+
+    // Content-status filters stay local and enabled while disconnected.
+    await page.getByRole("tab", { name: "Saved" }).click();
+    const offlineRetainedCard = page.locator(
+      `article[data-item-id="${retainedItemId}"]`,
+    );
+    await expect(offlineRetainedCard.getByRole("link")).toHaveAttribute(
+      "aria-disabled",
+      "false",
+    );
+    await offlineRetainedCard.getByRole("link").click();
+    await expect(page).toHaveURL(new RegExp(`/read/${retainedItemId}$`));
+    await expect(page.getByText("Paragraph 1:")).toBeVisible();
+    const archiveButton = page.getByRole("button", { name: "Archive" });
+    await expect(archiveButton).toBeDisabled();
+    await page.keyboard.press("e");
+    await expect
+      .poll(() => getFeedBodyPersistence(page, retainedItemId))
+      .toMatchObject({ hasBody: true, isWatched: false, retained: true });
+
+    await context.setOffline(false);
+    await expect(
+      page.getByText("Offline, some features may be disabled"),
+    ).toBeHidden({ timeout: 15_000 });
+    await expect(archiveButton).toBeEnabled();
+    await archiveButton.click();
+    await expect(page.getByRole("button", { name: "Unarchive" })).toBeVisible();
+    await page.evaluate(() => window.dispatchEvent(new Event("pagehide")));
+    await expect
+      .poll(() => getFeedBodyPersistence(page, retainedItemId))
+      .toMatchObject({ hasBody: false, isWatched: true, retained: false });
+  } finally {
+    await context.setOffline(false);
+    await cleanupUser(SELF_HOSTED_TURSO_PORT, email);
+  }
+});
+
+test("reloads a retained Bookmark capture through the production service worker", async ({
+  page,
+  context,
+}) => {
+  test.setTimeout(60_000);
   const { feedItemId, email, password } = await seedArticleData(
     SELF_HOSTED_TURSO_PORT,
     SELF_HOSTED_APP_PORT,
   );
+  const { bookmarkId } = await seedBookmarkProjectionData(
+    SELF_HOSTED_TURSO_PORT,
+    email,
+    feedItemId,
+  );
 
   try {
     await signIn({ page, email, password });
-    const articleCard = page.locator("article").filter({
-      hasText: "Test Article",
-    });
-    await expect(articleCard).toBeVisible({ timeout: 15_000 });
-
-    await page.evaluate(() => navigator.serviceWorker.ready);
-    if (
-      !(await page.evaluate(() => Boolean(navigator.serviceWorker.controller)))
-    ) {
-      await page.reload();
-      await page.evaluate(() => navigator.serviceWorker.ready);
-    }
-    await expect
-      .poll(() =>
-        page.evaluate(() => Boolean(navigator.serviceWorker.controller)),
-      )
-      .toBe(true);
-
-    await page.evaluate(() => {
-      navigator.serviceWorker.controller?.postMessage({
-        type: "WARM_NAVIGATION_CACHE",
-      });
-    });
-    await expect
-      .poll(() =>
-        page.evaluate(async () => {
-          const cache = await caches.open("navigation-cache");
-          const response = await cache.match("/", { ignoreVary: true });
-          return response
-            ? { redirected: response.redirected, status: response.status }
-            : null;
-        }),
-      )
-      .toEqual({ redirected: false, status: 200 });
-
-    await articleCard.getByRole("link").first().click();
-    await expect(page).toHaveURL(new RegExp(`/read/${feedItemId}$`));
-    await expect(page.getByText("Paragraph 1:")).toBeVisible();
-
-    const itemStorageKey =
-      `serial-application-store::normalized:v1::record:feedItemsDict:` +
-      encodeURIComponent(feedItemId);
-    const retainedBodyStorageKey =
-      `serial-application-store::normalized:v1::record:retainedFeedItemBodyIds:` +
-      encodeURIComponent(feedItemId);
-    await expect
-      .poll(() =>
-        page.evaluate(
-          async ({ itemKey, retainedBodyKey }) => {
-            const database = await new Promise<IDBDatabase>(
-              (resolve, reject) => {
-                const request = indexedDB.open("keyval-store");
-                request.onerror = () => reject(request.error);
-                request.onsuccess = () => resolve(request.result);
-              },
-            );
-            try {
-              return await new Promise<boolean>((resolve, reject) => {
-                const transaction = database.transaction("keyval", "readonly");
-                const store = transaction.objectStore("keyval");
-                const itemRequest = store.get(itemKey);
-                const retainedBodyRequest = store.get(retainedBodyKey);
-                transaction.onerror = () => reject(transaction.error);
-                transaction.oncomplete = () =>
-                  resolve(
-                    itemRequest.result?.content?.includes("Paragraph 1:") ===
-                      true && retainedBodyRequest.result === true,
-                  );
-              });
-            } finally {
-              database.close();
-            }
-          },
-          { itemKey: itemStorageKey, retainedBodyKey: retainedBodyStorageKey },
-        ),
-      )
-      .toBe(true);
+    await page.getByRole("tab", { name: /Saved/ }).click();
+    const bookmarkCard = page.locator(
+      `article[data-item-id="${bookmarkId}"][data-entity-kind="bookmark"]`,
+    );
+    await expect(bookmarkCard).toBeVisible({ timeout: 15_000 });
+    await bookmarkCard.getByRole("link").click();
+    await expect(page.getByText("Captured Bookmark body")).toBeVisible();
+    await expect.poll(() => hasBookmarkCapture(page, bookmarkId)).toBe(true);
+    await prepareControlledShell(page);
 
     await context.setOffline(true);
     await page.reload({ waitUntil: "domcontentloaded" });
 
-    await expect(page).toHaveURL(new RegExp(`/read/${feedItemId}$`));
-    await expect(page.getByText("Paragraph 1:")).toBeVisible({
+    await expect(page).toHaveURL(new RegExp(`/read/${bookmarkId}$`));
+    await expect(page.getByText("Captured Bookmark body")).toBeVisible({
       timeout: 15_000,
     });
     await expect(
       page.getByText("Offline, some features may be disabled"),
     ).toBeVisible();
     await expect(page.getByRole("button", { name: "Archive" })).toBeDisabled();
-
-    await context.setOffline(false);
-    await expect(
-      page.getByText("Offline, some features may be disabled"),
-    ).toBeHidden({ timeout: 15_000 });
   } finally {
     await context.setOffline(false);
     await cleanupUser(SELF_HOSTED_TURSO_PORT, email);

--- a/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
@@ -19,6 +19,12 @@ test.skip(
 );
 
 async function prepareControlledShell(page: Page) {
+  const serviceWorkerResponse = await page.request.get("/sw.js");
+  expect(serviceWorkerResponse.status()).toBe(200);
+  expect(serviceWorkerResponse.headers()["content-type"]).toContain(
+    "javascript",
+  );
+
   await page.evaluate(() => navigator.serviceWorker.ready);
   if (
     !(await page.evaluate(() => Boolean(navigator.serviceWorker.controller)))

--- a/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "@playwright/test";
+import { signIn } from "../fixtures/auth";
+import {
+  SELF_HOSTED_APP_PORT,
+  SELF_HOSTED_TURSO_PORT,
+} from "../fixtures/ports";
+import { cleanupUser, seedArticleData } from "../fixtures/seed-db";
+
+test.skip(
+  process.env.SERIAL_CLIENT_PERFORMANCE_PRODUCTION !== "1",
+  "The offline PWA check requires the production service worker.",
+);
+
+test("reloads a controlled authenticated reader from retained content while offline", async ({
+  page,
+  context,
+}) => {
+  const { feedItemId, email, password } = await seedArticleData(
+    SELF_HOSTED_TURSO_PORT,
+    SELF_HOSTED_APP_PORT,
+  );
+
+  try {
+    await signIn({ page, email, password });
+    const articleCard = page.locator("article").filter({
+      hasText: "Test Article",
+    });
+    await expect(articleCard).toBeVisible({ timeout: 15_000 });
+
+    await page.evaluate(() => navigator.serviceWorker.ready);
+    if (
+      !(await page.evaluate(() => Boolean(navigator.serviceWorker.controller)))
+    ) {
+      await page.reload();
+      await page.evaluate(() => navigator.serviceWorker.ready);
+    }
+    await expect
+      .poll(() =>
+        page.evaluate(() => Boolean(navigator.serviceWorker.controller)),
+      )
+      .toBe(true);
+
+    await page.evaluate(() => {
+      navigator.serviceWorker.controller?.postMessage({
+        type: "WARM_NAVIGATION_CACHE",
+      });
+    });
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          const cache = await caches.open("navigation-cache");
+          const response = await cache.match("/", { ignoreVary: true });
+          return response
+            ? { redirected: response.redirected, status: response.status }
+            : null;
+        }),
+      )
+      .toEqual({ redirected: false, status: 200 });
+
+    await articleCard.getByRole("link").first().click();
+    await expect(page).toHaveURL(new RegExp(`/read/${feedItemId}$`));
+    await expect(page.getByText("Paragraph 1:")).toBeVisible();
+
+    const itemStorageKey =
+      `serial-application-store::normalized:v1::record:feedItemsDict:` +
+      encodeURIComponent(feedItemId);
+    const retainedBodyStorageKey =
+      `serial-application-store::normalized:v1::record:retainedFeedItemBodyIds:` +
+      encodeURIComponent(feedItemId);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          async ({ itemKey, retainedBodyKey }) => {
+            const database = await new Promise<IDBDatabase>(
+              (resolve, reject) => {
+                const request = indexedDB.open("keyval-store");
+                request.onerror = () => reject(request.error);
+                request.onsuccess = () => resolve(request.result);
+              },
+            );
+            try {
+              return await new Promise<boolean>((resolve, reject) => {
+                const transaction = database.transaction("keyval", "readonly");
+                const store = transaction.objectStore("keyval");
+                const itemRequest = store.get(itemKey);
+                const retainedBodyRequest = store.get(retainedBodyKey);
+                transaction.onerror = () => reject(transaction.error);
+                transaction.oncomplete = () =>
+                  resolve(
+                    itemRequest.result?.content?.includes("Paragraph 1:") ===
+                      true && retainedBodyRequest.result === true,
+                  );
+              });
+            } finally {
+              database.close();
+            }
+          },
+          { itemKey: itemStorageKey, retainedBodyKey: retainedBodyStorageKey },
+        ),
+      )
+      .toBe(true);
+
+    await context.setOffline(true);
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    await expect(page).toHaveURL(new RegExp(`/read/${feedItemId}$`));
+    await expect(page.getByText("Paragraph 1:")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByText("Offline, some features may be disabled"),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Archive" })).toBeDisabled();
+
+    await context.setOffline(false);
+    await expect(
+      page.getByText("Offline, some features may be disabled"),
+    ).toBeHidden({ timeout: 15_000 });
+  } finally {
+    await context.setOffline(false);
+    await cleanupUser(SELF_HOSTED_TURSO_PORT, email);
+  }
+});

--- a/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/offline-pwa.spec.ts
@@ -166,9 +166,11 @@ test("keeps only retained text interactive and read-only after an offline reload
     await retainedCard.getByRole("link").hover();
     await page.keyboard.press("s");
     await expect(retainedCard).toHaveCount(0);
-    await page.evaluate(() => window.dispatchEvent(new Event("pagehide")));
     await expect
-      .poll(() => getFeedBodyPersistence(page, retainedItemId))
+      .poll(async () => {
+        await page.evaluate(() => window.dispatchEvent(new Event("pagehide")));
+        return getFeedBodyPersistence(page, retainedItemId);
+      })
       .toEqual({
         hasBody: true,
         isWatchLater: true,
@@ -345,6 +347,7 @@ test("opens pre-saved content offline after passive hydration alone", async ({
     ).toBeVisible({ timeout: 15_000 });
 
     await page.getByRole("tab", { name: "Saved" }).click();
+    const listUrl = page.url();
     const savedFeedCard = page.locator(`article[data-item-id="${feedItemId}"]`);
     await expect(savedFeedCard.getByRole("link")).toHaveAttribute(
       "aria-disabled",
@@ -355,6 +358,8 @@ test("opens pre-saved content offline after passive hydration alone", async ({
     await expect(page.getByText("Paragraph 1:")).toBeVisible();
 
     await page.goBack();
+    // The popstate must settle before the tab click, or the click races it.
+    await expect(page).toHaveURL(listUrl);
     await expect(
       page.getByText("Offline, some features may be disabled"),
     ).toBeVisible({ timeout: 15_000 });

--- a/apps/app/tests/unit/bookmarks/membership-revision.test.ts
+++ b/apps/app/tests/unit/bookmarks/membership-revision.test.ts
@@ -23,6 +23,11 @@ vi.mock("@tanstack/react-query", () => ({
 vi.mock("~/lib/orpc", () => {
   const mutationOptions = (options: unknown) => options;
   return {
+    orpcRouterClient: {
+      bookmark: {
+        getCapture: vi.fn().mockResolvedValue(null),
+      },
+    },
     orpc: {
       bookmark: {
         remove: { mutationOptions },

--- a/apps/app/tests/unit/bookmarks/membership-revision.test.ts
+++ b/apps/app/tests/unit/bookmarks/membership-revision.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import type { DatabasePageCapture } from "~/server/db/schema";
+import { bookmarkCapturesStore } from "~/lib/data/bookmarks/capture-store";
 import { bookmarksStore } from "~/lib/data/bookmarks/store";
 import { mixedContentStore } from "~/lib/data/mixed-content/store";
 import { getMixedContentMembershipRevision } from "~/lib/data/mixed-content/membershipRevision";
@@ -41,6 +43,16 @@ vi.mock("~/lib/orpc", () => {
 });
 
 const NOW = new Date("2026-08-19T12:00:00.000Z");
+
+const CAPTURE: DatabasePageCapture = {
+  bookmarkId: "bookmark-one",
+  contentHtml: "<p>Retained capture</p>",
+  contentHash: "capture-hash",
+  captureSource: "server-static-fetch",
+  extractorVersion: "test",
+  sanitizerPolicyVersion: 1,
+  capturedAt: NOW,
+};
 
 function bookmark(
   overrides: Partial<ApplicationBookmark> = {},
@@ -207,6 +219,41 @@ describe("Bookmark mixed-content membership revision", () => {
     );
 
     expect(revision()).toBe(initialRevision);
+  });
+
+  it("restores a retained capture after a failed Archive", () => {
+    const original = bookmark();
+    bookmarksStore.getState().upsert(original);
+    bookmarkCapturesStore.getState().upsert(CAPTURE);
+    setRetainedEntityPins("membership-revision:test", {
+      bookmarkIds: [original.id],
+    });
+    const mutation = useUpdateBookmarkStateMutation(
+      original.id,
+    ) as unknown as MutationCallbacks<
+      { bookmarkId: string; isRead: boolean },
+      ApplicationBookmark,
+      {
+        previousBookmark?: ApplicationBookmark;
+        previousCapture?: DatabasePageCapture;
+        token?: object;
+      }
+    >;
+    const input = { bookmarkId: original.id, isRead: true };
+
+    const context = mutation.onMutate(input);
+    expect(
+      bookmarkCapturesStore.getState().capturesDict[original.id],
+    ).toBeUndefined();
+
+    mutation.onError(new Error("failed"), input, context);
+
+    expect(bookmarksStore.getState().getBookmark(original.id)?.isRead).toBe(
+      false,
+    );
+    expect(bookmarkCapturesStore.getState().capturesDict[original.id]).toEqual(
+      CAPTURE,
+    );
   });
 
   it("drops a delayed progress response after the final body owner is released", () => {

--- a/apps/app/tests/unit/bookmarks/mixed-content-projection-events.test.ts
+++ b/apps/app/tests/unit/bookmarks/mixed-content-projection-events.test.ts
@@ -32,13 +32,19 @@ const orpcMocks = vi.hoisted(() => ({
   setBookmarkBulkReadValue: vi.fn(),
   setFeedBulkWatchedValue: vi.fn(),
   requestPage: vi.fn(),
+  getCaptures: vi.fn().mockResolvedValue([]),
+  requestFullTextForItems: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("~/lib/orpc", () => ({
   orpc: {},
   orpcRouterClient: {
-    bookmark: { setBulkReadValue: orpcMocks.setBookmarkBulkReadValue },
+    bookmark: {
+      setBulkReadValue: orpcMocks.setBookmarkBulkReadValue,
+      getCaptures: orpcMocks.getCaptures,
+    },
     feedItem: { setBulkWatchedValue: orpcMocks.setFeedBulkWatchedValue },
+    initial: { requestFullTextForItems: orpcMocks.requestFullTextForItems },
     mixedContent: { requestPage: orpcMocks.requestPage },
   },
 }));

--- a/apps/app/tests/unit/bookmarks/persistence.test.ts
+++ b/apps/app/tests/unit/bookmarks/persistence.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   deleteBookmark,
   getBookmarkCapture,
+  getBookmarkCaptures,
   persistBookmarkSave,
   saveBookmarkFromExtension,
   setBookmarkTag,
@@ -356,6 +357,35 @@ describe("Bookmark persistence", () => {
         bookmarkId: created.bookmark.id,
       }),
     ).toBeNull();
+  });
+
+  it("loads captures in one user-scoped batch", async () => {
+    const first = await saveCaptured(
+      "user-one",
+      "https://example.com/batch-one",
+    );
+    const second = await saveCaptured(
+      "user-one",
+      "https://example.com/batch-two",
+    );
+    const otherUser = await saveCaptured(
+      "user-two",
+      "https://example.com/batch-other-user",
+    );
+
+    const captures = await getBookmarkCaptures({
+      database,
+      userId: "user-one",
+      bookmarkIds: [
+        first.bookmark.id,
+        second.bookmark.id,
+        otherUser.bookmark.id,
+      ],
+    });
+
+    expect(captures.map(({ bookmarkId }) => bookmarkId).sort()).toEqual(
+      [first.bookmark.id, second.bookmark.id].sort(),
+    );
   });
 
   it("matches validated provider identity before canonical URL", async () => {

--- a/apps/app/tests/unit/components/offline-ui.test.ts
+++ b/apps/app/tests/unit/components/offline-ui.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://serial.test/" }
+
+import { getDefaultStore } from "jotai";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OfflineBanner } from "~/components/OfflineBanner";
+import { ArticleImageLightbox } from "~/components/feed/read/ArticleImageLightbox";
+import { connectionStateAtom } from "~/lib/data/atoms";
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const roots: Array<ReturnType<typeof createRoot>> = [];
+
+function render(element: ReturnType<typeof createElement>) {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  roots.push(root);
+  act(() => root.render(element));
+  return container;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount());
+  getDefaultStore().set(connectionStateAtom, "unknown");
+  vi.useRealTimers();
+});
+
+describe("Offline banner", () => {
+  it("waits through a short disconnect and clears on reconnect", () => {
+    vi.useFakeTimers();
+    const container = render(createElement(OfflineBanner));
+
+    act(() => getDefaultStore().set(connectionStateAtom, "disconnected"));
+    expect(container.textContent).toBe("");
+
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(container.textContent).toBe(
+      "Offline, some features may be disabled",
+    );
+
+    act(() => getDefaultStore().set(connectionStateAtom, "connected"));
+    expect(container.textContent).toBe("");
+  });
+});
+
+describe("article image fallback", () => {
+  it("keeps a failed image in flow as a square muted block", () => {
+    const container = render(
+      createElement(ArticleImageLightbox, {
+        src: "https://example.com/unavailable.jpg",
+        alt: "Unavailable illustration",
+      }),
+    );
+    const image = container.querySelector("img");
+    expect(image).not.toBeNull();
+
+    act(() => image?.dispatchEvent(new Event("error")));
+
+    const fallback = container.querySelector("[data-image-fallback]");
+    expect(fallback?.className).toContain("aspect-square");
+    expect(fallback?.className).toContain("bg-muted");
+    expect(fallback?.getAttribute("aria-label")).toBe(
+      "Unavailable illustration",
+    );
+  });
+});

--- a/apps/app/tests/unit/data/bookmark-capture-reacquire.test.ts
+++ b/apps/app/tests/unit/data/bookmark-capture-reacquire.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import { bookmarkCapturesStore } from "~/lib/data/bookmarks/capture-store";
+import { reacquireRetainedCapture } from "~/lib/data/bookmarks/mutations";
+import { bookmarksStore } from "~/lib/data/bookmarks/store";
+
+const mocks = vi.hoisted(() => ({
+  getCapture: vi.fn(),
+}));
+
+vi.mock("~/lib/orpc", () => ({
+  orpc: {
+    bookmark: {
+      save: { mutationOptions: (options: unknown) => options },
+      updateState: { mutationOptions: (options: unknown) => options },
+      setView: { mutationOptions: (options: unknown) => options },
+      setTag: { mutationOptions: (options: unknown) => options },
+      delete: { mutationOptions: (options: unknown) => options },
+    },
+  },
+  orpcRouterClient: {
+    bookmark: { getCapture: mocks.getCapture },
+  },
+}));
+
+const bookmark = {
+  id: "bookmark-1",
+  contentType: "text",
+  isSaved: true,
+  isRead: false,
+  captureHash: "capture-hash",
+} as ApplicationBookmark;
+
+const capture = {
+  bookmarkId: bookmark.id,
+  contentHtml: "<p>Reacquired capture</p>",
+  contentHash: "capture-hash",
+  captureSource: "server-static-fetch" as const,
+  extractorVersion: "test",
+  sanitizerPolicyVersion: 1,
+  capturedAt: new Date("2026-08-31T12:00:00Z"),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  bookmarksStore.getState().reset();
+  bookmarkCapturesStore.getState().reset();
+});
+
+describe("reacquireRetainedCapture", () => {
+  it("fetches and persists the capture for a retain-eligible Bookmark", async () => {
+    bookmarksStore.getState().upsert(bookmark);
+    mocks.getCapture.mockResolvedValue({ status: "capture", capture });
+
+    await reacquireRetainedCapture(bookmark);
+
+    expect(mocks.getCapture).toHaveBeenCalledWith({
+      bookmarkId: bookmark.id,
+    });
+    expect(bookmarkCapturesStore.getState().capturesDict[bookmark.id]).toEqual(
+      capture,
+    );
+  });
+
+  it("skips the fetch when the capture is already retained", async () => {
+    bookmarksStore.getState().upsert(bookmark);
+    bookmarkCapturesStore.getState().upsert(capture);
+
+    await reacquireRetainedCapture(bookmark);
+
+    expect(mocks.getCapture).not.toHaveBeenCalled();
+  });
+
+  it("skips ineligible Bookmarks", async () => {
+    await reacquireRetainedCapture({ ...bookmark, isRead: true });
+    await reacquireRetainedCapture({ ...bookmark, isSaved: false });
+    await reacquireRetainedCapture({ ...bookmark, captureHash: null });
+
+    expect(mocks.getCapture).not.toHaveBeenCalled();
+  });
+
+  it("discards the response when retention flipped mid-flight", async () => {
+    bookmarksStore.getState().upsert(bookmark);
+    mocks.getCapture.mockImplementation(() => {
+      // An Archive lands while the capture request is in flight.
+      bookmarksStore.getState().upsert({ ...bookmark, isRead: true });
+      return Promise.resolve({ status: "capture", capture });
+    });
+
+    await reacquireRetainedCapture(bookmark);
+
+    expect(
+      bookmarkCapturesStore.getState().capturesDict[bookmark.id],
+    ).toBeUndefined();
+  });
+
+  it("discards the response after sign-out cleared the store", async () => {
+    bookmarksStore.getState().upsert(bookmark);
+    mocks.getCapture.mockImplementation(() => {
+      bookmarksStore.getState().reset();
+      return Promise.resolve({ status: "capture", capture });
+    });
+
+    await reacquireRetainedCapture(bookmark);
+
+    expect(bookmarkCapturesStore.getState().capturesDict).toEqual({});
+  });
+});

--- a/apps/app/tests/unit/data/bookmark-capture-retention.test.ts
+++ b/apps/app/tests/unit/data/bookmark-capture-retention.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { DatabasePageCapture } from "~/server/db/schema";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import { bookmarkCapturesStore } from "~/lib/data/bookmarks/capture-store";
+import { bookmarksStore } from "~/lib/data/bookmarks/store";
+
+const capture: DatabasePageCapture = {
+  bookmarkId: "bookmark-1",
+  contentHtml: "<p>Retained Page capture</p>",
+  contentHash: "capture-hash",
+  captureSource: "server-static-fetch",
+  extractorVersion: "test",
+  sanitizerPolicyVersion: 1,
+  capturedAt: new Date("2026-08-27T12:00:00Z"),
+};
+
+const bookmark = {
+  id: "bookmark-1",
+  contentType: "text",
+  isRead: false,
+} as ApplicationBookmark;
+
+afterEach(() => {
+  bookmarksStore.getState().reset();
+  bookmarkCapturesStore.getState().reset();
+});
+
+describe("Bookmark Page-capture retention", () => {
+  it("keeps an Unread text capture and removes it on Archive", () => {
+    bookmarksStore.getState().upsert(bookmark);
+    bookmarkCapturesStore.getState().upsert(capture);
+    expect(bookmarkCapturesStore.getState().capturesDict[bookmark.id]).toEqual(
+      capture,
+    );
+
+    bookmarksStore.getState().upsert({ ...bookmark, isRead: true });
+    expect(
+      bookmarkCapturesStore.getState().capturesDict[bookmark.id],
+    ).toBeUndefined();
+  });
+
+  it("removes the capture with deleted Bookmark metadata", () => {
+    bookmarksStore.getState().upsert(bookmark);
+    bookmarkCapturesStore.getState().upsert(capture);
+
+    bookmarksStore.getState().remove(bookmark.id);
+
+    expect(
+      bookmarkCapturesStore.getState().capturesDict[bookmark.id],
+    ).toBeUndefined();
+  });
+});

--- a/apps/app/tests/unit/data/bookmark-capture-retention.test.ts
+++ b/apps/app/tests/unit/data/bookmark-capture-retention.test.ts
@@ -17,6 +17,7 @@ const capture: DatabasePageCapture = {
 const bookmark = {
   id: "bookmark-1",
   contentType: "text",
+  isSaved: true,
   isRead: false,
 } as ApplicationBookmark;
 
@@ -34,6 +35,17 @@ describe("Bookmark Page-capture retention", () => {
     );
 
     bookmarksStore.getState().upsert({ ...bookmark, isRead: true });
+    expect(
+      bookmarkCapturesStore.getState().capturesDict[bookmark.id],
+    ).toBeUndefined();
+  });
+
+  it("removes the capture when the Bookmark is unsaved", () => {
+    bookmarksStore.getState().upsert(bookmark);
+    bookmarkCapturesStore.getState().upsert(capture);
+
+    bookmarksStore.getState().upsert({ ...bookmark, isSaved: false });
+
     expect(
       bookmarkCapturesStore.getState().capturesDict[bookmark.id],
     ).toBeUndefined();

--- a/apps/app/tests/unit/data/direct-request-transport.test.ts
+++ b/apps/app/tests/unit/data/direct-request-transport.test.ts
@@ -266,12 +266,14 @@ describe("direct request transport", () => {
     });
 
     await vi.waitFor(() => {
-      expect(mocks.requestFullTextForItems).toHaveBeenCalledWith({
-        itemIds: [savedFeedItem.id],
-      });
-      expect(mocks.getCaptures).toHaveBeenCalledWith({
-        bookmarkIds: [savedBookmark.id],
-      });
+      expect(mocks.requestFullTextForItems).toHaveBeenCalledWith(
+        { itemIds: [savedFeedItem.id] },
+        expect.anything(),
+      );
+      expect(mocks.getCaptures).toHaveBeenCalledWith(
+        { bookmarkIds: [savedBookmark.id] },
+        expect.anything(),
+      );
       expect(
         feedItemsStore.getState().feedItemsDict[savedFeedItem.id]?.content,
       ).toBe("Saved Feed body");

--- a/apps/app/tests/unit/data/direct-request-transport.test.ts
+++ b/apps/app/tests/unit/data/direct-request-transport.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ApplicationFeedItem } from "~/server/db/schema";
+import type {
+  ApplicationFeedItem,
+  DatabasePageCapture,
+} from "~/server/db/schema";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
 import { dataRequestActions } from "~/lib/data/directRequests";
+import { bookmarkCapturesStore } from "~/lib/data/bookmarks/capture-store";
+import { bookmarksStore } from "~/lib/data/bookmarks/store";
 import {
   getMixedScopeKey,
   mixedContentStore,
@@ -13,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   invalidateQueries: vi.fn(),
   requestPage: vi.fn(),
   requestFullTextForItems: vi.fn(),
+  getCaptures: vi.fn(),
   streamingImport: vi.fn(),
 }));
 
@@ -25,6 +32,7 @@ vi.mock("~/lib/orpc", () => ({
     },
   },
   orpcRouterClient: {
+    bookmark: { getCaptures: mocks.getCaptures },
     mixedContent: { requestPage: mocks.requestPage },
     initial: {
       requestFullTextForItems: mocks.requestFullTextForItems,
@@ -66,6 +74,53 @@ function feedItem(): ApplicationFeedItem {
   };
 }
 
+function bookmark(): ApplicationBookmark {
+  return {
+    id: "bookmark-one",
+    userId: "user-one",
+    sourceUrl: "https://example.com/bookmark",
+    effectiveUrl: "https://example.com/bookmark",
+    canonicalUrl: "https://example.com/bookmark",
+    platform: "website",
+    contentType: "text",
+    orientation: null,
+    contentId: null,
+    classificationSource: "url",
+    classifierVersion: 1,
+    isSaved: true,
+    isRead: false,
+    progress: 0,
+    duration: 0,
+    savedUpdatedAt: now,
+    readUpdatedAt: now,
+    progressUpdatedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    title: "Bookmark",
+    description: null,
+    author: null,
+    siteName: "example.com",
+    publishedAt: null,
+    iconUrl: null,
+    thumbnailUrl: null,
+    previewSource: "url",
+    captureHash: "capture-hash",
+    capturedAt: now,
+    viewIds: [],
+    tagIds: [],
+  };
+}
+
+const capture: DatabasePageCapture = {
+  bookmarkId: "bookmark-one",
+  contentHtml: "<p>Saved Bookmark body</p>",
+  contentHash: "capture-hash",
+  captureSource: "server-static-fetch",
+  extractorVersion: "test",
+  sanitizerPolicyVersion: 1,
+  capturedAt: now,
+};
+
 const scope = { type: "view" as const, viewId: 7 };
 const contentStatus = {
   saveStatus: "inbox" as const,
@@ -77,6 +132,8 @@ describe("direct request transport", () => {
     vi.clearAllMocks();
     mixedContentStore.getState().reset();
     feedItemsStore.getState().reset();
+    bookmarksStore.getState().reset();
+    bookmarkCapturesStore.getState().reset();
     loadingActor.send({ type: "RESET" });
   });
 
@@ -169,6 +226,59 @@ describe("direct request transport", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("hydrates missing Saved text bodies after applying a fetched page", async () => {
+    const savedFeedItem = { ...feedItem(), isWatchLater: true };
+    const savedBookmark = bookmark();
+    mocks.requestPage.mockResolvedValue({
+      references: [
+        {
+          entityKind: "feed-item",
+          entityId: savedFeedItem.id,
+          sectionPlacement: null,
+          normalizedAt: now,
+        },
+        {
+          entityKind: "bookmark",
+          entityId: savedBookmark.id,
+          sectionPlacement: null,
+          normalizedAt: now,
+        },
+      ],
+      bookmarks: [savedBookmark],
+      feedItems: [savedFeedItem],
+      cursor: null,
+      hasMore: false,
+    });
+    mocks.requestFullTextForItems.mockResolvedValue([
+      {
+        id: savedFeedItem.id,
+        content: "Saved Feed body",
+        contentSnippet: "Saved Feed preview",
+      },
+    ]);
+    mocks.getCaptures.mockResolvedValue([capture]);
+
+    await dataRequestActions.requestMixedContentPage(scope, {
+      saveStatus: "saved",
+      archiveStatus: "unread",
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.requestFullTextForItems).toHaveBeenCalledWith({
+        itemIds: [savedFeedItem.id],
+      });
+      expect(mocks.getCaptures).toHaveBeenCalledWith({
+        bookmarkIds: [savedBookmark.id],
+      });
+      expect(
+        feedItemsStore.getState().feedItemsDict[savedFeedItem.id]?.content,
+      ).toBe("Saved Feed body");
+      expect(
+        bookmarkCapturesStore.getState().capturesDict[savedBookmark.id],
+      ).toEqual(capture);
+    });
   });
 
   it("applies import progress from the direct response stream", async () => {

--- a/apps/app/tests/unit/data/feed-page-retention.test.ts
+++ b/apps/app/tests/unit/data/feed-page-retention.test.ts
@@ -21,7 +21,7 @@ function makeItem(pageIndex: number, itemIndex: number): ApplicationFeedItem {
     author: "Serial test",
     url: `https://example.com/${id}`,
     thumbnail: "",
-    content: `<p>${id}</p>`,
+    content: "",
     contentSnippet: id,
     contentType: "text",
     isWatched: false,
@@ -39,10 +39,15 @@ function makeItem(pageIndex: number, itemIndex: number): ApplicationFeedItem {
   };
 }
 
-function seedAndRetainPages(pageCount: number) {
+function seedAndRetainPages(pageCount: number, retainedBodyId?: string) {
   const items = Array.from({ length: pageCount }, (_page, pageIndex) =>
     Array.from({ length: 30 }, (_item, itemIndex) =>
-      makeItem(pageIndex, itemIndex),
+      (() => {
+        const item = makeItem(pageIndex, itemIndex);
+        return item.id === retainedBodyId
+          ? { ...item, content: "<p>Offline body</p>" }
+          : item;
+      })(),
     ),
   );
   feedItemsStore.setState({
@@ -50,6 +55,7 @@ function seedAndRetainPages(pageCount: number) {
       items.flat().map((item) => [item.id, item]),
     ),
     feedItemsOrder: items.flat().map((item) => item.id),
+    retainedFeedItemBodyIds: retainedBodyId ? { [retainedBodyId]: true } : {},
   });
   for (let pageIndex = 0; pageIndex < pageCount; pageIndex++) {
     feedItemsStore.getState().retainFeedItemPage({
@@ -115,5 +121,34 @@ describe("Feed-item page retention", () => {
     expect(state.retainedFeedPages[SCOPE_KEY]).toHaveLength(8);
     expect(state.feedItemsDict["page-0-item-0"]).toBeDefined();
     expect(state.feedItemsDict["page-1-item-0"]).toBeUndefined();
+  });
+
+  it("retains a loaded Unread text body without retaining its cursor page", () => {
+    const item = makeItem(0, 0);
+    seedAndRetainPages(12, item.id);
+
+    const retained = feedItemsStore.getState();
+    expect(
+      retained.retainedFeedPages[SCOPE_KEY]?.some((page) =>
+        page.entityIds.includes(item.id),
+      ),
+    ).toBe(false);
+    expect(retained.feedItemsDict[item.id]?.content).toBe(
+      "<p>Offline body</p>",
+    );
+  });
+
+  it("removes a retained body when the item is archived", () => {
+    const item = makeItem(0, 0);
+    feedItemsStore
+      .getState()
+      .setFeedItem(item.id, { ...item, content: "<p>Offline body</p>" });
+
+    feedItemsStore.getState().setFeedItem(item.id, {
+      ...feedItemsStore.getState().feedItemsDict[item.id]!,
+      isWatched: true,
+    });
+
+    expect(feedItemsStore.getState().feedItemsDict[item.id]?.content).toBe("");
   });
 });

--- a/apps/app/tests/unit/data/feed-page-retention.test.ts
+++ b/apps/app/tests/unit/data/feed-page-retention.test.ts
@@ -6,6 +6,7 @@ import {
   setRetainedEntityPins,
 } from "~/lib/data/page-retention";
 import { feedItemsStore, getFeedItemScopeKey } from "~/lib/data/store";
+import { getPersistedFeedItemRetentionState } from "~/lib/data/feed-page-retention";
 import { CONTENT_STATUS_FILTERS } from "~/lib/content-status";
 
 const SCOPE_KEY = getFeedItemScopeKey("view", 7, CONTENT_STATUS_FILTERS[0]);
@@ -138,7 +139,7 @@ describe("Feed-item page retention", () => {
     );
   });
 
-  it("removes a retained body when the item is archived", () => {
+  it("drops body retention when the item is archived", () => {
     const item = makeItem(0, 0);
     feedItemsStore
       .getState()
@@ -149,6 +150,17 @@ describe("Feed-item page retention", () => {
       isWatched: true,
     });
 
-    expect(feedItemsStore.getState().feedItemsDict[item.id]?.content).toBe("");
+    // The live store keeps the body so the online reader can render it...
+    expect(feedItemsStore.getState().feedItemsDict[item.id]?.content).toBe(
+      "<p>Offline body</p>",
+    );
+    expect(feedItemsStore.getState().retainedFeedItemBodyIds[item.id]).toBe(
+      undefined,
+    );
+    // ...while the persisted snapshot no longer carries it.
+    expect(
+      getPersistedFeedItemRetentionState(feedItemsStore.getState())
+        .feedItemsDict[item.id]?.content,
+    ).toBe("");
   });
 });

--- a/apps/app/tests/unit/data/navigation-cache.test.ts
+++ b/apps/app/tests/unit/data/navigation-cache.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  getCacheableNavigationResponse,
+  normalizeNavigationResponse,
+} from "~/lib/pwa/navigation-cache";
+
+describe("service-worker navigation cache", () => {
+  it("rejects a transient server error instead of replacing the shell", () => {
+    const response = new Response("unavailable", { status: 503 });
+
+    expect(getCacheableNavigationResponse(response)).toBeNull();
+  });
+
+  it("keeps successful responses cacheable", () => {
+    const response = new Response("shell", { status: 200 });
+
+    expect(getCacheableNavigationResponse(response)).toBe(response);
+  });
+
+  it("removes redirected response metadata from a valid shell", () => {
+    const response = new Response("shell", { status: 200 });
+    Object.defineProperty(response, "redirected", { value: true });
+
+    const normalized = normalizeNavigationResponse(response);
+
+    expect(normalized).not.toBe(response);
+    expect(normalized.redirected).toBe(false);
+    expect(normalized.status).toBe(200);
+  });
+});

--- a/apps/app/tests/unit/data/navigation-cache.test.ts
+++ b/apps/app/tests/unit/data/navigation-cache.test.ts
@@ -4,17 +4,40 @@ import {
   normalizeNavigationResponse,
 } from "~/lib/pwa/navigation-cache";
 
+const ROOT_URL = "https://app.example.com/";
+
+function responseAt(url: string, init?: ResponseInit) {
+  const response = new Response("shell", init);
+  Object.defineProperty(response, "url", { value: url });
+  return response;
+}
+
 describe("service-worker navigation cache", () => {
   it("rejects a transient server error instead of replacing the shell", () => {
     const response = new Response("unavailable", { status: 503 });
 
-    expect(getCacheableNavigationResponse(response)).toBeNull();
+    expect(getCacheableNavigationResponse(ROOT_URL, response)).toBeNull();
   });
 
-  it("keeps successful responses cacheable", () => {
+  it("keeps successful same-path responses cacheable", () => {
+    const response = responseAt(ROOT_URL, { status: 200 });
+
+    expect(getCacheableNavigationResponse(ROOT_URL, response)).toBe(response);
+  });
+
+  it("keeps synthetic responses without a URL cacheable", () => {
     const response = new Response("shell", { status: 200 });
 
-    expect(getCacheableNavigationResponse(response)).toBe(response);
+    expect(getCacheableNavigationResponse(ROOT_URL, response)).toBe(response);
+  });
+
+  it("rejects a response that resolved at the sign-in page", () => {
+    const response = responseAt("https://app.example.com/auth/sign-in", {
+      status: 200,
+    });
+    Object.defineProperty(response, "redirected", { value: true });
+
+    expect(getCacheableNavigationResponse(ROOT_URL, response)).toBeNull();
   });
 
   it("removes redirected response metadata from a valid shell", () => {

--- a/apps/app/tests/unit/data/normalized-idb-storage-in-place.test.ts
+++ b/apps/app/tests/unit/data/normalized-idb-storage-in-place.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNormalizedIDBStorage } from "~/lib/data/normalized-idb-storage";
+
+const indexedDb = vi.hoisted(() => ({
+  entries: new Map<IDBValidKey, unknown>(),
+}));
+
+function cloneStoredValue<T>(value: T): T {
+  return value === undefined ? value : structuredClone(value);
+}
+
+vi.mock("idb-keyval", () => ({
+  clear: vi.fn(() => Promise.resolve(indexedDb.entries.clear())),
+  del: vi.fn((key: IDBValidKey) =>
+    Promise.resolve(indexedDb.entries.delete(key)),
+  ),
+  delMany: vi.fn((keys: IDBValidKey[]) => {
+    for (const key of keys) indexedDb.entries.delete(key);
+    return Promise.resolve();
+  }),
+  get: vi.fn((key: IDBValidKey) =>
+    Promise.resolve(cloneStoredValue(indexedDb.entries.get(key))),
+  ),
+  getMany: vi.fn((keys: IDBValidKey[]) =>
+    Promise.resolve(
+      keys.map((key) => cloneStoredValue(indexedDb.entries.get(key))),
+    ),
+  ),
+  keys: vi.fn(() => Promise.resolve([...indexedDb.entries.keys()])),
+  set: vi.fn((key: IDBValidKey, value: unknown) => {
+    indexedDb.entries.set(key, cloneStoredValue(value));
+    return Promise.resolve();
+  }),
+  setMany: vi.fn((entries: Array<[IDBValidKey, unknown]>) => {
+    for (const [key, value] of entries) {
+      indexedDb.entries.set(key, cloneStoredValue(value));
+    }
+    return Promise.resolve();
+  }),
+}));
+
+afterEach(() => {
+  indexedDb.entries.clear();
+});
+
+describe("normalized IndexedDB in-place record updates", () => {
+  it("persists a replaced entity from a stable dictionary", async () => {
+    const records = { item: { id: "item", archived: false } };
+    const storage = createNormalizedIDBStorage<{
+      records: Record<string, { id: string; archived: boolean }>;
+    }>({ recordFields: ["records"] });
+    const recordKey =
+      "test-store::normalized:v1::record:records:" + encodeURIComponent("item");
+
+    storage.setItem("test-store", { state: { records } });
+    window.dispatchEvent(new Event("pagehide"));
+    await vi.waitFor(() =>
+      expect(indexedDb.entries.get(recordKey)).toEqual({
+        id: "item",
+        archived: false,
+      }),
+    );
+
+    records.item = { id: "item", archived: true };
+    storage.setItem("test-store", { state: { records } });
+    window.dispatchEvent(new Event("pagehide"));
+
+    await vi.waitFor(() =>
+      expect(indexedDb.entries.get(recordKey)).toEqual({
+        id: "item",
+        archived: true,
+      }),
+    );
+  });
+});

--- a/apps/app/tests/unit/data/offline-content.test.ts
+++ b/apps/app/tests/unit/data/offline-content.test.ts
@@ -1,9 +1,52 @@
 import { describe, expect, it } from "vitest";
+import type { ApplicationFeedItem } from "~/server/db/schema";
 import {
   canOpenContent,
   canOpenOfflineContent,
+  retainEligibleFeedBody,
+  stripIneligibleFeedBodyForPersistence,
 } from "~/lib/data/offline-content";
 import { canMutate } from "~/lib/data/offline-mutations";
+
+function archivedTextItem() {
+  return {
+    id: "item-1",
+    contentType: "text",
+    isWatched: true,
+    content: "<p>Archived body</p>",
+    contentSnippet: "Archived",
+    contentHash: "hash-1",
+  } as unknown as ApplicationFeedItem;
+}
+
+describe("archived body handling", () => {
+  it("keeps an archived body in the live store for online reading", () => {
+    const item = archivedTextItem();
+
+    expect(retainEligibleFeedBody(undefined, item)).toBe(item);
+  });
+
+  it("strips an archived body from the persisted snapshot", () => {
+    const item = archivedTextItem();
+
+    const persisted = stripIneligibleFeedBodyForPersistence(item);
+
+    expect(persisted.content).toBe("");
+    expect(persisted.contentSnippet).toBe("Archived");
+    expect(item.content).toBe("<p>Archived body</p>");
+    // Stable identity across flushes so the normalized IDB diff sees no
+    // change without a real update.
+    expect(stripIneligibleFeedBodyForPersistence(item)).toBe(persisted);
+  });
+
+  it("passes through items whose body is already eligible or empty", () => {
+    const eligible = { ...archivedTextItem(), isWatched: false };
+    const empty = { ...archivedTextItem(), content: "" };
+
+    expect(stripIneligibleFeedBodyForPersistence(eligible)).toBe(eligible);
+    expect(stripIneligibleFeedBodyForPersistence(empty)).toBe(empty);
+  });
+});
 
 describe("offline content capability", () => {
   it("opens normal destinations until disconnection is established", () => {

--- a/apps/app/tests/unit/data/offline-content.test.ts
+++ b/apps/app/tests/unit/data/offline-content.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  canOpenContent,
+  canOpenOfflineContent,
+} from "~/lib/data/offline-content";
+import { canMutate } from "~/lib/data/offline-mutations";
+
+describe("offline content capability", () => {
+  it("opens normal destinations until disconnection is established", () => {
+    expect(
+      canOpenContent({
+        connectionState: "unknown",
+        contentType: "video",
+        hasBody: false,
+      }),
+    ).toBe(true);
+    expect(
+      canOpenContent({
+        connectionState: "connected",
+        contentType: "text",
+        hasBody: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("opens only retained text while disconnected", () => {
+    expect(canOpenOfflineContent({ contentType: "text", hasBody: true })).toBe(
+      true,
+    );
+    expect(
+      canOpenContent({
+        connectionState: "disconnected",
+        contentType: "text",
+        hasBody: false,
+      }),
+    ).toBe(false);
+    expect(
+      canOpenContent({
+        connectionState: "disconnected",
+        contentType: "video",
+        hasBody: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("offline mutation gate", () => {
+  it("blocks mutations only after disconnection is established", () => {
+    expect(canMutate("unknown")).toBe(true);
+    expect(canMutate("connected")).toBe(true);
+    expect(canMutate("disconnected")).toBe(false);
+  });
+});

--- a/apps/app/tests/unit/data/offline-hydration.test.ts
+++ b/apps/app/tests/unit/data/offline-hydration.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApplicationFeedItem } from "~/server/db/schema";
+import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import { bookmarkCapturesStore } from "~/lib/data/bookmarks/capture-store";
+import { bookmarksStore } from "~/lib/data/bookmarks/store";
+import {
+  hydrateOfflineBodiesForPage,
+  invalidateOfflineHydration,
+  planPageBodyHydration,
+} from "~/lib/data/offline-hydration";
+import { feedItemsStore } from "~/lib/data/store";
+
+const mocks = vi.hoisted(() => ({
+  requestFullTextForItems: vi.fn(),
+  getCaptures: vi.fn(),
+}));
+
+vi.mock("~/lib/orpc", () => ({
+  orpcRouterClient: {
+    bookmark: { getCaptures: mocks.getCaptures },
+    initial: { requestFullTextForItems: mocks.requestFullTextForItems },
+  },
+}));
+
+const now = new Date("2026-08-31T12:00:00.000Z");
+
+function feedItem(
+  overrides: Partial<ApplicationFeedItem> = {},
+): ApplicationFeedItem {
+  return {
+    id: "feed-item-one",
+    feedId: 1,
+    contentId: "content-one",
+    title: "Article",
+    author: "Author",
+    url: "https://example.com/article",
+    thumbnail: "",
+    content: "",
+    contentSnippet: "preview",
+    contentType: "text",
+    isWatched: false,
+    isWatchLater: true,
+    progress: 0,
+    duration: 0,
+    orientation: null,
+    postedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    isWatchedUpdatedAt: null,
+    isWatchLaterUpdatedAt: null,
+    contentHash: "content-hash",
+    platform: "website",
+    ...overrides,
+  };
+}
+
+function bookmark(
+  overrides: Partial<ApplicationBookmark> = {},
+): ApplicationBookmark {
+  return {
+    id: "bookmark-one",
+    userId: "user-one",
+    sourceUrl: "https://example.com/bookmark",
+    effectiveUrl: "https://example.com/bookmark",
+    canonicalUrl: "https://example.com/bookmark",
+    platform: "website",
+    contentType: "text",
+    orientation: null,
+    contentId: null,
+    classificationSource: "url",
+    classifierVersion: 1,
+    isSaved: true,
+    isRead: false,
+    progress: 0,
+    duration: 0,
+    savedUpdatedAt: now,
+    readUpdatedAt: now,
+    progressUpdatedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    title: "Bookmark",
+    description: null,
+    author: null,
+    siteName: "example.com",
+    publishedAt: null,
+    iconUrl: null,
+    thumbnailUrl: null,
+    previewSource: "url",
+    captureHash: "capture-hash",
+    capturedAt: now,
+    viewIds: [],
+    tagIds: [],
+    ...overrides,
+  } as unknown as ApplicationBookmark;
+}
+
+function planWith(input: {
+  feedItems?: ApplicationFeedItem[];
+  bookmarks?: ApplicationBookmark[];
+  retainedFeedIds?: string[];
+  capturedBookmarkIds?: string[];
+}) {
+  return planPageBodyHydration({
+    feedItems: input.feedItems ?? [],
+    bookmarks: input.bookmarks ?? [],
+    hasRetainedFeedBody: (id) => input.retainedFeedIds?.includes(id) === true,
+    hasBookmarkCapture: (id) =>
+      input.capturedBookmarkIds?.includes(id) === true,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateOfflineHydration();
+  feedItemsStore.getState().reset();
+  bookmarksStore.getState().reset();
+  bookmarkCapturesStore.getState().reset();
+});
+
+describe("planPageBodyHydration", () => {
+  it.each([
+    ["video item", feedItem({ contentType: "video" })],
+    ["archived item", feedItem({ isWatched: true })],
+    ["inbox item", feedItem({ isWatchLater: false })],
+  ])("skips a %s entirely", (_label, item) => {
+    expect(planWith({ feedItems: [item] })).toEqual({
+      retainLoadedFeedItemIds: [],
+      fetchFeedItemIds: [],
+      fetchBookmarkIds: [],
+    });
+  });
+
+  it("fetches a Saved Unread text item without a body", () => {
+    expect(planWith({ feedItems: [feedItem()] }).fetchFeedItemIds).toEqual([
+      "feed-item-one",
+    ]);
+  });
+
+  it("retains a loaded body only while it is unmarked", () => {
+    const loaded = feedItem({ content: "<p>Body</p>" });
+    expect(planWith({ feedItems: [loaded] }).retainLoadedFeedItemIds).toEqual([
+      "feed-item-one",
+    ]);
+    expect(
+      planWith({ feedItems: [loaded], retainedFeedIds: ["feed-item-one"] }),
+    ).toEqual({
+      retainLoadedFeedItemIds: [],
+      fetchFeedItemIds: [],
+      fetchBookmarkIds: [],
+    });
+  });
+
+  it.each([
+    ["uncaptured", bookmark({ captureHash: null })],
+    ["unsaved", bookmark({ isSaved: false })],
+    ["archived", bookmark({ isRead: true })],
+    ["video", bookmark({ contentType: "video" })],
+  ])("skips an %s Bookmark", (_label, entity) => {
+    expect(planWith({ bookmarks: [entity] }).fetchBookmarkIds).toEqual([]);
+  });
+
+  it("fetches a Saved Unread capture only while it is absent", () => {
+    expect(planWith({ bookmarks: [bookmark()] }).fetchBookmarkIds).toEqual([
+      "bookmark-one",
+    ]);
+    expect(
+      planWith({
+        bookmarks: [bookmark()],
+        capturedBookmarkIds: ["bookmark-one"],
+      }).fetchBookmarkIds,
+    ).toEqual([]);
+  });
+});
+
+describe("hydrateOfflineBodiesForPage", () => {
+  it("retries a failed capture fetch on a page that no longer carries it", async () => {
+    const entity = bookmark();
+    bookmarksStore.getState().upsert(entity);
+    mocks.getCaptures.mockRejectedValueOnce(new Error("offline"));
+    await hydrateOfflineBodiesForPage({ feedItems: [], bookmarks: [entity] });
+    expect(
+      bookmarkCapturesStore.getState().capturesDict[entity.id],
+    ).toBeUndefined();
+
+    const capture = {
+      bookmarkId: entity.id,
+      contentHtml: "<p>Capture</p>",
+      contentHash: "capture-hash",
+      captureSource: "server-static-fetch",
+      extractorVersion: "test",
+      sanitizerPolicyVersion: 1,
+      capturedAt: now,
+    };
+    mocks.getCaptures.mockResolvedValueOnce([capture]);
+    await hydrateOfflineBodiesForPage({ feedItems: [], bookmarks: [] });
+    expect(mocks.getCaptures).toHaveBeenCalledTimes(2);
+    expect(bookmarkCapturesStore.getState().capturesDict[entity.id]).toEqual(
+      capture,
+    );
+  });
+
+  it("drops a failed fetch when the entity stops qualifying", async () => {
+    const entity = bookmark();
+    bookmarksStore.getState().upsert(entity);
+    mocks.getCaptures.mockRejectedValueOnce(new Error("offline"));
+    await hydrateOfflineBodiesForPage({ feedItems: [], bookmarks: [entity] });
+
+    bookmarksStore.getState().upsert({ ...entity, isSaved: false });
+    await hydrateOfflineBodiesForPage({ feedItems: [], bookmarks: [] });
+    expect(mocks.getCaptures).toHaveBeenCalledTimes(1);
+  });
+
+  it("never re-requests a body the server already returned empty", async () => {
+    const item = feedItem();
+    feedItemsStore.getState().setFeedItems([item]);
+    mocks.requestFullTextForItems.mockResolvedValue([
+      { id: item.id, content: "", contentSnippet: "" },
+    ]);
+    await hydrateOfflineBodiesForPage({ feedItems: [item], bookmarks: [] });
+    await hydrateOfflineBodiesForPage({ feedItems: [item], bookmarks: [] });
+    expect(mocks.requestFullTextForItems).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards an in-flight capture response after invalidation", async () => {
+    const entity = bookmark();
+    bookmarksStore.getState().upsert(entity);
+    let resolveCaptures: (captures: unknown[]) => void = () => {};
+    mocks.getCaptures.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveCaptures = resolve;
+      }),
+    );
+    const hydration = hydrateOfflineBodiesForPage({
+      feedItems: [],
+      bookmarks: [entity],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    invalidateOfflineHydration();
+    bookmarkCapturesStore.getState().reset();
+    resolveCaptures([
+      {
+        bookmarkId: entity.id,
+        contentHtml: "<p>Stale user capture</p>",
+        contentHash: "capture-hash",
+        captureSource: "server-static-fetch",
+        extractorVersion: "test",
+        sanitizerPolicyVersion: 1,
+        capturedAt: now,
+      },
+    ]);
+    await hydration;
+    expect(bookmarkCapturesStore.getState().capturesDict).toEqual({});
+  });
+});

--- a/apps/app/tests/unit/data/offline-hydration.test.ts
+++ b/apps/app/tests/unit/data/offline-hydration.test.ts
@@ -221,6 +221,84 @@ describe("hydrateOfflineBodiesForPage", () => {
     expect(mocks.requestFullTextForItems).toHaveBeenCalledTimes(1);
   });
 
+  it("re-requests an empty body once its content hash changes", async () => {
+    const item = feedItem();
+    feedItemsStore.getState().setFeedItems([item]);
+    mocks.requestFullTextForItems.mockResolvedValue([
+      { id: item.id, content: "", contentSnippet: "" },
+    ]);
+    await hydrateOfflineBodiesForPage({ feedItems: [item], bookmarks: [] });
+    await hydrateOfflineBodiesForPage({ feedItems: [item], bookmarks: [] });
+    expect(mocks.requestFullTextForItems).toHaveBeenCalledTimes(1);
+
+    const regenerated = feedItem({ contentHash: "regenerated-hash" });
+    feedItemsStore.getState().setFeedItems([regenerated]);
+    await hydrateOfflineBodiesForPage({
+      feedItems: [regenerated],
+      bookmarks: [],
+    });
+    expect(mocks.requestFullTextForItems).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent page applications into one hydration run", async () => {
+    const first = bookmark({ id: "bookmark-a" });
+    const second = bookmark({ id: "bookmark-b" });
+    bookmarksStore.getState().upsert(first);
+    bookmarksStore.getState().upsert(second);
+    mocks.getCaptures.mockImplementation(
+      ({ bookmarkIds }: { bookmarkIds: string[] }) =>
+        Promise.resolve(
+          bookmarkIds.map((bookmarkId) => ({
+            bookmarkId,
+            contentHtml: "<p>Capture</p>",
+            contentHash: "capture-hash",
+            captureSource: "server-static-fetch",
+            extractorVersion: "test",
+            sanitizerPolicyVersion: 1,
+            capturedAt: now,
+          })),
+        ),
+    );
+    const firstRun = hydrateOfflineBodiesForPage({
+      feedItems: [],
+      bookmarks: [first],
+    });
+    const secondRun = hydrateOfflineBodiesForPage({
+      feedItems: [],
+      bookmarks: [second],
+    });
+    expect(secondRun).toBe(firstRun);
+    await firstRun;
+    expect(
+      bookmarkCapturesStore.getState().capturesDict[first.id],
+    ).toBeDefined();
+    expect(
+      bookmarkCapturesStore.getState().capturesDict[second.id],
+    ).toBeDefined();
+  });
+
+  it("discards an in-flight fulltext response after invalidation", async () => {
+    const item = feedItem();
+    feedItemsStore.getState().setFeedItems([item]);
+    let resolveFulltext: (items: unknown[]) => void = () => {};
+    mocks.requestFullTextForItems.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFulltext = resolve;
+      }),
+    );
+    const hydration = hydrateOfflineBodiesForPage({
+      feedItems: [item],
+      bookmarks: [],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    invalidateOfflineHydration();
+    resolveFulltext([
+      { id: item.id, content: "<p>Late body</p>", contentSnippet: "late" },
+    ]);
+    await hydration;
+    expect(feedItemsStore.getState().feedItemsDict[item.id]?.content).toBe("");
+  });
+
   it("discards an in-flight capture response after invalidation", async () => {
     const entity = bookmark();
     bookmarksStore.getState().upsert(entity);

--- a/apps/app/tests/unit/data/offline-hydration.test.ts
+++ b/apps/app/tests/unit/data/offline-hydration.test.ts
@@ -299,6 +299,54 @@ describe("hydrateOfflineBodiesForPage", () => {
     expect(feedItemsStore.getState().feedItemsDict[item.id]?.content).toBe("");
   });
 
+  it("does not resurrect a severed run alongside the newly admitted one", async () => {
+    const gated = bookmark({ id: "bookmark-gated" });
+    const fresh = bookmark({ id: "bookmark-fresh" });
+    const queued = bookmark({ id: "bookmark-queued" });
+    bookmarksStore.getState().upsert(gated);
+    const deferred: Array<(captures: unknown[]) => void> = [];
+    mocks.getCaptures.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          deferred.push(resolve);
+        }),
+    );
+    const severedRun = hydrateOfflineBodiesForPage({
+      feedItems: [],
+      bookmarks: [gated],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    invalidateOfflineHydration();
+
+    bookmarksStore.getState().upsert(fresh);
+    bookmarksStore.getState().upsert(queued);
+    const admittedRun = hydrateOfflineBodiesForPage({
+      feedItems: [],
+      bookmarks: [fresh],
+    });
+    expect(admittedRun).not.toBe(severedRun);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // A third application queues a sweep while the admitted run is gated;
+    // only the admitted run may pick it up once its fetch resolves.
+    void hydrateOfflineBodiesForPage({ feedItems: [], bookmarks: [queued] });
+    expect(deferred).toHaveLength(2);
+
+    // The severed run resolves first. It must terminate instead of
+    // draining the queued sweep out from under the admitted run.
+    deferred[0]?.([]);
+    await severedRun;
+    expect(mocks.getCaptures).toHaveBeenCalledTimes(2);
+
+    deferred[1]?.([]);
+    await vi.waitFor(() => expect(deferred).toHaveLength(3));
+    expect(mocks.getCaptures.mock.calls[2]?.[0]).toEqual({
+      bookmarkIds: [queued.id],
+    });
+    deferred[2]?.([]);
+    await admittedRun;
+    expect(mocks.getCaptures).toHaveBeenCalledTimes(3);
+  });
+
   it("discards an in-flight capture response after invalidation", async () => {
     const entity = bookmark();
     bookmarksStore.getState().upsert(entity);

--- a/apps/app/tests/unit/data/subscription-connection.test.ts
+++ b/apps/app/tests/unit/data/subscription-connection.test.ts
@@ -1,0 +1,41 @@
+import { getDefaultStore } from "jotai";
+import { afterEach, describe, expect, it } from "vitest";
+import { connectionStateAtom } from "~/lib/data/atoms";
+import {
+  initializeDataSubscriptionConnection,
+  markDataSubscriptionConnected,
+  markDataSubscriptionFailed,
+  markDataSubscriptionPaused,
+} from "~/lib/data/subscriptionConnection";
+
+const store = getDefaultStore();
+
+afterEach(() => store.set(connectionStateAtom, "unknown"));
+
+describe("subscription connection state", () => {
+  it("establishes an immediate offline state from the browser", () => {
+    initializeDataSubscriptionConnection(false);
+    expect(store.get(connectionStateAtom)).toBe("disconnected");
+  });
+
+  it("waits for a live connection before establishing connected", () => {
+    initializeDataSubscriptionConnection(true);
+    expect(store.get(connectionStateAtom)).toBe("unknown");
+
+    markDataSubscriptionConnected();
+    expect(store.get(connectionStateAtom)).toBe("connected");
+  });
+
+  it("marks a visible live connection failure as disconnected", () => {
+    markDataSubscriptionConnected();
+    markDataSubscriptionFailed({ isOnline: true, isVisible: true });
+    expect(store.get(connectionStateAtom)).toBe("disconnected");
+  });
+
+  it("preserves the previous state for an intentional hidden pause", () => {
+    markDataSubscriptionConnected();
+    markDataSubscriptionPaused();
+    markDataSubscriptionFailed({ isOnline: true, isVisible: false });
+    expect(store.get(connectionStateAtom)).toBe("connected");
+  });
+});

--- a/apps/app/tests/unit/feed-items/merge-feed-item.test.ts
+++ b/apps/app/tests/unit/feed-items/merge-feed-item.test.ts
@@ -41,7 +41,7 @@ describe("mergeFeedItem", () => {
     clearPendingFeedItemOverrides();
   });
 
-  it("preserves versioned item fields when the content hash matches", () => {
+  it("preserves matching versioned fields while clearing an Archived body", () => {
     const existingItem = makeItem();
     const incomingItem = makeItem({
       title: "Incoming title",
@@ -61,7 +61,7 @@ describe("mergeFeedItem", () => {
     const mergedItem = mergeFeedItem(existingItem, incomingItem);
 
     expect(mergedItem.title).toBe("Original title");
-    expect(mergedItem.content).toBe("Original content");
+    expect(mergedItem.content).toBe("");
     expect(mergedItem.contentSnippet).toBe("Original snippet");
     expect(mergedItem.thumbnail).toBe("https://example.com/original.jpg");
     expect(mergedItem.isWatched).toBe(true);

--- a/apps/app/tests/unit/feed-items/merge-feed-item.test.ts
+++ b/apps/app/tests/unit/feed-items/merge-feed-item.test.ts
@@ -41,7 +41,7 @@ describe("mergeFeedItem", () => {
     clearPendingFeedItemOverrides();
   });
 
-  it("preserves matching versioned fields while clearing an Archived body", () => {
+  it("preserves versioned item fields when the content hash matches", () => {
     const existingItem = makeItem();
     const incomingItem = makeItem({
       title: "Incoming title",
@@ -61,7 +61,7 @@ describe("mergeFeedItem", () => {
     const mergedItem = mergeFeedItem(existingItem, incomingItem);
 
     expect(mergedItem.title).toBe("Original title");
-    expect(mergedItem.content).toBe("");
+    expect(mergedItem.content).toBe("Original content");
     expect(mergedItem.contentSnippet).toBe("Original snippet");
     expect(mergedItem.thumbnail).toBe("https://example.com/original.jpg");
     expect(mergedItem.isWatched).toBe(true);

--- a/apps/app/tests/unit/feed-items/optimistic-rollback.test.ts
+++ b/apps/app/tests/unit/feed-items/optimistic-rollback.test.ts
@@ -153,9 +153,10 @@ describe("optimistic feed item mutations", () => {
     expect(retainLoadedFeedItemBody(previousFeedItem.id)).toBe(true);
 
     const context = applyOptimisticWatchedValue(previousFeedItem.id, true);
+    // The live body survives the optimistic Archive; only retention drops.
     expect(
       feedItemsStore.getState().feedItemsDict[previousFeedItem.id]?.content,
-    ).toBe("");
+    ).toBe(previousFeedItem.content);
     expect(
       feedItemsStore.getState().retainedFeedItemBodyIds[previousFeedItem.id],
     ).toBeUndefined();

--- a/apps/app/tests/unit/feed-items/optimistic-rollback.test.ts
+++ b/apps/app/tests/unit/feed-items/optimistic-rollback.test.ts
@@ -9,7 +9,7 @@ import {
   rollbackOptimisticWatchedValues,
   settleOptimisticWatchedValues,
 } from "~/lib/data/feed-items/mutations";
-import { feedItemsStore } from "~/lib/data/store";
+import { feedItemsStore, retainLoadedFeedItemBody } from "~/lib/data/store";
 import {
   getMixedScopeKey,
   mixedContentStore,
@@ -143,6 +143,31 @@ describe("optimistic feed item mutations", () => {
       feedItemsStore.getState().feedItemsDict[previousFeedItem.id];
     expect(rolledBackItem?.isWatched).toBe(false);
     expect(rolledBackItem?.updatedAt).toBe(previousFeedItem.updatedAt);
+  });
+
+  it("restores a retained article body after a failed Archive", () => {
+    const previousFeedItem = makeItem();
+    feedItemsStore
+      .getState()
+      .setFeedItem(previousFeedItem.id, previousFeedItem);
+    expect(retainLoadedFeedItemBody(previousFeedItem.id)).toBe(true);
+
+    const context = applyOptimisticWatchedValue(previousFeedItem.id, true);
+    expect(
+      feedItemsStore.getState().feedItemsDict[previousFeedItem.id]?.content,
+    ).toBe("");
+    expect(
+      feedItemsStore.getState().retainedFeedItemBodyIds[previousFeedItem.id],
+    ).toBeUndefined();
+
+    rollbackOptimisticWatchedValue(context);
+
+    expect(
+      feedItemsStore.getState().feedItemsDict[previousFeedItem.id]?.content,
+    ).toBe(previousFeedItem.content);
+    expect(
+      feedItemsStore.getState().retainedFeedItemBodyIds[previousFeedItem.id],
+    ).toBe(true);
   });
 
   it("does not roll an older failure over a newer optimistic update", () => {

--- a/apps/app/tests/unit/hooks/offline-video-progress.test.ts
+++ b/apps/app/tests/unit/hooks/offline-video-progress.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { getDefaultStore } from "jotai";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { connectionStateAtom } from "~/lib/data/atoms";
+import { useSaveBookmarkVideoProgress } from "~/lib/hooks/useSaveBookmarkVideoProgress";
+import { useSaveProgress } from "~/lib/hooks/useSaveProgress";
+
+const mocks = vi.hoisted(() => ({
+  saveBookmarkProgress: vi.fn(),
+  saveFeedProgress: vi.fn(),
+}));
+
+vi.mock("~/lib/data/feed-items/mutations", () => ({
+  useSetProgressMutation: () => ({ mutate: mocks.saveFeedProgress }),
+}));
+
+vi.mock("~/lib/data/store", () => ({
+  useFeedItemValue: () => ({ id: "feed-item", feedId: 1 }),
+}));
+
+vi.mock("~/lib/data/bookmarks", () => ({
+  useBookmarkValue: () => ({ id: "bookmark" }),
+}));
+
+vi.mock("~/lib/data/bookmarks/mutations", () => ({
+  useUpdateBookmarkStateMutation: () => ({
+    mutate: mocks.saveBookmarkProgress,
+  }),
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const roots: Array<ReturnType<typeof createRoot>> = [];
+
+function ProgressHarness() {
+  useSaveProgress({
+    contentId: "feed-item",
+    enabled: true,
+    getProgress: () => ({ progress: 4, duration: 10 }),
+  });
+  useSaveBookmarkVideoProgress({
+    bookmarkId: "bookmark",
+    enabled: true,
+    getProgress: () => ({ progress: 5, duration: 12 }),
+  });
+  return null;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  getDefaultStore().set(connectionStateAtom, "disconnected");
+});
+
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount());
+  getDefaultStore().set(connectionStateAtom, "unknown");
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("offline video progress", () => {
+  it("blocks interval and unmount writes while disconnected", () => {
+    const root = createRoot(document.createElement("div"));
+    roots.push(root);
+    act(() => root.render(createElement(ProgressHarness)));
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(mocks.saveFeedProgress).not.toHaveBeenCalled();
+    expect(mocks.saveBookmarkProgress).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+    roots.splice(roots.indexOf(root), 1);
+    expect(mocks.saveFeedProgress).not.toHaveBeenCalled();
+    expect(mocks.saveBookmarkProgress).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/tests/unit/navigation/feed-item-action-revalidation.test.ts
+++ b/apps/app/tests/unit/navigation/feed-item-action-revalidation.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as Jotai from "jotai";
 import { useFeedItemActions } from "~/lib/hooks/useFeedItemActions";
 
 const mocks = vi.hoisted(() => ({
@@ -12,6 +13,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock("react", () => ({
   useCallback: <T extends (...args: never[]) => unknown>(callback: T) =>
     callback,
+}));
+vi.mock("jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof Jotai>()),
+  useAtomValue: () => "connected",
 }));
 vi.mock("@tanstack/react-router", () => ({
   useRouter: () => ({ navigate: vi.fn() }),
@@ -44,6 +49,7 @@ vi.mock("~/lib/data/store", () => ({
     isWatched: false,
     isWatchLater: true,
   }),
+  useHasRetainedFeedItemBody: () => false,
 }));
 vi.mock("~/lib/data/navigation/refreshOnLocalTransition", () => ({
   refreshNavigationAfterFeedItemChangeIfNeeded:

--- a/packages/ui/src/bookmark-editor.tsx
+++ b/packages/ui/src/bookmark-editor.tsx
@@ -47,6 +47,7 @@ export function BookmarkEditor({
   isDeleting,
   onDelete,
   onDone,
+  disabled = false,
 }: {
   bookmark: {
     title: string;
@@ -69,6 +70,7 @@ export function BookmarkEditor({
   isDeleting: boolean;
   onDelete: () => void | Promise<void>;
   onDone: () => void;
+  disabled?: boolean;
 }) {
   const showFeedback = shouldShowBookmarkEditorFeedback(feedback, bookmark);
   const feedbackPresentation =
@@ -135,6 +137,7 @@ export function BookmarkEditor({
           onCreate={onCreateView}
           createLabel="Create view"
           createPlaceholder="New view name..."
+          disabled={disabled}
         />
         <SelectableChipList
           label="Tags"
@@ -145,6 +148,7 @@ export function BookmarkEditor({
           onCreate={onCreateTag}
           createLabel="Create tag"
           createPlaceholder="New tag name..."
+          disabled={disabled}
         />
         {afterOrganization}
       </div>
@@ -153,7 +157,7 @@ export function BookmarkEditor({
         <Button
           variant="destructive"
           className="flex-1"
-          disabled={isDeleting}
+          disabled={disabled || isDeleting}
           aria-label="Delete Bookmark"
           onClick={() => void onDelete()}
         >

--- a/packages/ui/src/selectable-chip-list.tsx
+++ b/packages/ui/src/selectable-chip-list.tsx
@@ -38,6 +38,7 @@ type SelectableChipListProps = {
   createPlaceholder?: string;
   prioritizedIds?: ReadonlySet<number>;
   emptyMessage?: string;
+  disabled?: boolean;
 };
 
 const MAX_ROWS = 5;
@@ -81,6 +82,7 @@ export function SelectableChipList({
   createPlaceholder = `New ${label.toLowerCase().replace(/s$/, "")} name...`,
   prioritizedIds = new Set(),
   emptyMessage = `No ${label.toLowerCase()} available`,
+  disabled = false,
 }: SelectableChipListProps) {
   const [createOpen, setCreateOpen] = useState(false);
   const [createSearch, setCreateSearch] = useState("");
@@ -124,6 +126,7 @@ export function SelectableChipList({
   );
   const canCreate =
     Boolean(onCreate) &&
+    !disabled &&
     Boolean(trimmedCreateSearch) &&
     !hasExactCreateMatch &&
     !isCreating;
@@ -215,6 +218,7 @@ export function SelectableChipList({
                   size="icon"
                   className="size-6"
                   aria-label={createLabel}
+                  disabled={disabled}
                 >
                   <PlusIcon size={14} />
                 </Button>
@@ -302,6 +306,7 @@ export function SelectableChipList({
                 key={option.id}
                 type="button"
                 aria-pressed={isSelected}
+                disabled={disabled}
                 onClick={() => onToggle(option.id)}
                 className={cn(
                   badgeVariants({


### PR DESCRIPTION
- track explicit connection state and show the delayed offline banner
- retain eligible unread article bodies and bookmark captures for offline reading
- gate mutations and timed progress writes while preserving local navigation and content filters
- normalize and warm the service-worker navigation cache without caching failed responses
- render failed reader images as inert square fallbacks
- restore retained bodies and captures when optimistic Archive mutations fail
- serve the generated service worker through Nitro and exercise production PWA tests against the deployed server

Issue: https://github.com/megaflorasoftware/serial-agents/blob/main/agents/.scratch/offline-read-only-pwa/issues/01-implement-read-only-offline-pwa.md