### PR TITLE
Add atproto connection linking and management

### DIFF
--- a/apps/app/src/app/_app.tsx
+++ b/apps/app/src/app/_app.tsx
@@ -9,6 +9,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { CheckIcon } from "lucide-react";
 import { Suspense, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { AppDialogs } from "../components/feed/AppDialogs";
 import { Header } from "../components/feed/Header";
 import { GlobalImportDropzone } from "../components/feed/import/GlobalImportDropzone";
@@ -27,6 +28,7 @@ import { InitialClientQueries } from "~/lib/data/InitialClientQueries";
 import { loadingActor } from "~/lib/data/loading-machine";
 import { usePlanSuccessStore } from "~/lib/data/plan-success";
 import { useSubscription } from "~/lib/data/subscription";
+import { ATPROTO_LINK_RESULT_PARAM } from "~/lib/auth/atproto";
 import { useAltKeyHeld } from "~/lib/hooks/useAltKeyHeld";
 import { authMiddleware } from "~/server/auth";
 import { orpc, orpcRouterClient } from "~/lib/orpc";
@@ -178,6 +180,44 @@ function useCheckoutSuccess() {
   return { awaitingUpgrade, billingEnabled };
 }
 
+const ATPROTO_LINK_ERROR_MESSAGES: Record<string, string> = {
+  conflict: "That Atmosphere account is already connected to another user.",
+  exists:
+    "You already have an Atmosphere account connected. Disconnect it first.",
+};
+
+/**
+ * Detect the ?atproto_link= result param the AT Protocol link callback
+ * redirects back with, toast the outcome, and re-open the connections
+ * dialog so the user sees the connection's state.
+ */
+function useAtprotoLinkReturn() {
+  const launchDialog = useDialogStore((s) => s.launchDialog);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const result = params.get(ATPROTO_LINK_RESULT_PARAM);
+    if (!result) return;
+
+    // Clean the query param from the URL
+    params.delete(ATPROTO_LINK_RESULT_PARAM);
+    const newUrl =
+      window.location.pathname +
+      (params.size > 0 ? `?${params.toString()}` : "");
+    window.history.replaceState({}, "", newUrl);
+
+    if (result === "success") {
+      toast.success("Atmosphere account connected");
+    } else {
+      toast.error(
+        ATPROTO_LINK_ERROR_MESSAGES[result] ??
+          "Couldn't connect your Atmosphere account. Please try again.",
+      );
+    }
+    launchDialog("connections");
+  }, [launchDialog]);
+}
+
 /**
  * Detect ?subscription=open query param (set by the Polar portal return URL)
  * and re-open the subscription dialog.
@@ -244,6 +284,7 @@ function CheckoutSuccessDialog({
 function RootLayout() {
   useAltKeyHeld();
   usePortalReturn();
+  useAtprotoLinkReturn();
   const { pathname } = useLocation();
   const { awaitingUpgrade, billingEnabled } = useCheckoutSuccess();
   const showPlanSuccess = usePlanSuccessStore((s) => s.showDialog);

--- a/apps/app/src/components/ConnectionsDialog.tsx
+++ b/apps/app/src/components/ConnectionsDialog.tsx
@@ -1,12 +1,16 @@
 import { useState } from "react";
 import {
+  AtprotoConnectionForm,
+  AtprotoConnectionListItem,
+} from "./connections/AtprotoConnection";
+import {
   InstapaperConnectionForm,
   InstapaperConnectionListItem,
 } from "./connections/InstapaperConnection";
 import { ControlledResponsiveDialog } from "./ui/responsive-dropdown";
 import { useDialogStore } from "~/components/feed/dialogStore";
 
-type ConnectionView = "list" | "instapaper";
+type ConnectionView = "list" | "instapaper" | "atproto";
 
 function ConnectionsList({
   onSelectService,
@@ -15,12 +19,25 @@ function ConnectionsList({
 }) {
   return (
     <div className="grid gap-2">
+      <AtprotoConnectionListItem onSelect={() => onSelectService("atproto")} />
       <InstapaperConnectionListItem
         onSelect={() => onSelectService("instapaper")}
       />
     </div>
   );
 }
+
+const VIEW_TITLES: Record<ConnectionView, string> = {
+  list: "Connections",
+  instapaper: "Instapaper",
+  atproto: "Atmosphere",
+};
+
+const VIEW_DESCRIPTIONS: Record<ConnectionView, string> = {
+  list: "Manage your connected services",
+  instapaper: "Connect your Instapaper account",
+  atproto: "Connect your Atmosphere account",
+};
 
 export function ConnectionsDialog() {
   const [view, setView] = useState<ConnectionView>("list");
@@ -35,24 +52,19 @@ export function ConnectionsDialog() {
     }
   };
 
-  const title = view === "list" ? "Connections" : "Instapaper";
-  const description =
-    view === "list"
-      ? "Manage your connected services"
-      : "Connect your Instapaper account";
-
   return (
     <ControlledResponsiveDialog
       open={dialog === "connections"}
       onOpenChange={handleOpenChange}
-      title={title}
-      description={description}
+      title={VIEW_TITLES[view]}
+      description={VIEW_DESCRIPTIONS[view]}
       onBack={view !== "list" ? () => setView("list") : undefined}
     >
       {view === "list" && <ConnectionsList onSelectService={setView} />}
       {view === "instapaper" && (
         <InstapaperConnectionForm onSuccess={() => setView("list")} />
       )}
+      {view === "atproto" && <AtprotoConnectionForm />}
     </ControlledResponsiveDialog>
   );
 }

--- a/apps/app/src/components/connections/AtprotoConnection.tsx
+++ b/apps/app/src/components/connections/AtprotoConnection.tsx
@@ -71,6 +71,7 @@ export function AtprotoConnectionListItem({
 
   const computedStatus = status ?? {
     isConnected: false,
+    needsReconnect: false,
     handle: null,
     isConfigured: false,
   };
@@ -121,13 +122,21 @@ export function AtprotoConnectionListItem({
           <span className="text-muted-foreground text-sm">
             {computedStatus.handle}
           </span>
+        ) : computedStatus.needsReconnect ? (
+          // Credentials were lost (revoked at the PDS, failed refresh) but
+          // the sign-in method still exists: the row re-links on click and
+          // keeps its disconnect affordance.
+          <span className="text-muted-foreground text-sm">
+            Reconnect {computedStatus.handle}
+          </span>
         ) : (
           <span className="text-muted-foreground text-sm">Not connected</span>
         )}
       </div>
       {isLoading ? (
         <Loader2Icon className="text-muted-foreground animate-spin" size={20} />
-      ) : !computedStatus.isConfigured ? null : computedStatus.isConnected ? (
+      ) : !computedStatus.isConfigured ? null : computedStatus.isConnected ||
+        computedStatus.needsReconnect ? (
         <Button
           variant="outline"
           size="sm"

--- a/apps/app/src/components/connections/AtprotoConnection.tsx
+++ b/apps/app/src/components/connections/AtprotoConnection.tsx
@@ -1,0 +1,154 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronRightIcon, Loader2Icon, UnplugIcon } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { orpc } from "~/lib/orpc";
+
+export function AtprotoConnectionForm() {
+  const [handle, setHandle] = useState("");
+
+  const linkMutation = useMutation(
+    orpc.atproto.linkAccount.mutationOptions({
+      onSuccess: (data) => {
+        // Hand the browser to the authorization server; the link callback
+        // redirects back into the app with the result.
+        window.location.assign(data.url);
+      },
+      onError: (error) => {
+        toast.error(error.message || "Failed to connect Atmosphere account");
+      },
+    }),
+  );
+
+  return (
+    <form
+      className="grid gap-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        linkMutation.mutate({ identifier: handle });
+      }}
+    >
+      <div className="grid gap-2">
+        <Label htmlFor="atproto-handle">Handle</Label>
+        <Input
+          id="atproto-handle"
+          type="text"
+          value={handle}
+          placeholder="name.bsky.social"
+          onChange={(e) => setHandle(e.target.value)}
+          autoComplete="off"
+          autoCapitalize="none"
+          spellCheck={false}
+        />
+      </div>
+      <Button
+        type="submit"
+        disabled={linkMutation.isPending || !handle}
+      >
+        {linkMutation.isPending ? (
+          <Loader2Icon className="animate-spin" size={16} />
+        ) : (
+          "Connect"
+        )}
+      </Button>
+    </form>
+  );
+}
+
+export function AtprotoConnectionListItem({
+  onSelect,
+}: {
+  onSelect: () => void;
+}) {
+  const queryClient = useQueryClient();
+
+  const { data: status, isLoading } = useQuery(
+    orpc.atproto.getConnectionStatus.queryOptions(),
+  );
+
+  const computedStatus = status ?? {
+    isConnected: false,
+    handle: null,
+    isConfigured: false,
+  };
+
+  const unlinkMutation = useMutation(
+    orpc.atproto.unlinkAccount.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: orpc.atproto.getConnectionStatus.queryKey(),
+        });
+        toast.success("Atmosphere account disconnected");
+      },
+      onError: (error) => {
+        toast.error(error.message || "Failed to disconnect Atmosphere");
+      },
+    }),
+  );
+
+  const isClickable =
+    !isLoading && !status?.isConnected && status?.isConfigured;
+
+  return (
+    <div
+      role={isClickable ? "button" : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      onClick={isClickable ? onSelect : undefined}
+      onKeyDown={
+        isClickable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelect();
+              }
+            }
+          : undefined
+      }
+      className={`flex items-center justify-between rounded-lg border p-4 ${
+        isClickable ? "hover:bg-muted cursor-pointer transition-colors" : ""
+      }`}
+    >
+      <div className="flex flex-col">
+        <span className="font-medium">Atmosphere</span>
+        {isLoading ? (
+          <span className="text-muted-foreground text-sm">Loading...</span>
+        ) : !computedStatus.isConfigured ? (
+          <span className="text-muted-foreground text-sm">Not available</span>
+        ) : computedStatus.isConnected ? (
+          <span className="text-muted-foreground text-sm">
+            {computedStatus.handle}
+          </span>
+        ) : (
+          <span className="text-muted-foreground text-sm">Not connected</span>
+        )}
+      </div>
+      {isLoading ? (
+        <Loader2Icon className="text-muted-foreground animate-spin" size={20} />
+      ) : !computedStatus.isConfigured ? null : computedStatus.isConnected ? (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            unlinkMutation.mutate(undefined);
+          }}
+          disabled={unlinkMutation.isPending}
+        >
+          {unlinkMutation.isPending ? (
+            <Loader2Icon className="animate-spin" size={16} />
+          ) : (
+            <>
+              <UnplugIcon size={16} />
+              <span className="ml-1.5">Disconnect</span>
+            </>
+          )}
+        </Button>
+      ) : (
+        <ChevronRightIcon className="text-muted-foreground" size={20} />
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/components/connections/AtprotoConnection.tsx
+++ b/apps/app/src/components/connections/AtprotoConnection.tsx
@@ -144,6 +144,10 @@ export function AtprotoConnectionListItem({
             e.stopPropagation();
             unlinkMutation.mutate(undefined);
           }}
+          // In the reconnect state the row itself is clickable; keyboard
+          // activation must not bubble into its Enter/Space handler (which
+          // would preventDefault this button and open the link form).
+          onKeyDown={(e) => e.stopPropagation()}
           disabled={unlinkMutation.isPending}
         >
           {unlinkMutation.isPending ? (

--- a/apps/app/src/components/feed/UserProfileEditDialog/index.tsx
+++ b/apps/app/src/components/feed/UserProfileEditDialog/index.tsx
@@ -13,6 +13,7 @@ import { Label } from "~/components/ui/label";
 import { ControlledResponsiveDialog } from "~/components/ui/responsive-dropdown";
 import { IS_DEMO_INSTANCE } from "~/lib/demo";
 import { authClient } from "~/lib/auth-client";
+import { isAtprotoPlaceholderEmail } from "~/lib/auth/atproto";
 import { AUTH_RESET_PASSWORD_URL } from "~/lib/auth/constants";
 import { useUpdateNameMutation } from "~/lib/data/user/useUpdateNameMutation";
 import { userEmailSchema, userNameSchema } from "~/server/api/schemas";
@@ -30,7 +31,12 @@ export function UserProfileEditDialog() {
     launchDialog("edit-user-profile", { settingsPane: pane });
   };
 
-  const userEmail = data?.user.email ?? "";
+  // A DID-only (Atmosphere) user carries an internal placeholder email
+  // that is never surfaced: show the field empty and require a real email
+  // before a password can be set (the reset flow delivers by email).
+  const rawEmail = data?.user.email ?? "";
+  const hasRealEmail = !!rawEmail && !isAtprotoPlaceholderEmail(rawEmail);
+  const userEmail = hasRealEmail ? rawEmail : "";
 
   if (settingsPane === "export") {
     return (
@@ -105,16 +111,27 @@ export function UserProfileEditDialog() {
             />
             <div className="grid gap-2">
               <Label>Password</Label>
-              <Button variant="outline" asChild>
-                <Link
-                  to={AUTH_RESET_PASSWORD_URL}
-                  search={{
-                    email: userEmail,
-                  }}
-                >
-                  Update password
-                </Link>
-              </Button>
+              {hasRealEmail ? (
+                <Button variant="outline" asChild>
+                  <Link
+                    to={AUTH_RESET_PASSWORD_URL}
+                    search={{
+                      email: userEmail,
+                    }}
+                  >
+                    Update password
+                  </Link>
+                </Button>
+              ) : (
+                <>
+                  <Button variant="outline" disabled>
+                    Update password
+                  </Button>
+                  <p className="text-muted-foreground text-sm">
+                    Add an email address to set a password.
+                  </p>
+                </>
+              )}
             </div>
           </>
         )}

--- a/apps/app/src/components/feed/UserProfileEditDialog/index.tsx
+++ b/apps/app/src/components/feed/UserProfileEditDialog/index.tsx
@@ -102,6 +102,15 @@ export function UserProfileEditDialog() {
                   toast.error(error.message ?? "Failed to change email");
                   return "failed";
                 }
+                // Unverified users on instances without email transport get
+                // the change applied directly; everyone else gets the
+                // verification round trip.
+                const fresh = await authClient.getSession();
+                if (fresh.data?.user.email === updatedEmail) {
+                  void refetchUser();
+                  toast.success("Email updated.");
+                  return "saved";
+                }
                 toast.success(
                   "Verification email sent! Check your new inbox to confirm.",
                 );

--- a/apps/app/src/components/feed/UserProfileEditDialog/index.tsx
+++ b/apps/app/src/components/feed/UserProfileEditDialog/index.tsx
@@ -3,10 +3,12 @@
 import { Link } from "@tanstack/react-router";
 import { ChevronRightIcon, DownloadIcon, Trash2Icon } from "lucide-react";
 
+import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useDialogStore } from "../dialogStore";
 import { DeleteAccountSection } from "./DeleteAccountSection";
 import { ExportDataSection } from "./ExportDataSection";
+import { fetchIsForgotPasswordEnabled } from "~/server/auth/endpoints";
 import { EditableSavableTextField } from "~/components/form/EditableSavableTextField";
 import { Button } from "~/components/ui/button";
 import { Label } from "~/components/ui/label";
@@ -37,6 +39,14 @@ export function UserProfileEditDialog() {
   const rawEmail = data?.user.email ?? "";
   const hasRealEmail = !!rawEmail && !isAtprotoPlaceholderEmail(rawEmail);
   const userEmail = hasRealEmail ? rawEmail : "";
+
+  // Password changes go through the emailed reset flow, which the reset
+  // page refuses without transport — same gate the sign-in page puts on
+  // "Forgot your password?".
+  const { data: isPasswordResetAvailable } = useQuery({
+    queryKey: ["is-forgot-password-enabled"],
+    queryFn: () => fetchIsForgotPasswordEnabled(),
+  });
 
   if (settingsPane === "export") {
     return (
@@ -120,7 +130,9 @@ export function UserProfileEditDialog() {
             />
             <div className="grid gap-2">
               <Label>Password</Label>
-              {hasRealEmail ? (
+              {/* While availability is still loading, keep the link — the
+                  reset page itself degrades gracefully. */}
+              {hasRealEmail && isPasswordResetAvailable !== false ? (
                 <Button variant="outline" asChild>
                   <Link
                     to={AUTH_RESET_PASSWORD_URL}
@@ -137,7 +149,9 @@ export function UserProfileEditDialog() {
                     Update password
                   </Button>
                   <p className="text-muted-foreground text-sm">
-                    Add an email address to set a password.
+                    {hasRealEmail
+                      ? "Password reset is unavailable on this instance. Contact your admin to set a password."
+                      : "Add an email address to set a password."}
                   </p>
                 </>
               )}

--- a/apps/app/src/components/feed/UserProfileEditDialog/index.tsx
+++ b/apps/app/src/components/feed/UserProfileEditDialog/index.tsx
@@ -46,6 +46,8 @@ export function UserProfileEditDialog() {
   const { data: isPasswordResetAvailable } = useQuery({
     queryKey: ["is-forgot-password-enabled"],
     queryFn: () => fetchIsForgotPasswordEnabled(),
+    // Constant for the process lifetime (env-derived).
+    staleTime: Infinity,
   });
 
   if (settingsPane === "export") {

--- a/apps/app/src/lib/auth/atproto.ts
+++ b/apps/app/src/lib/auth/atproto.ts
@@ -1,0 +1,30 @@
+/**
+ * Client-safe AT Protocol auth constants shared between the server plugin
+ * and the UI. No env access — the server-side machinery lives under
+ * server/auth/atproto.
+ */
+
+/**
+ * Reserved domain of the deterministic internal placeholder email a
+ * DID-only user carries (see placeholderEmailForDid in
+ * server/auth/atproto/config). Never surfaced in UI and never deliverable.
+ */
+export const ATPROTO_PLACEHOLDER_EMAIL_DOMAIN = "atproto.invalid";
+
+/**
+ * Whether an email is the internal DID placeholder rather than a real,
+ * user-provided address. Email-dependent surfaces (password setup, the
+ * settings email field) treat a placeholder as "no email yet".
+ */
+export function isAtprotoPlaceholderEmail(email: string): boolean {
+  return email.endsWith(`@${ATPROTO_PLACEHOLDER_EMAIL_DOMAIN}`);
+}
+
+/**
+ * Query param the link callback redirects back into the app with, carrying
+ * one of the result codes below. The app shell toasts it and reopens the
+ * connections dialog, mirroring the Polar portal-return convention.
+ */
+export const ATPROTO_LINK_RESULT_PARAM = "atproto_link";
+
+export type AtprotoLinkResult = "success" | "conflict" | "exists" | "error";

--- a/apps/app/src/lib/constants.ts
+++ b/apps/app/src/lib/constants.ts
@@ -37,12 +37,13 @@ export const CREDENTIAL_PROVIDER_ID = "credential";
 export const ATPROTO_PROVIDER_ID = "atproto";
 
 /**
- * Per-admin sign-in methods derived from account rows, counting only
+ * Per-user sign-in methods derived from account rows, counting only
  * providers this instance has configured (env-dependent, so supplied by
- * the caller). Lockout accounting builds on this: a sign-in method may
- * not be disabled while it is some admin's only way in. Pure so both
- * admin config handlers share one accounting of which account rows count
- * as which method.
+ * the caller). Named for its original caller, admin lockout accounting (a
+ * sign-in method may not be disabled while it is some admin's only way
+ * in); the connection unlink guard shares it for the same question about
+ * any user. Pure so every guard shares one accounting of which account
+ * rows count as which method.
  */
 export function getAdminSigninMethods(options: {
   adminUserIds: string[];

--- a/apps/app/src/server/api/routers/atprotoRouter.ts
+++ b/apps/app/src/server/api/routers/atprotoRouter.ts
@@ -3,7 +3,8 @@ import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import {
   ATPROTO_PROVIDER_ID,
-  CREDENTIAL_PROVIDER_ID,
+  getAdminSigninMethods,
+  getEnabledAuthProviders,
 } from "~/lib/constants";
 import { identifierSchema } from "~/server/auth/atproto/schemas";
 import { getKV } from "~/server/kv";
@@ -12,7 +13,7 @@ import {
   isOAuthConfigured,
 } from "~/server/auth/constants";
 import { refreshEmailVerificationExempt } from "~/server/auth/email-verification-policy";
-import { account, atprotoConnections } from "~/server/db/schema";
+import { account, appConfig, atprotoConnections } from "~/server/db/schema";
 import { protectedProcedure } from "~/server/orpc/base";
 import { logError } from "~/server/logger";
 import { env } from "~/env";
@@ -27,22 +28,39 @@ import { env } from "~/env";
 
 export const getConnectionStatus = protectedProcedure.handler(
   async ({ context }) => {
-    const connection = await context.db.query.atprotoConnections.findFirst({
-      where: eq(atprotoConnections.userId, context.user.id),
-    });
+    const [connection, accountRow] = await Promise.all([
+      context.db.query.atprotoConnections.findFirst({
+        where: eq(atprotoConnections.userId, context.user.id),
+      }),
+      context.db
+        .select({ accountId: account.accountId })
+        .from(account)
+        .where(
+          and(
+            eq(account.userId, context.user.id),
+            eq(account.providerId, ATPROTO_PROVIDER_ID),
+          ),
+        )
+        .get(),
+    ]);
 
     const isConnected =
       !!connection && connection.status === "active" && !!connection.session;
-    // A bound row whose credentials were destroyed (failed refresh, grant
-    // revoked at the PDS, rotated store key): the atproto sign-in method
-    // still exists, so the row must surface reconnect and disconnect
+    // The sign-in method (the account row) can outlive its working
+    // credentials: a bound row whose blob was destroyed (failed refresh,
+    // grant revoked at the PDS, rotated store key) or a connection lost
+    // mid-unlink. Either way the row must surface reconnect and disconnect
     // affordances rather than a bare "not connected".
-    const needsReconnect = !!connection && !isConnected;
+    const needsReconnect = (!!connection || !!accountRow) && !isConnected;
 
     return {
       isConnected,
       needsReconnect,
-      handle: connection ? (connection.handle ?? connection.did) : null,
+      handle:
+        connection?.handle ??
+        connection?.did ??
+        accountRow?.accountId ??
+        null,
       isConfigured: isAtprotoConfigured(),
     };
   },
@@ -137,7 +155,11 @@ export const linkAccount = protectedProcedure
 
 export const unlinkAccount = protectedProcedure.handler(async ({ context }) => {
   const accountRows = await context.db
-    .select({ id: account.id, providerId: account.providerId })
+    .select({
+      id: account.id,
+      userId: account.userId,
+      providerId: account.providerId,
+    })
     .from(account)
     .where(eq(account.userId, context.user.id))
     .all();
@@ -152,16 +174,26 @@ export const unlinkAccount = protectedProcedure.handler(async ({ context }) => {
     return { success: true };
   }
 
-  // Refuse to remove the user's sole sign-in method: they need a password
-  // credential or a generic OAuth account on a still-configured provider
-  // to keep a way back in.
-  const hasCredential = accountRows.some(
-    (row) => row.providerId === CREDENTIAL_PROVIDER_ID,
+  // Refuse to remove the user's sole sign-in method. Methods are counted
+  // by the same shared accounting the admin lockout guard uses, then
+  // intersected with the enabled sign-in providers: a credential row is no
+  // way back in while email sign-in is switched off.
+  const signinConfig = await context.db
+    .select({ value: appConfig.value })
+    .from(appConfig)
+    .where(eq(appConfig.key, "enabled-signin-providers"))
+    .get();
+  const enabledProviders = getEnabledAuthProviders(signinConfig?.value);
+  const [methods = []] = getAdminSigninMethods({
+    adminUserIds: [context.user.id],
+    accountRows,
+    oauthProviderId: isOAuthConfigured() ? env.OAUTH_PROVIDER_ID : undefined,
+    atprotoConfigured: isAtprotoConfigured(),
+  });
+  const remainingMethods = methods.filter(
+    (method) => method !== "atproto" && enabledProviders.includes(method),
   );
-  const hasUsableOAuth =
-    isOAuthConfigured() &&
-    accountRows.some((row) => row.providerId === env.OAUTH_PROVIDER_ID);
-  if (atprotoRows.length > 0 && !hasCredential && !hasUsableOAuth) {
+  if (atprotoRows.length > 0 && remainingMethods.length === 0) {
     throw new ORPCError("PRECONDITION_FAILED", {
       message:
         "Atmosphere is your only way to sign in. Add a password before disconnecting it.",

--- a/apps/app/src/server/api/routers/atprotoRouter.ts
+++ b/apps/app/src/server/api/routers/atprotoRouter.ts
@@ -1,0 +1,134 @@
+import { ORPCError } from "@orpc/server";
+import { eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import { CREDENTIAL_PROVIDER_ID } from "~/lib/constants";
+import { ATPROTO_PROVIDER_ID } from "~/server/auth/atproto/config";
+import { identifierSchema } from "~/server/auth/atproto/schemas";
+import {
+  isAtprotoConfigured,
+  isOAuthConfigured,
+} from "~/server/auth/constants";
+import { refreshEmailVerificationExempt } from "~/server/auth/email-verification-policy";
+import { account, atprotoConnections } from "~/server/db/schema";
+import { protectedProcedure } from "~/server/orpc/base";
+import { logError } from "~/server/logger";
+import { env } from "~/env";
+
+/**
+ * The ConnectionsDialog surface for the AT Protocol connection: status,
+ * link start, and unlink. The OAuth round trip itself lives on the Better
+ * Auth plugin (server/auth/atproto/plugin.ts); linking starts here because
+ * it requires the caller's session, and the callback lands on the plugin's
+ * dedicated link-callback endpoint.
+ */
+
+export const getConnectionStatus = protectedProcedure.handler(
+  async ({ context }) => {
+    const connection = await context.db.query.atprotoConnections.findFirst({
+      where: eq(atprotoConnections.userId, context.user.id),
+    });
+
+    const isConnected =
+      !!connection && connection.status === "active" && !!connection.session;
+
+    return {
+      isConnected,
+      handle: isConnected ? (connection.handle ?? connection.did) : null,
+      isConfigured: isAtprotoConfigured(),
+    };
+  },
+);
+
+export const linkAccount = protectedProcedure
+  .input(z.object({ identifier: identifierSchema }))
+  .handler(async ({ context, input }) => {
+    if (!isAtprotoConfigured()) {
+      throw new ORPCError("PRECONDITION_FAILED", {
+        message: "Atmosphere is not available on this instance.",
+      });
+    }
+
+    const connection = await context.db.query.atprotoConnections.findFirst({
+      where: eq(atprotoConnections.userId, context.user.id),
+    });
+    if (connection && connection.status === "active" && !!connection.session) {
+      throw new ORPCError("CONFLICT", {
+        message:
+          "You already have an Atmosphere account connected. Disconnect it first.",
+      });
+    }
+
+    try {
+      // Dynamic import keeps the SDK off the module graph of unconfigured
+      // instances, matching the auth module's own pattern.
+      const { startAtprotoLink } = await import("~/server/auth/atproto/service");
+      const url = await startAtprotoLink({
+        identifier: input.identifier,
+        userId: context.user.id,
+      });
+      return { url: url.toString() };
+    } catch (err) {
+      logError("[atproto] link authorize failed:", err);
+      throw new ORPCError("BAD_REQUEST", {
+        message:
+          "Could not start the Atmosphere connection for that handle. Check the handle and try again.",
+      });
+    }
+  });
+
+export const unlinkAccount = protectedProcedure.handler(async ({ context }) => {
+  const accountRows = await context.db
+    .select({ id: account.id, providerId: account.providerId })
+    .from(account)
+    .where(eq(account.userId, context.user.id))
+    .all();
+  const atprotoRows = accountRows.filter(
+    (row) => row.providerId === ATPROTO_PROVIDER_ID,
+  );
+  const connection = await context.db.query.atprotoConnections.findFirst({
+    where: eq(atprotoConnections.userId, context.user.id),
+  });
+
+  if (atprotoRows.length === 0 && !connection) {
+    return { success: true };
+  }
+
+  // Refuse to remove the user's sole sign-in method: they need a password
+  // credential or a generic OAuth account on a still-configured provider
+  // to keep a way back in.
+  const hasCredential = accountRows.some(
+    (row) => row.providerId === CREDENTIAL_PROVIDER_ID,
+  );
+  const hasUsableOAuth =
+    isOAuthConfigured() &&
+    accountRows.some((row) => row.providerId === env.OAUTH_PROVIDER_ID);
+  if (atprotoRows.length > 0 && !hasCredential && !hasUsableOAuth) {
+    throw new ORPCError("PRECONDITION_FAILED", {
+      message:
+        "Atmosphere is your only way to sign in. Add a password before disconnecting it.",
+    });
+  }
+
+  if (connection) {
+    // Revoke the grant server-side and destroy the credential material,
+    // then release the row so the DID can be linked again later (the
+    // unbound row is swept once stale).
+    const { unlinkAtprotoConnection } =
+      await import("~/server/auth/atproto/service");
+    await unlinkAtprotoConnection(context.user.id);
+  }
+
+  if (atprotoRows.length > 0) {
+    await context.db.delete(account).where(
+      inArray(
+        account.id,
+        atprotoRows.map((row) => row.id),
+      ),
+    );
+    // Account deletion has no Better Auth database hook; recompute the
+    // email-verification exemption explicitly (fail-closed either way).
+    await refreshEmailVerificationExempt(context.db, context.user.id);
+  }
+
+  return { success: true };
+});

--- a/apps/app/src/server/api/routers/atprotoRouter.ts
+++ b/apps/app/src/server/api/routers/atprotoRouter.ts
@@ -1,9 +1,12 @@
 import { ORPCError } from "@orpc/server";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
-import { CREDENTIAL_PROVIDER_ID } from "~/lib/constants";
-import { ATPROTO_PROVIDER_ID } from "~/server/auth/atproto/config";
+import {
+  ATPROTO_PROVIDER_ID,
+  CREDENTIAL_PROVIDER_ID,
+} from "~/lib/constants";
 import { identifierSchema } from "~/server/auth/atproto/schemas";
+import { getKV } from "~/server/kv";
 import {
   isAtprotoConfigured,
   isOAuthConfigured,
@@ -39,6 +42,29 @@ export const getConnectionStatus = protectedProcedure.handler(
   },
 );
 
+/**
+ * Each link start fans out to identity resolution and writes an auth-state
+ * row with a 1-hour TTL, so it gets the same kind of budget the plugin
+ * puts on its authorize endpoint — here per user, since the procedure is
+ * session-required. The read-then-write window can undercount a burst
+ * slightly; this is an abuse ceiling, not an exact quota.
+ */
+const LINK_RATE_LIMIT_MAX_PER_WINDOW = 10;
+const LINK_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+async function enforceLinkRateLimit(userId: string): Promise<void> {
+  const kv = await getKV();
+  const window = Math.floor(Date.now() / (LINK_RATE_LIMIT_WINDOW_SECONDS * 1000));
+  const key = `atproto-link-rate:${userId}:${window}`;
+  const count = Number((await kv.get(key)) ?? "0");
+  if (count >= LINK_RATE_LIMIT_MAX_PER_WINDOW) {
+    throw new ORPCError("TOO_MANY_REQUESTS", {
+      message: "Too many connection attempts. Try again in a minute.",
+    });
+  }
+  await kv.set(key, String(count + 1), LINK_RATE_LIMIT_WINDOW_SECONDS * 2);
+}
+
 export const linkAccount = protectedProcedure
   .input(z.object({ identifier: identifierSchema }))
   .handler(async ({ context, input }) => {
@@ -47,11 +73,38 @@ export const linkAccount = protectedProcedure
         message: "Atmosphere is not available on this instance.",
       });
     }
+    await enforceLinkRateLimit(context.user.id);
 
     const connection = await context.db.query.atprotoConnections.findFirst({
       where: eq(atprotoConnections.userId, context.user.id),
     });
     if (connection && connection.status === "active" && !!connection.session) {
+      throw new ORPCError("CONFLICT", {
+        message:
+          "You already have an Atmosphere account connected. Disconnect it first.",
+      });
+    }
+
+    // A different DID already attached (even with a disconnected
+    // connection) would only fail at the callback with "exists", burning a
+    // real grant at the PDS. A typed handle can't be compared to the
+    // stored DID before resolution, so this blocks only the clear case;
+    // the callback stays the authoritative enforcement either way.
+    const existingAccount = await context.db
+      .select({ accountId: account.accountId })
+      .from(account)
+      .where(
+        and(
+          eq(account.userId, context.user.id),
+          eq(account.providerId, ATPROTO_PROVIDER_ID),
+        ),
+      )
+      .get();
+    if (
+      existingAccount &&
+      input.identifier.startsWith("did:") &&
+      existingAccount.accountId !== input.identifier
+    ) {
       throw new ORPCError("CONFLICT", {
         message:
           "You already have an Atmosphere account connected. Disconnect it first.",

--- a/apps/app/src/server/api/routers/atprotoRouter.ts
+++ b/apps/app/src/server/api/routers/atprotoRouter.ts
@@ -33,10 +33,16 @@ export const getConnectionStatus = protectedProcedure.handler(
 
     const isConnected =
       !!connection && connection.status === "active" && !!connection.session;
+    // A bound row whose credentials were destroyed (failed refresh, grant
+    // revoked at the PDS, rotated store key): the atproto sign-in method
+    // still exists, so the row must surface reconnect and disconnect
+    // affordances rather than a bare "not connected".
+    const needsReconnect = !!connection && !isConnected;
 
     return {
       isConnected,
-      handle: isConnected ? (connection.handle ?? connection.did) : null,
+      needsReconnect,
+      handle: connection ? (connection.handle ?? connection.did) : null,
       isConfigured: isAtprotoConfigured(),
     };
   },

--- a/apps/app/src/server/auth/atproto/config.ts
+++ b/apps/app/src/server/auth/atproto/config.ts
@@ -2,6 +2,7 @@ import { createHmac } from "node:crypto";
 import { JoseKey } from "@atproto/oauth-client-node";
 import { parseEncryptionKey } from "./crypto";
 import type { OAuthClientMetadataInput } from "@atproto/oauth-client-node";
+import { ATPROTO_PLACEHOLDER_EMAIL_DOMAIN } from "~/lib/auth/atproto";
 import { env } from "~/env";
 
 /**
@@ -45,6 +46,10 @@ export const ATPROTO_ROUTES = {
   jwks: `${ATPROTO_ROUTE_PREFIX}jwks.json`,
   authorize: `${ATPROTO_ROUTE_PREFIX}authorize`,
   callback: `${ATPROTO_ROUTE_PREFIX}callback`,
+  // Link flows land on their own registered redirect URI so the policy
+  // classifiers in server/auth/index.tsx (which gate the sign-in callback
+  // path) never treat an add-on link as a sign-in or roll it back.
+  linkCallback: `${ATPROTO_ROUTE_PREFIX}link-callback`,
 } as const;
 
 const AUTH_MOUNT = "/api/auth";
@@ -53,7 +58,20 @@ export const ATPROTO_PATHS = {
   clientMetadata: `${AUTH_MOUNT}${ATPROTO_ROUTES.clientMetadata}`,
   jwks: `${AUTH_MOUNT}${ATPROTO_ROUTES.jwks}`,
   callback: `${AUTH_MOUNT}${ATPROTO_ROUTES.callback}`,
+  linkCallback: `${AUTH_MOUNT}${ATPROTO_ROUTES.linkCallback}`,
 } as const;
+
+/**
+ * Absolute redirect URI of the link callback. authorize() defaults to the
+ * first registered redirect URI (the sign-in callback); link flows pass
+ * this one explicitly at both the authorize and the code-exchange leg.
+ */
+export function getAtprotoLinkRedirectUri(): `https://${string}` {
+  // PUBLIC_BASE_URL is always https-served where atproto is enabled (the
+  // authorization server refuses plain-http redirect URIs anyway); the
+  // assertion satisfies the SDK's template-literal redirect_uri type.
+  return `${baseUrl()}${ATPROTO_PATHS.linkCallback}` as `https://${string}`;
+}
 
 export function getAtprotoClientMetadata(): OAuthClientMetadataInput {
   const base = baseUrl();
@@ -61,7 +79,12 @@ export function getAtprotoClientMetadata(): OAuthClientMetadataInput {
     client_id: `${base}${ATPROTO_PATHS.clientMetadata}`,
     client_name: "Serial",
     client_uri: base,
-    redirect_uris: [`${base}${ATPROTO_PATHS.callback}`],
+    redirect_uris: [
+      // Order matters: the SDK defaults to the first entry, which must stay
+      // the sign-in callback.
+      `${base}${ATPROTO_PATHS.callback}`,
+      `${base}${ATPROTO_PATHS.linkCallback}`,
+    ],
     grant_types: ["authorization_code", "refresh_token"],
     response_types: ["code"],
     scope: ATPROTO_SCOPE,
@@ -175,5 +198,5 @@ export function placeholderEmailForDid(did: string): string {
     .update(did)
     .digest("hex")
     .slice(0, 16);
-  return `${sanitized}.${suffix}@atproto.invalid`;
+  return `${sanitized}.${suffix}@${ATPROTO_PLACEHOLDER_EMAIL_DOMAIN}`;
 }

--- a/apps/app/src/server/auth/atproto/plugin.ts
+++ b/apps/app/src/server/auth/atproto/plugin.ts
@@ -1,21 +1,31 @@
 import { z } from "zod";
-import { APIError, createAuthEndpoint } from "better-auth/api";
+import {
+  APIError,
+  createAuthEndpoint,
+  getSessionFromCtx,
+} from "better-auth/api";
 import { setSessionCookie } from "better-auth/cookies";
 import { handleOAuthUserInfo } from "better-auth/oauth2";
 import {
   ATPROTO_PROVIDER_ID,
   ATPROTO_ROUTE_PREFIX,
   ATPROTO_ROUTES,
+  getAtprotoLinkRedirectUri,
   placeholderEmailForDid,
   validateAtprotoConfigAtStartup,
 } from "./config";
 import { getAtprotoClient } from "./client";
+import { didSchema, identifierSchema } from "./schemas";
 import {
+  AtprotoLinkError,
   bindAtprotoConnection,
+  completeAtprotoLink,
   finishAtprotoAuth,
   startAtprotoAuth,
 } from "./service";
 import type { BetterAuthPlugin } from "better-auth";
+import type { AtprotoLinkResult } from "~/lib/auth/atproto";
+import { ATPROTO_LINK_RESULT_PARAM } from "~/lib/auth/atproto";
 import { logError } from "~/server/logger";
 
 /**
@@ -36,26 +46,13 @@ import { logError } from "~/server/logger";
 const SIGN_IN_ERROR_REDIRECT = "/auth/sign-in?error=atproto";
 const SIGN_IN_SUCCESS_REDIRECT = "/";
 
-// The SDK's resolver accepts full URLs and would fetch metadata from any
-// host an unauthenticated caller names. Sign-in only ever needs a DID or a
-// handle-shaped hostname, so everything else is rejected at the edge.
-const DID_PATTERN = /^did:[a-z]+:[a-zA-Z0-9._%:-]+$/;
-const HANDLE_PATTERN =
-  /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)+$/;
-
-const didSchema = z
-  .string()
-  .trim()
-  .max(512)
-  .regex(DID_PATTERN, "Not a valid DID");
-const identifierSchema = z
-  .string()
-  .trim()
-  .max(512)
-  .refine(
-    (value) => DID_PATTERN.test(value) || HANDLE_PATTERN.test(value),
-    "Enter a handle like name.bsky.social or a DID",
-  );
+/**
+ * Link flows return into the signed-in app rather than the auth pages; the
+ * app shell reads the result param, toasts it, and reopens the connections
+ * dialog.
+ */
+const linkResultRedirect = (result: AtprotoLinkResult) =>
+  `/?${ATPROTO_LINK_RESULT_PARAM}=${result}`;
 
 export const atprotoPlugin = () => {
   // Fail closed at startup on malformed config: the store key throws
@@ -175,6 +172,56 @@ export const atprotoPlugin = () => {
           throw ctx.redirect(SIGN_IN_SUCCESS_REDIRECT);
         },
       ),
+
+      /**
+       * Complete a link flow: attach the verified DID to the signed-in
+       * user as an add-on connection. Deliberately not classified by the
+       * policy hooks in server/auth/index.tsx — no user is created and no
+       * session is issued here, so sign-in gating and auto-signup rollback
+       * do not apply; the oRPC link procedure already required a session
+       * to start the flow.
+       */
+      atprotoLinkCallback: createAuthEndpoint(
+        ATPROTO_ROUTES.linkCallback,
+        { method: "GET" },
+        async (ctx) => {
+          const session = await getSessionFromCtx(ctx);
+          if (!session) {
+            throw ctx.redirect(linkResultRedirect("error"));
+          }
+
+          const url = new URL(ctx.request?.url ?? "http://invalid");
+          let result;
+          try {
+            result = await finishAtprotoAuth(url.searchParams, {
+              redirectUri: getAtprotoLinkRedirectUri(),
+            });
+          } catch (err) {
+            logError("[atproto] link callback failed:", err);
+            throw ctx.redirect(linkResultRedirect("error"));
+          }
+
+          try {
+            await completeAtprotoLink({
+              did: result.did,
+              grantedScope: result.grantedScope,
+              sessionUserId: session.user.id,
+              linkUserId: result.linkUserId,
+              createAccountRow: (data) =>
+                ctx.context.internalAdapter.createAccount(data),
+            });
+          } catch (err) {
+            logError("[atproto] link failed:", err);
+            const linkResult: AtprotoLinkResult =
+              err instanceof AtprotoLinkError && err.code !== "state"
+                ? err.code
+                : "error";
+            throw ctx.redirect(linkResultRedirect(linkResult));
+          }
+
+          throw ctx.redirect(linkResultRedirect("success"));
+        },
+      ),
     },
     rateLimit: [
       // Buckets are keyed per client IP and path. Authorize stays the
@@ -185,7 +232,9 @@ export const atprotoPlugin = () => {
         max: 30,
       },
       {
-        pathMatcher: (path: string) => path === ATPROTO_ROUTES.callback,
+        pathMatcher: (path: string) =>
+          path === ATPROTO_ROUTES.callback ||
+          path === ATPROTO_ROUTES.linkCallback,
         window: 60,
         max: 60,
       },

--- a/apps/app/src/server/auth/atproto/plugin.ts
+++ b/apps/app/src/server/auth/atproto/plugin.ts
@@ -21,6 +21,7 @@ import {
   bindAtprotoConnection,
   completeAtprotoLink,
   finishAtprotoAuth,
+  revokeAtprotoConnection,
   startAtprotoAuth,
 } from "./service";
 import type { BetterAuthPlugin } from "better-auth";
@@ -131,6 +132,15 @@ export const atprotoPlugin = () => {
             throw ctx.redirect(SIGN_IN_ERROR_REDIRECT);
           }
 
+          // A link flow's code can only be exchanged against the link
+          // redirect URI, so this should be unreachable — but sign-in and
+          // link state must never cross, and that invariant belongs to us,
+          // not the authorization server.
+          if (result.linkUserId) {
+            logError("[atproto] link state arrived on the sign-in callback");
+            throw ctx.redirect(SIGN_IN_ERROR_REDIRECT);
+          }
+
           const { did, handle } = result;
           const outcome = await handleOAuthUserInfo(ctx, {
             userInfo: {
@@ -212,6 +222,18 @@ export const atprotoPlugin = () => {
             });
           } catch (err) {
             logError("[atproto] link failed:", err);
+            const isConflict =
+              err instanceof AtprotoLinkError && err.code === "conflict";
+            // The code exchange already stored a live session for the DID.
+            // On every non-conflict failure the connection is unbound, so
+            // revoke it rather than leak an orphaned grant at the PDS. A
+            // conflict means the DID's row is bound to its existing owner
+            // and the fresh session now backs their connection — leave it.
+            if (!isConflict) {
+              await revokeAtprotoConnection(result.did).catch((revokeErr) =>
+                logError("[atproto] failed to revoke after link failure:", revokeErr),
+              );
+            }
             const linkResult: AtprotoLinkResult =
               err instanceof AtprotoLinkError && err.code !== "state"
                 ? err.code

--- a/apps/app/src/server/auth/atproto/plugin.ts
+++ b/apps/app/src/server/auth/atproto/plugin.ts
@@ -21,7 +21,7 @@ import {
   bindAtprotoConnection,
   completeAtprotoLink,
   finishAtprotoAuth,
-  revokeAtprotoConnection,
+  revokeAtprotoConnectionIfUnbound,
   startAtprotoAuth,
 } from "./service";
 import type { BetterAuthPlugin } from "better-auth";
@@ -222,18 +222,17 @@ export const atprotoPlugin = () => {
             });
           } catch (err) {
             logError("[atproto] link failed:", err);
-            const isConflict =
-              err instanceof AtprotoLinkError && err.code === "conflict";
             // The code exchange already stored a live session for the DID.
-            // On every non-conflict failure the connection is unbound, so
-            // revoke it rather than leak an orphaned grant at the PDS. A
-            // conflict means the DID's row is bound to its existing owner
-            // and the fresh session now backs their connection — leave it.
-            if (!isConflict) {
-              await revokeAtprotoConnection(result.did).catch((revokeErr) =>
-                logError("[atproto] failed to revoke after link failure:", revokeErr),
-              );
-            }
+            // When the failure leaves the connection unbound, revoke it
+            // rather than leak an orphaned grant at the PDS; a row bound
+            // to its owner is left alone (see the helper's rationale).
+            await revokeAtprotoConnectionIfUnbound(result.did).catch(
+              (revokeErr) =>
+                logError(
+                  "[atproto] failed to revoke after link failure:",
+                  revokeErr,
+                ),
+            );
             const linkResult: AtprotoLinkResult =
               err instanceof AtprotoLinkError && err.code !== "state"
                 ? err.code

--- a/apps/app/src/server/auth/atproto/schemas.ts
+++ b/apps/app/src/server/auth/atproto/schemas.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+/**
+ * Input validation shared by the plugin's authorize endpoint and the oRPC
+ * link procedure. The SDK's resolver accepts full URLs and would fetch
+ * metadata from any host a caller names; sign-in and linking only ever need
+ * a DID or a handle-shaped hostname, so everything else is rejected at the
+ * edge.
+ */
+
+export const DID_PATTERN = /^did:[a-z]+:[a-zA-Z0-9._%:-]+$/;
+export const HANDLE_PATTERN =
+  /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)+$/;
+
+export const didSchema = z
+  .string()
+  .trim()
+  .max(512)
+  .regex(DID_PATTERN, "Not a valid DID");
+
+export const identifierSchema = z
+  .string()
+  .trim()
+  .max(512)
+  .refine(
+    (value) => DID_PATTERN.test(value) || HANDLE_PATTERN.test(value),
+    "Enter a handle like name.bsky.social or a DID",
+  );

--- a/apps/app/src/server/auth/atproto/service.ts
+++ b/apps/app/src/server/auth/atproto/service.ts
@@ -1,8 +1,9 @@
-import { and, eq, isNull, or } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, lt, or } from "drizzle-orm";
 import { getAtprotoClient } from "./client";
 import {
   ATPROTO_PROVIDER_ID,
   ATPROTO_SCOPE,
+  AUTH_STATE_TTL_MS,
   getAtprotoLinkRedirectUri,
 } from "./config";
 import {
@@ -49,10 +50,36 @@ export async function startAtprotoAuth(input: {
 }): Promise<URL> {
   const client = await getAtprotoClient();
   // Opportunistic cleanup of expired attempts; never blocks the flow.
-  sweepExpiredAtprotoState(db).catch(captureException);
+  sweepStaleAtprotoConnections().catch(captureException);
   return client.authorize(input.identifier, {
     scope: input.scope ?? ATPROTO_SCOPE,
   });
+}
+
+/**
+ * Opportunistic cleanup: revoke stale unbound connections that still hold
+ * credentials (a link or sign-in whose callback completed the code
+ * exchange but never bound a user), then remove expired state and
+ * credential-free unbound rows. Revocation disconnects the row, so the
+ * store sweep can delete it once it goes stale again.
+ */
+async function sweepStaleAtprotoConnections(): Promise<void> {
+  const cutoff = new Date(Date.now() - AUTH_STATE_TTL_MS);
+  const orphans = await db
+    .select({ did: atprotoConnections.did })
+    .from(atprotoConnections)
+    .where(
+      and(
+        isNull(atprotoConnections.userId),
+        isNotNull(atprotoConnections.session),
+        lt(atprotoConnections.updatedAt, cutoff),
+      ),
+    )
+    .all();
+  for (const orphan of orphans) {
+    await revokeAtprotoConnection(orphan.did);
+  }
+  await sweepExpiredAtprotoState(db);
 }
 
 /**
@@ -182,7 +209,7 @@ export async function startAtprotoLink(input: {
   userId: string;
 }): Promise<URL> {
   const client = await getAtprotoClient();
-  sweepExpiredAtprotoState(db).catch(captureException);
+  sweepStaleAtprotoConnections().catch(captureException);
   return client.authorize(input.identifier, {
     scope: ATPROTO_SCOPE,
     state: JSON.stringify({ linkUserId: input.userId }),

--- a/apps/app/src/server/auth/atproto/service.ts
+++ b/apps/app/src/server/auth/atproto/service.ts
@@ -13,6 +13,7 @@ import {
 import type { OAuthSession } from "@atproto/oauth-client-node";
 import { db } from "~/server/db";
 import { account, atprotoConnections } from "~/server/db/schema";
+import { getKV } from "~/server/kv";
 import { captureException } from "~/server/logger";
 
 /**
@@ -56,14 +57,30 @@ export async function startAtprotoAuth(input: {
   });
 }
 
+/** At most one revocation sweep per interval, instance-wide via KV. */
+const SWEEP_INTERVAL_SECONDS = 5 * 60;
+/** Revocations are serial outbound calls; bound the batch per sweep. */
+const SWEEP_MAX_REVOCATIONS = 10;
+
 /**
  * Opportunistic cleanup: revoke stale unbound connections that still hold
  * credentials (a link or sign-in whose callback completed the code
  * exchange but never bound a user), then remove expired state and
  * credential-free unbound rows. Revocation disconnects the row, so the
- * store sweep can delete it once it goes stale again.
+ * store sweep can delete it once it goes stale again. Fires on the
+ * authorize paths, so it is throttled and bounded: revocations are
+ * network calls, and an authorization-server outage must not multiply
+ * them under concurrent sign-ins.
  */
 async function sweepStaleAtprotoConnections(): Promise<void> {
+  const kv = await getKV();
+  const acquired = await kv.setNX(
+    "atproto-connection-sweep",
+    "running",
+    SWEEP_INTERVAL_SECONDS,
+  );
+  if (!acquired) return;
+
   const cutoff = new Date(Date.now() - AUTH_STATE_TTL_MS);
   const orphans = await db
     .select({ did: atprotoConnections.did })
@@ -75,6 +92,7 @@ async function sweepStaleAtprotoConnections(): Promise<void> {
         lt(atprotoConnections.updatedAt, cutoff),
       ),
     )
+    .limit(SWEEP_MAX_REVOCATIONS)
     .all();
   for (const orphan of orphans) {
     await revokeAtprotoConnection(orphan.did);
@@ -327,6 +345,29 @@ export async function completeAtprotoLink(input: {
       err instanceof Error ? err.message : `Could not bind ${did}`,
     );
   }
+}
+
+/**
+ * Revoke a DID's stored session only when its connection row is unbound —
+ * the cleanup for a failed link or sign-in whose code exchange already
+ * stored credentials. A bound row is deliberately left alone: whoever
+ * completed that exchange authenticated as the DID at the PDS, the
+ * account row already maps the DID to its owning user for sign-in, and
+ * the freshly stored session is an equally valid credential for the same
+ * identity backing the owner's connection — revoking it would only break
+ * the owner (the SDK revokes the previous grant before the exchange, so
+ * there is no older session to fall back to).
+ */
+export async function revokeAtprotoConnectionIfUnbound(
+  did: string,
+): Promise<void> {
+  const row = await db
+    .select({ userId: atprotoConnections.userId })
+    .from(atprotoConnections)
+    .where(eq(atprotoConnections.did, did))
+    .get();
+  if (row && row.userId !== null) return;
+  await revokeAtprotoConnection(did);
 }
 
 /**

--- a/apps/app/src/server/auth/atproto/service.ts
+++ b/apps/app/src/server/auth/atproto/service.ts
@@ -1,13 +1,17 @@
 import { and, eq, isNull, or } from "drizzle-orm";
 import { getAtprotoClient } from "./client";
-import { ATPROTO_SCOPE } from "./config";
+import {
+  ATPROTO_PROVIDER_ID,
+  ATPROTO_SCOPE,
+  getAtprotoLinkRedirectUri,
+} from "./config";
 import {
   disconnectAtprotoConnection,
   sweepExpiredAtprotoState,
 } from "./stores";
 import type { OAuthSession } from "@atproto/oauth-client-node";
 import { db } from "~/server/db";
-import { atprotoConnections } from "~/server/db/schema";
+import { account, atprotoConnections } from "~/server/db/schema";
 import { captureException } from "~/server/logger";
 
 /**
@@ -26,6 +30,12 @@ export interface AtprotoCallbackResult {
   handle: string | null;
   /** The scope actually granted by the authorization server. */
   grantedScope: string;
+  /**
+   * The user a link flow was started for (from the server-stored app
+   * state), null for sign-in and upgrade flows. The link callback must
+   * verify it against the current session before attaching anything.
+   */
+  linkUserId: string | null;
 }
 
 /**
@@ -53,16 +63,28 @@ export async function startAtprotoAuth(input: {
  */
 export async function finishAtprotoAuth(
   params: URLSearchParams,
+  options?: {
+    /**
+     * The redirect URI this callback is being served on, when it is not
+     * the default sign-in callback (the SDK exchanges the code against the
+     * first registered redirect URI unless told otherwise).
+     */
+    redirectUri?: `https://${string}`;
+  },
 ): Promise<AtprotoCallbackResult> {
   const client = await getAtprotoClient();
-  const { session, state } = await client.callback(params);
+  const { session, state } = await client.callback(
+    params,
+    options?.redirectUri ? { redirect_uri: options.redirectUri } : undefined,
+  );
   const did = session.did;
+  const appState = parseAppState(state);
 
   // An upgrade flow pins the subject it re-consents for. If the user
   // switched accounts at the authorization server, destroy the session the
   // SDK just stored and fail — completing would swap the caller's Serial
   // session to a different user.
-  const expectedDid = parseExpectedDid(state);
+  const expectedDid = appState.expectedDid;
   if (expectedDid && expectedDid !== did) {
     await session.signOut().catch(captureException);
     throw new Error(
@@ -85,18 +107,39 @@ export async function finishAtprotoAuth(
     captureException(err);
   }
 
-  return { session, did, handle, grantedScope };
+  return {
+    session,
+    did,
+    handle,
+    grantedScope,
+    linkUserId: appState.linkUserId ?? null,
+  };
 }
 
-function parseExpectedDid(state: string | null): string | undefined {
-  if (!state) return undefined;
+/**
+ * The app state Serial threads through authorize(): `expectedDid` pins an
+ * upgrade's subject, `linkUserId` records who a link flow was started for.
+ * Stored server-side by the SDK's state store, so neither is forgeable
+ * from the callback URL.
+ */
+function parseAppState(state: string | null): {
+  expectedDid?: string;
+  linkUserId?: string;
+} {
+  if (!state) return {};
   try {
-    const parsed = JSON.parse(state) as { expectedDid?: unknown };
-    return typeof parsed.expectedDid === "string"
-      ? parsed.expectedDid
-      : undefined;
+    const parsed = JSON.parse(state) as {
+      expectedDid?: unknown;
+      linkUserId?: unknown;
+    };
+    return {
+      expectedDid:
+        typeof parsed.expectedDid === "string" ? parsed.expectedDid : undefined,
+      linkUserId:
+        typeof parsed.linkUserId === "string" ? parsed.linkUserId : undefined,
+    };
   } catch {
-    return undefined;
+    return {};
   }
 }
 
@@ -126,6 +169,158 @@ export async function bindAtprotoConnection(
   if (result.rowsAffected === 0) {
     throw new Error(`No bindable atproto connection for ${did}`);
   }
+}
+
+/**
+ * Begin a link flow for a signed-in user: same authorize round trip as
+ * sign-in, but the server-stored app state pins who it was started for and
+ * the redirect lands on the link callback, which the policy classifiers
+ * deliberately do not gate as a sign-in.
+ */
+export async function startAtprotoLink(input: {
+  identifier: string;
+  userId: string;
+}): Promise<URL> {
+  const client = await getAtprotoClient();
+  sweepExpiredAtprotoState(db).catch(captureException);
+  return client.authorize(input.identifier, {
+    scope: ATPROTO_SCOPE,
+    state: JSON.stringify({ linkUserId: input.userId }),
+    redirect_uri: getAtprotoLinkRedirectUri(),
+  });
+}
+
+/**
+ * A link attempt failed for a reason the user can act on. The code maps to
+ * the redirect result the app shell toasts: "conflict" when the DID belongs
+ * to a different Serial user, "exists" when this user already has a
+ * different Atmosphere account attached, "state" when the callback did not
+ * match the session that started the flow.
+ */
+export class AtprotoLinkError extends Error {
+  constructor(
+    public readonly code: "conflict" | "exists" | "state",
+    message: string,
+  ) {
+    super(message);
+    this.name = "AtprotoLinkError";
+  }
+}
+
+/**
+ * Attach a verified DID to the signed-in user: the account row (the key
+ * either-method sign-in resolves through) plus the connection binding. The
+ * account row is created through the caller-supplied adapter so Better
+ * Auth's database hooks fire (the email-verification exemption recompute).
+ * Conflicts never steal: a DID owned by another user and a second DID for
+ * the same user are both refused.
+ */
+export async function completeAtprotoLink(input: {
+  did: string;
+  grantedScope: string;
+  /** The signed-in user completing the callback. */
+  sessionUserId: string;
+  /** Who the flow was started for, from the server-stored app state. */
+  linkUserId: string | null;
+  createAccountRow: (data: {
+    userId: string;
+    providerId: string;
+    accountId: string;
+    scope: string;
+  }) => Promise<{ id: string }>;
+}): Promise<void> {
+  const { did, sessionUserId } = input;
+
+  if (!input.linkUserId || input.linkUserId !== sessionUserId) {
+    throw new AtprotoLinkError(
+      "state",
+      `Link callback for ${did} did not match the session that started it`,
+    );
+  }
+
+  const existingForDid = await db
+    .select({ id: account.id, userId: account.userId })
+    .from(account)
+    .where(
+      and(
+        eq(account.providerId, ATPROTO_PROVIDER_ID),
+        eq(account.accountId, did),
+      ),
+    )
+    .get();
+  if (existingForDid && existingForDid.userId !== sessionUserId) {
+    throw new AtprotoLinkError(
+      "conflict",
+      `${did} is already linked to another user`,
+    );
+  }
+
+  const existingForUser = await db
+    .select({ id: account.id, accountId: account.accountId })
+    .from(account)
+    .where(
+      and(
+        eq(account.userId, sessionUserId),
+        eq(account.providerId, ATPROTO_PROVIDER_ID),
+      ),
+    )
+    .get();
+  if (existingForUser && existingForUser.accountId !== did) {
+    throw new AtprotoLinkError(
+      "exists",
+      `User already has a different atproto account (${existingForUser.accountId})`,
+    );
+  }
+
+  let createdAccountId: string | null = null;
+  if (!existingForDid) {
+    const created = await input.createAccountRow({
+      userId: sessionUserId,
+      providerId: ATPROTO_PROVIDER_ID,
+      accountId: did,
+      scope: input.grantedScope,
+    });
+    createdAccountId = created.id;
+  }
+
+  try {
+    await bindAtprotoConnection(did, sessionUserId);
+  } catch (err) {
+    // A concurrent bind won the race for this DID. Remove the account row
+    // just created so a half-linked state can't power a later sign-in.
+    if (createdAccountId) {
+      try {
+        await db.delete(account).where(eq(account.id, createdAccountId));
+      } catch (cleanupErr) {
+        captureException(cleanupErr);
+      }
+    }
+    throw new AtprotoLinkError(
+      "conflict",
+      err instanceof Error ? err.message : `Could not bind ${did}`,
+    );
+  }
+}
+
+/**
+ * Sever a user's connection: revoke the grant (server-side and locally)
+ * and release the connection row so the DID can be linked again later.
+ * The unbound row is swept by sweepExpiredAtprotoState once stale. Returns
+ * whether a connection existed. Account-row policy (the sole-sign-in-method
+ * guard) belongs to the caller.
+ */
+export async function unlinkAtprotoConnection(userId: string): Promise<void> {
+  const row = await db
+    .select({ id: atprotoConnections.id, did: atprotoConnections.did })
+    .from(atprotoConnections)
+    .where(eq(atprotoConnections.userId, userId))
+    .get();
+  if (!row) return;
+  await revokeAtprotoConnection(row.did);
+  await db
+    .update(atprotoConnections)
+    .set({ userId: null, updatedAt: new Date() })
+    .where(eq(atprotoConnections.id, row.id));
 }
 
 /**

--- a/apps/app/src/server/auth/atproto/stores.ts
+++ b/apps/app/src/server/auth/atproto/stores.ts
@@ -164,6 +164,11 @@ export async function disconnectAtprotoConnection(
  * Remove expired authorization state and connection rows that finished the
  * OAuth callback but were never bound to a user (abandoned or rolled-back
  * sign-ups). Runs opportunistically when an authorize flow starts.
+ *
+ * Only credential-free rows are deleted: an unbound row whose session is
+ * still set holds the sole token able to revoke the PDS-side grant, and
+ * hard-deleting it would leak that grant forever. The service's sweep
+ * wrapper revokes those first (see sweepStaleAtprotoConnections).
  */
 export async function sweepExpiredAtprotoState(
   database: AtprotoDatabase,
@@ -177,6 +182,7 @@ export async function sweepExpiredAtprotoState(
     .where(
       and(
         isNull(atprotoConnections.userId),
+        isNull(atprotoConnections.session),
         lt(atprotoConnections.updatedAt, new Date(now - AUTH_STATE_TTL_MS)),
       ),
     );

--- a/apps/app/src/server/auth/classify.ts
+++ b/apps/app/src/server/auth/classify.ts
@@ -1,0 +1,57 @@
+import type { AuthAttempt, CompletedAuth } from "~/server/auth/policy";
+import { ATPROTO_ROUTES } from "~/server/auth/atproto/config";
+
+/**
+ * Classify a Better Auth request path into the explicit provider identity
+ * and intent the shared policy service consumes. OAuth-style providers
+ * (generic OAuth, atproto) gate as sign-in for both the start and callback
+ * paths; disallowed auto-signups are rolled back by the post-auth policy
+ * instead.
+ *
+ * The atproto link paths are deliberately unclassified: a link attaches a
+ * connection to an existing session, creates no user and issues no
+ * session, so neither sign-in gating nor auto-signup rollback may apply.
+ * Both matchers use exact equality so the link callback can never be
+ * swept in by a prefix match.
+ */
+export function classifyAuthRequest(
+  path: string,
+): Pick<AuthAttempt, "provider" | "intent"> | undefined {
+  if (path.startsWith("/sign-up")) {
+    return { provider: "email", intent: "sign-up" };
+  }
+  if (path === "/sign-in/email") {
+    return { provider: "email", intent: "sign-in" };
+  }
+  if (
+    path.startsWith("/sign-in/oauth2") ||
+    path.startsWith("/oauth2/callback/")
+  ) {
+    return { provider: "oauth", intent: "sign-in" };
+  }
+  if (path === ATPROTO_ROUTES.authorize || path === ATPROTO_ROUTES.callback) {
+    return { provider: "atproto", intent: "sign-in" };
+  }
+  return undefined;
+}
+
+/**
+ * Classify a Better Auth request path into the completed-flow identity the
+ * post-auth policy consumes. Only sign-up-capable paths return a value:
+ * email sign-up creates a user directly, and the OAuth callback may have
+ * auto-created one.
+ */
+export function classifyCompletedAuth(
+  path: string,
+): Pick<CompletedAuth, "provider" | "flow"> | undefined {
+  if (path.startsWith("/sign-up")) {
+    return { provider: "email", flow: "sign-up" };
+  }
+  if (path.startsWith("/oauth2/callback/")) {
+    return { provider: "oauth", flow: "callback" };
+  }
+  if (path === ATPROTO_ROUTES.callback) {
+    return { provider: "atproto", flow: "callback" };
+  }
+  return undefined;
+}

--- a/apps/app/src/server/auth/index.tsx
+++ b/apps/app/src/server/auth/index.tsx
@@ -24,6 +24,7 @@ import ResetPasswordEmail from "~/emails/reset-password";
 import VerifyEmailEmail from "~/emails/verify-email";
 import VerifyEmailChangeEmail from "~/emails/verify-email-change";
 import { BASE_SIGNED_OUT_URL } from "~/lib/constants";
+import { isAtprotoPlaceholderEmail } from "~/lib/auth/atproto";
 import {
   isAtprotoConfigured,
   isOAuthConfigured,
@@ -301,6 +302,15 @@ export const auth = betterAuth({
     enabled: true,
     maxPasswordLength: 64,
     async sendResetPassword(data) {
+      // A DID-only user's internal placeholder address is never
+      // deliverable; setting a password requires adding a real email
+      // first (the settings dialog enforces the same order).
+      if (isAtprotoPlaceholderEmail(data.user.email)) {
+        logMessage(
+          "[auth] Skipped reset password email for placeholder address",
+        );
+        return;
+      }
       try {
         const html = await render(
           <ResetPasswordEmail

--- a/apps/app/src/server/auth/index.tsx
+++ b/apps/app/src/server/auth/index.tsx
@@ -19,7 +19,6 @@ import {
   applySubscriptionSideEffects,
   syncPolarDataToKV,
 } from "../subscriptions/kv";
-import type { AuthAttempt, CompletedAuth } from "~/server/auth/policy";
 import ResetPasswordEmail from "~/emails/reset-password";
 import VerifyEmailEmail from "~/emails/verify-email";
 import VerifyEmailChangeEmail from "~/emails/verify-email-change";
@@ -30,8 +29,11 @@ import {
   isOAuthConfigured,
   TRUSTED_ORIGINS_SET,
 } from "~/server/auth/constants";
-import { ATPROTO_ROUTES } from "~/server/auth/atproto/config";
 import { atprotoPlugin } from "~/server/auth/atproto/plugin";
+import {
+  classifyAuthRequest,
+  classifyCompletedAuth,
+} from "~/server/auth/classify";
 import {
   refreshEmailVerificationExempt,
   requiresEmailVerification,
@@ -225,51 +227,6 @@ function buildAtprotoPlugin() {
   return [atprotoPlugin()];
 }
 
-// Classify a Better Auth request path into the explicit provider identity
-// and intent the shared policy service consumes. OAuth-style providers
-// (generic OAuth, atproto) gate as sign-in for both the start and callback
-// paths; disallowed auto-signups are rolled back by the post-auth policy
-// instead.
-function classifyAuthRequest(
-  path: string,
-): Pick<AuthAttempt, "provider" | "intent"> | undefined {
-  if (path.startsWith("/sign-up")) {
-    return { provider: "email", intent: "sign-up" };
-  }
-  if (path === "/sign-in/email") {
-    return { provider: "email", intent: "sign-in" };
-  }
-  if (
-    path.startsWith("/sign-in/oauth2") ||
-    path.startsWith("/oauth2/callback/")
-  ) {
-    return { provider: "oauth", intent: "sign-in" };
-  }
-  if (path === ATPROTO_ROUTES.authorize || path === ATPROTO_ROUTES.callback) {
-    return { provider: "atproto", intent: "sign-in" };
-  }
-  return undefined;
-}
-
-// Classify a Better Auth request path into the completed-flow identity the
-// post-auth policy consumes. Only sign-up-capable paths return a value:
-// email sign-up creates a user directly, and the OAuth callback may have
-// auto-created one.
-function classifyCompletedAuth(
-  path: string,
-): Pick<CompletedAuth, "provider" | "flow"> | undefined {
-  if (path.startsWith("/sign-up")) {
-    return { provider: "email", flow: "sign-up" };
-  }
-  if (path.startsWith("/oauth2/callback/")) {
-    return { provider: "oauth", flow: "callback" };
-  }
-  if (path === ATPROTO_ROUTES.callback) {
-    return { provider: "atproto", flow: "callback" };
-  }
-  return undefined;
-}
-
 // ctx.body is unvalidated request input; only pass the token through when it
 // is actually a string.
 function getInvitationToken(body: unknown): string | undefined {
@@ -343,7 +300,15 @@ export const auth = betterAuth({
       },
     },
     changeEmail: {
+      // Without email transport a verification round trip can never
+      // complete, which would leave a DID-only user unable to ever add a
+      // real email (and therefore a password). Apply an unverified user's
+      // change directly in that case — "verified when transport is
+      // configured" per the atproto onboarding decision. Verified users
+      // are unaffected: the option only applies when emailVerified is
+      // false.
       enabled: true,
+      updateEmailWithoutVerification: !IS_EMAIL_ENABLED,
     },
     deleteUser: {
       enabled: true,
@@ -360,6 +325,9 @@ export const auth = betterAuth({
   },
   emailVerification: {
     sendVerificationEmail: async ({ user, url }) => {
+      // Better Auth still invokes this after a direct (no-transport) email
+      // update; without a provider the send below would reject unhandled.
+      if (!IS_EMAIL_ENABLED) return;
       try {
         const html = await render(
           <VerifyEmailChangeEmail

--- a/apps/app/src/server/auth/policy.ts
+++ b/apps/app/src/server/auth/policy.ts
@@ -34,6 +34,14 @@ const SIGN_IN_DISABLED_MESSAGES: Record<AuthProvider, string> = {
 
 const SIGN_UPS_DISABLED_MESSAGE = "Sign ups are currently disabled";
 
+/**
+ * How recently a user must have been created for the callback rollback to
+ * treat them as auto-created by that same callback. Generous — the row is
+ * written milliseconds before the after-hook runs — while keeping any
+ * established account safely out of rollback's reach.
+ */
+const AUTO_SIGNUP_ROLLBACK_WINDOW_MS = 60 * 1000;
+
 export interface AuthAttempt {
   provider: AuthProvider;
   intent: "sign-in" | "sign-up";
@@ -196,16 +204,29 @@ export async function applyPostAuthPolicy(
       });
   } else if (completed.flow === "callback") {
     // Non-first user arriving via a callback — the provider may have
-    // auto-created a user. If this is a brand-new user (single session)
-    // and sign-ups for this provider aren't allowed, roll back the
-    // auto-created user.
+    // auto-created a user. Roll back only when this is genuinely that
+    // auto-created user: created within this request (creation recency)
+    // and holding no other session. Session count alone is not enough — an
+    // established user whose provider was linked as an add-on connection
+    // can arrive via callback with exactly one session (all others
+    // expired), and deleting them here would destroy a real account.
+    const userRow = await db
+      .select({ createdAt: user.createdAt })
+      .from(user)
+      .where(eq(user.id, userId))
+      .get();
+    const wasJustCreated =
+      !!userRow &&
+      Date.now() - userRow.createdAt.getTime() <=
+        AUTO_SIGNUP_ROLLBACK_WINDOW_MS;
+
     const sessionCount = await db
       .select({ count: count() })
       .from(session)
       .where(eq(session.userId, userId))
       .get();
 
-    if ((sessionCount?.count ?? 0) <= 1) {
+    if (wasJustCreated && (sessionCount?.count ?? 0) <= 1) {
       const configs = await db.select().from(appConfig).all();
       const publicSignupConfig = configs.find(
         (c) => c.key === "public-signup-enabled",

--- a/apps/app/src/server/orpc/router.ts
+++ b/apps/app/src/server/orpc/router.ts
@@ -2,6 +2,7 @@ import * as adminRouter from "~/server/api/routers/admin";
 import * as feedRouter from "~/server/api/routers/feed-router";
 import * as feedItemRouter from "~/server/api/routers/feedItemRouter";
 import * as initialRouter from "~/server/api/routers/initialRouter";
+import * as atprotoRouter from "~/server/api/routers/atprotoRouter";
 import * as instapaperRouter from "~/server/api/routers/instapaperRouter";
 import * as userConfigRouter from "~/server/api/routers/userConfigRouter";
 import * as userRouter from "~/server/api/routers/userRouter";
@@ -20,6 +21,7 @@ export const orpcRouter = {
   initial: initialRouter,
   userConfig: userConfigRouter,
   instapaper: instapaperRouter,
+  atproto: atprotoRouter,
   user: userRouter,
   feedCategories: feedCategoriesRouter,
   contentCategories: contentCategoriesRouter,

--- a/apps/app/tests/e2e/fixtures/seed-db.ts
+++ b/apps/app/tests/e2e/fixtures/seed-db.ts
@@ -47,6 +47,80 @@ export async function cleanupUser(tursoPort: number, email: string) {
   client.close();
 }
 
+/**
+ * Seed a linked AT Protocol connection for a user: the account row plus an
+ * active connection row, the state the link callback leaves behind. The
+ * stored session blob is deliberately unreadable ciphertext — unlink must
+ * still disconnect (mirroring a rotated store key).
+ */
+export async function seedAtprotoLink(
+  tursoPort: number,
+  email: string,
+  options: { did: string; handle: string },
+) {
+  const { db, client } = getDb(tursoPort);
+  const testUser = await db
+    .select({ id: schema.user.id })
+    .from(schema.user)
+    .where(eq(schema.user.email, email))
+    .get();
+  if (!testUser) {
+    client.close();
+    throw new Error("Atproto link seed user was not found");
+  }
+  const now = new Date();
+  await db.insert(schema.account).values({
+    id: createId(),
+    accountId: options.did,
+    providerId: "atproto",
+    userId: testUser.id,
+    scope: "atproto",
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(schema.atprotoConnections).values({
+    did: options.did,
+    userId: testUser.id,
+    session: "e2e-unreadable-ciphertext",
+    scopes: "atproto",
+    handle: options.handle,
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  });
+  client.close();
+}
+
+/** The database state the unlink assertions check. */
+export async function getAtprotoLinkState(tursoPort: number, did: string) {
+  const { db, client } = getDb(tursoPort);
+  const accountRows = await db
+    .select({ id: schema.account.id })
+    .from(schema.account)
+    .where(eq(schema.account.accountId, did))
+    .all();
+  const connection = await db
+    .select({
+      userId: schema.atprotoConnections.userId,
+      status: schema.atprotoConnections.status,
+      session: schema.atprotoConnections.session,
+    })
+    .from(schema.atprotoConnections)
+    .where(eq(schema.atprotoConnections.did, did))
+    .get();
+  client.close();
+  return { accountRowCount: accountRows.length, connection: connection ?? null };
+}
+
+/** Remove a seeded connection row (unlink leaves it unbound, not deleted). */
+export async function cleanupAtprotoConnection(tursoPort: number, did: string) {
+  const { db, client } = getDb(tursoPort);
+  await db
+    .delete(schema.atprotoConnections)
+    .where(eq(schema.atprotoConnections.did, did));
+  client.close();
+}
+
 export async function seedExtensionSession(tursoPort: number, email: string) {
   const { db, client } = getDb(tursoPort);
   const testUser = await db

--- a/apps/app/tests/e2e/self-hosted/connections-atproto.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/connections-atproto.spec.ts
@@ -1,0 +1,118 @@
+import { randomBytes } from "node:crypto";
+import { expect, test } from "@playwright/test";
+import { SELF_HOSTED_TURSO_PORT } from "../fixtures/ports";
+import {
+  cleanupAtprotoConnection,
+  cleanupUser,
+  generateTestEmail,
+  getAtprotoLinkState,
+  seedAtprotoLink,
+} from "../fixtures/seed-db";
+import { signUp } from "../fixtures/auth";
+
+/**
+ * The ConnectionsDialog surface for the AT Protocol connection. The full
+ * authorize round trip needs a real authorization server, so the link
+ * state is seeded directly (the rows the link callback leaves behind) and
+ * the dialog + unlink flow run end to end against the real app server.
+ */
+
+test.describe("atproto connection management", () => {
+  test.use({ viewport: { width: 1920, height: 1080 } });
+
+  let testEmail: string;
+  let did: string;
+
+  test.afterEach(async () => {
+    if (did) {
+      await cleanupAtprotoConnection(SELF_HOSTED_TURSO_PORT, did);
+    }
+    if (testEmail) {
+      await cleanupUser(SELF_HOSTED_TURSO_PORT, testEmail);
+    }
+  });
+
+  test("connection row, seeded link status, and disconnect", async ({
+    page,
+  }) => {
+    test.setTimeout(60000);
+    testEmail = generateTestEmail();
+    did = `did:plc:e2e${randomBytes(6).toString("hex")}`;
+    const handle = "linked.example.com";
+
+    await signUp({
+      page,
+      name: "Atmosphere Tester",
+      email: testEmail,
+      password: "password123",
+    });
+
+    const openConnections = async () => {
+      // The left sidebar is offcanvas until opened, and a pre-hydration
+      // click on the toggle is swallowed — retry until the user menu is
+      // actually reachable.
+      const userButton = page
+        .getByRole("button", { name: /Atmosphere Tester/ })
+        .first();
+      const userButtonInViewport = async () => {
+        const box = await userButton.boundingBox();
+        return !!box && box.x >= 0;
+      };
+      await expect(async () => {
+        if (!(await userButtonInViewport())) {
+          await page.getByRole("button", { name: "Menu" }).click();
+        }
+        await expect(userButton).toBeInViewport({ timeout: 2000 });
+      }).toPass({ timeout: 20000, intervals: [500, 1000, 2000] });
+      await userButton.click();
+      await page.getByRole("menuitem", { name: "Connections" }).click();
+      await expect(
+        page.getByText("Manage your connected services"),
+      ).toBeVisible();
+    };
+
+    // Not yet linked: the Atmosphere row is configured and clickable, and
+    // opens the handle entry form.
+    await openConnections();
+    const atmosphereRow = page
+      .locator("div")
+      .filter({ has: page.getByText("Atmosphere", { exact: true }) })
+      .filter({ hasText: "Not connected" })
+      .last();
+    await expect(atmosphereRow).toBeVisible();
+    await atmosphereRow.click();
+    await expect(page.getByLabel("Handle")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Connect" })).toBeDisabled();
+    await page.keyboard.press("Escape");
+
+    // Linked (seeded): the row shows the current handle with a disconnect
+    // affordance.
+    await seedAtprotoLink(SELF_HOSTED_TURSO_PORT, testEmail, { did, handle });
+    // Drop the persisted query cache so the seeded state is refetched.
+    await page.evaluate(() => {
+      try {
+        localStorage.removeItem("REACT_QUERY_OFFLINE_CACHE");
+      } catch {
+        // localStorage may not be available in some contexts
+      }
+    });
+    await page.reload();
+    await openConnections();
+    await expect(page.getByText(handle)).toBeVisible();
+
+    // Disconnect: removes the sign-in method and destroys the credential
+    // material even though the seeded blob is unreadable ciphertext.
+    await page.getByRole("button", { name: /disconnect/i }).first().click();
+    await expect(page.getByText("Atmosphere account disconnected")).toBeVisible(
+      { timeout: 10000 },
+    );
+    await expect(page.getByText("Not connected").first()).toBeVisible();
+
+    await expect
+      .poll(async () => getAtprotoLinkState(SELF_HOSTED_TURSO_PORT, did))
+      .toMatchObject({
+        accountRowCount: 0,
+        connection: { userId: null, status: "disconnected", session: null },
+      });
+  });
+});

--- a/apps/app/tests/e2e/self-hosted/connections-atproto.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/connections-atproto.spec.ts
@@ -98,7 +98,10 @@ test.describe("atproto connection management", () => {
     });
     await page.reload();
     await openConnections();
-    await expect(page.getByText(handle)).toBeVisible();
+    // The persisted-cache restore can serve the stale "not connected"
+    // status first; the on-mount refetch replaces it (slowly under
+    // parallel-worker load).
+    await expect(page.getByText(handle)).toBeVisible({ timeout: 15000 });
 
     // Disconnect: removes the sign-in method and destroys the credential
     // material even though the seeded blob is unreadable ciphertext.

--- a/apps/app/tests/unit/auth/atproto-callback.test.ts
+++ b/apps/app/tests/unit/auth/atproto-callback.test.ts
@@ -111,7 +111,30 @@ describe("finishAtprotoAuth", () => {
     expect(result.did).toBe(DID);
     expect(result.handle).toBe("reader.bsky.social");
     expect(result.grantedScope).toBe("atproto");
+    expect(result.linkUserId).toBeNull();
     expect((await connectionRow())?.handle).toBe("reader.bsky.social");
+  });
+
+  it("surfaces the link state's user and passes the redirect URI through", async () => {
+    const oauth = oauthSession(DID);
+    const callback = vi
+      .fn()
+      .mockResolvedValue({
+        session: oauth,
+        state: JSON.stringify({ linkUserId: "user-1" }),
+      });
+    clientHolder.current = fakeClient({ callback });
+
+    const result = await finishAtprotoAuth(new URLSearchParams("code=abc"), {
+      redirectUri: "https://serial.test/api/auth/atproto/link-callback",
+    });
+
+    expect(result.linkUserId).toBe("user-1");
+    // The code exchange must run against the link redirect URI, not the
+    // default sign-in callback.
+    expect(callback).toHaveBeenCalledWith(expect.any(URLSearchParams), {
+      redirect_uri: "https://serial.test/api/auth/atproto/link-callback",
+    });
   });
 
   it("surfaces a failed callback validation and persists nothing", async () => {

--- a/apps/app/tests/unit/auth/atproto-link.test.ts
+++ b/apps/app/tests/unit/auth/atproto-link.test.ts
@@ -1,0 +1,271 @@
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyMigrations,
+  createLocalBenchmarkTarget,
+  openBenchmarkDatabase,
+} from "../../../scripts/performance/database";
+import { account, atprotoConnections, user } from "~/server/db/schema";
+
+/**
+ * The add-on link boundary: completeAtprotoLink must attach a DID only to
+ * the session user the flow was started for, never steal a DID from
+ * another user, and never leave a half-linked state (an account row
+ * without a bound connection) behind. unlinkAtprotoConnection must revoke
+ * and release the connection so the DID can be linked again.
+ */
+
+const dbHolder = vi.hoisted(() => {
+  const holder: { current: unknown } = { current: undefined };
+  return holder;
+});
+
+const revokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/server/db", () => ({
+  get db() {
+    return dbHolder.current;
+  },
+}));
+
+vi.mock("~/server/auth/atproto/client", () => ({
+  getAtprotoClient: async () => ({ revoke: revokeMock }),
+}));
+
+const { AtprotoLinkError, completeAtprotoLink, unlinkAtprotoConnection } =
+  await import("~/server/auth/atproto/service");
+
+type Session = ReturnType<typeof openBenchmarkDatabase>;
+type Target = ReturnType<typeof createLocalBenchmarkTarget>;
+
+const DID = "did:plc:linkme";
+const OTHER_DID = "did:plc:other";
+
+describe("atproto link and unlink", () => {
+  let session: Session;
+  let target: Target;
+
+  beforeEach(async () => {
+    target = createLocalBenchmarkTarget();
+    session = openBenchmarkDatabase({ url: target.url });
+    await applyMigrations(session.baseClient);
+    dbHolder.current = session.database;
+    revokeMock.mockReset();
+
+    for (const id of ["user-1", "user-2"]) {
+      await session.database.insert(user).values({
+        id,
+        name: id,
+        email: `${id}@example.com`,
+        emailVerified: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    }
+    // The connection row the OAuth callback's session store already wrote.
+    await session.database.insert(atprotoConnections).values({
+      did: DID,
+      session: "ciphertext",
+      scopes: "atproto",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  });
+
+  afterEach(() => {
+    session.close();
+    target.cleanup();
+    dbHolder.current = undefined;
+  });
+
+  function insertAccountRow(id: string, userId: string, accountId: string) {
+    return session.database.insert(account).values({
+      id,
+      accountId,
+      providerId: "atproto",
+      userId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  function createAccountRow(id: string) {
+    return async (data: {
+      userId: string;
+      providerId: string;
+      accountId: string;
+      scope: string;
+    }) => {
+      await session.database.insert(account).values({
+        id,
+        accountId: data.accountId,
+        providerId: data.providerId,
+        userId: data.userId,
+        scope: data.scope,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      return { id };
+    };
+  }
+
+  async function accountRows() {
+    return session.database.select().from(account).all();
+  }
+
+  async function connectionRow() {
+    const rows = await session.database
+      .select()
+      .from(atprotoConnections)
+      .where(eq(atprotoConnections.did, DID))
+      .all();
+    return rows[0];
+  }
+
+  it("links a DID to the session user: account row plus bound connection", async () => {
+    await completeAtprotoLink({
+      did: DID,
+      grantedScope: "atproto",
+      sessionUserId: "user-1",
+      linkUserId: "user-1",
+      createAccountRow: createAccountRow("acc-1"),
+    });
+
+    const rows = await accountRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      providerId: "atproto",
+      accountId: DID,
+      userId: "user-1",
+    });
+    expect((await connectionRow())?.userId).toBe("user-1");
+  });
+
+  it("rejects a callback whose stored state names a different user", async () => {
+    const create = vi.fn();
+    await expect(
+      completeAtprotoLink({
+        did: DID,
+        grantedScope: "atproto",
+        sessionUserId: "user-2",
+        linkUserId: "user-1",
+        createAccountRow: create,
+      }),
+    ).rejects.toMatchObject({ code: "state" });
+    expect(create).not.toHaveBeenCalled();
+    expect(await accountRows()).toHaveLength(0);
+  });
+
+  it("rejects a callback with no link state at all", async () => {
+    await expect(
+      completeAtprotoLink({
+        did: DID,
+        grantedScope: "atproto",
+        sessionUserId: "user-1",
+        linkUserId: null,
+        createAccountRow: vi.fn(),
+      }),
+    ).rejects.toBeInstanceOf(AtprotoLinkError);
+  });
+
+  it("refuses a DID already linked to another user", async () => {
+    await insertAccountRow("acc-other", "user-2", DID);
+    await expect(
+      completeAtprotoLink({
+        did: DID,
+        grantedScope: "atproto",
+        sessionUserId: "user-1",
+        linkUserId: "user-1",
+        createAccountRow: vi.fn(),
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+  });
+
+  it("refuses a second DID for a user with one already linked", async () => {
+    await insertAccountRow("acc-existing", "user-1", OTHER_DID);
+    await expect(
+      completeAtprotoLink({
+        did: DID,
+        grantedScope: "atproto",
+        sessionUserId: "user-1",
+        linkUserId: "user-1",
+        createAccountRow: vi.fn(),
+      }),
+    ).rejects.toMatchObject({ code: "exists" });
+  });
+
+  it("re-linking the same DID does not create a second account row", async () => {
+    await insertAccountRow("acc-1", "user-1", DID);
+    const create = vi.fn();
+    await completeAtprotoLink({
+      did: DID,
+      grantedScope: "atproto",
+      sessionUserId: "user-1",
+      linkUserId: "user-1",
+      createAccountRow: create,
+    });
+    expect(create).not.toHaveBeenCalled();
+    expect(await accountRows()).toHaveLength(1);
+    expect((await connectionRow())?.userId).toBe("user-1");
+  });
+
+  it("removes the created account row when the connection bind loses a race", async () => {
+    // The connection was bound to another user between callback and link.
+    await session.database
+      .update(atprotoConnections)
+      .set({ userId: "user-2" })
+      .where(eq(atprotoConnections.did, DID));
+
+    await expect(
+      completeAtprotoLink({
+        did: DID,
+        grantedScope: "atproto",
+        sessionUserId: "user-1",
+        linkUserId: "user-1",
+        createAccountRow: createAccountRow("acc-1"),
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+    // No half-linked state: the just-created account row is gone.
+    expect(await accountRows()).toHaveLength(0);
+  });
+
+  it("unlink revokes, destroys credentials, and releases the connection", async () => {
+    await completeAtprotoLink({
+      did: DID,
+      grantedScope: "atproto",
+      sessionUserId: "user-1",
+      linkUserId: "user-1",
+      createAccountRow: createAccountRow("acc-1"),
+    });
+
+    await unlinkAtprotoConnection("user-1");
+
+    expect(revokeMock).toHaveBeenCalledWith(DID);
+    const row = await connectionRow();
+    // Credential material destroyed (restore(did) has nothing to load) and
+    // the row released so the DID can be linked again later.
+    expect(row?.session).toBeNull();
+    expect(row?.status).toBe("disconnected");
+    expect(row?.userId).toBeNull();
+  });
+
+  it("unlink still releases the connection when server-side revoke fails", async () => {
+    await session.database
+      .update(atprotoConnections)
+      .set({ userId: "user-1" })
+      .where(eq(atprotoConnections.did, DID));
+    revokeMock.mockRejectedValueOnce(new Error("authorization server down"));
+
+    await unlinkAtprotoConnection("user-1");
+
+    const row = await connectionRow();
+    expect(row?.session).toBeNull();
+    expect(row?.userId).toBeNull();
+  });
+
+  it("unlink is a no-op for a user with no connection", async () => {
+    await expect(unlinkAtprotoConnection("user-2")).resolves.toBeUndefined();
+    expect(revokeMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/tests/unit/auth/atproto-link.test.ts
+++ b/apps/app/tests/unit/auth/atproto-link.test.ts
@@ -47,6 +47,7 @@ vi.mock("~/env", () => ({
 const {
   AtprotoLinkError,
   completeAtprotoLink,
+  revokeAtprotoConnectionIfUnbound,
   startAtprotoLink,
   unlinkAtprotoConnection,
 } = await import("~/server/auth/atproto/service");
@@ -283,6 +284,23 @@ describe("atproto link and unlink", () => {
   it("unlink is a no-op for a user with no connection", async () => {
     await expect(unlinkAtprotoConnection("user-2")).resolves.toBeUndefined();
     expect(revokeMock).not.toHaveBeenCalled();
+  });
+
+  it("conditional revoke destroys an unbound connection's credentials", async () => {
+    await revokeAtprotoConnectionIfUnbound(DID);
+    expect(revokeMock).toHaveBeenCalledWith(DID);
+    expect((await connectionRow())?.session).toBeNull();
+  });
+
+  it("conditional revoke leaves a bound connection alone", async () => {
+    await session.database
+      .update(atprotoConnections)
+      .set({ userId: "user-2" })
+      .where(eq(atprotoConnections.did, DID));
+
+    await revokeAtprotoConnectionIfUnbound(DID);
+    expect(revokeMock).not.toHaveBeenCalled();
+    expect((await connectionRow())?.session).toBe("ciphertext");
   });
 
   it("starting a flow revokes stale unbound connections still holding credentials", async () => {

--- a/apps/app/tests/unit/auth/atproto-link.test.ts
+++ b/apps/app/tests/unit/auth/atproto-link.test.ts
@@ -21,6 +21,7 @@ const dbHolder = vi.hoisted(() => {
 });
 
 const revokeMock = vi.hoisted(() => vi.fn());
+const authorizeMock = vi.hoisted(() => vi.fn());
 
 vi.mock("~/server/db", () => ({
   get db() {
@@ -29,11 +30,26 @@ vi.mock("~/server/db", () => ({
 }));
 
 vi.mock("~/server/auth/atproto/client", () => ({
-  getAtprotoClient: async () => ({ revoke: revokeMock }),
+  getAtprotoClient: async () => ({
+    revoke: revokeMock,
+    authorize: authorizeMock,
+  }),
 }));
 
-const { AtprotoLinkError, completeAtprotoLink, unlinkAtprotoConnection } =
-  await import("~/server/auth/atproto/service");
+// startAtprotoLink derives its redirect URI from the public base URL.
+vi.mock("~/env", () => ({
+  env: {
+    PUBLIC_BASE_URL: "https://serial.test",
+    BETTER_AUTH_SECRET: "test-secret",
+  },
+}));
+
+const {
+  AtprotoLinkError,
+  completeAtprotoLink,
+  startAtprotoLink,
+  unlinkAtprotoConnection,
+} = await import("~/server/auth/atproto/service");
 
 type Session = ReturnType<typeof openBenchmarkDatabase>;
 type Target = ReturnType<typeof createLocalBenchmarkTarget>;
@@ -267,5 +283,23 @@ describe("atproto link and unlink", () => {
   it("unlink is a no-op for a user with no connection", async () => {
     await expect(unlinkAtprotoConnection("user-2")).resolves.toBeUndefined();
     expect(revokeMock).not.toHaveBeenCalled();
+  });
+
+  it("starting a flow revokes stale unbound connections still holding credentials", async () => {
+    // A link whose callback stored a session but never bound a user, now
+    // past the auth-state TTL.
+    await session.database
+      .update(atprotoConnections)
+      .set({ updatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000) })
+      .where(eq(atprotoConnections.did, DID));
+    authorizeMock.mockResolvedValue(new URL("https://pds.example/authorize"));
+
+    await startAtprotoLink({ identifier: "user.example.com", userId: "user-1" });
+    // The sweep is fire-and-forget; give it a beat.
+    await vi.waitFor(() => expect(revokeMock).toHaveBeenCalledWith(DID));
+
+    const row = await connectionRow();
+    expect(row?.session).toBeNull();
+    expect(row?.status).toBe("disconnected");
   });
 });

--- a/apps/app/tests/unit/auth/atproto-stores.test.ts
+++ b/apps/app/tests/unit/auth/atproto-stores.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   createAtprotoSessionStore,
   createAtprotoStateStore,
+  disconnectAtprotoConnection,
   sweepExpiredAtprotoState,
 } from "~/server/auth/atproto/stores";
 import { atprotoAuthState, atprotoConnections, user } from "~/server/db/schema";
@@ -307,11 +308,22 @@ describe("atproto database stores", () => {
         .update(atprotoConnections)
         .set({ userId: "user-1", updatedAt: staleDate })
         .where(eq(atprotoConnections.did, DID));
+      // A stale unbound row that STILL holds credentials must survive: its
+      // session is the only token able to revoke the PDS-side grant, and
+      // the service-level sweep revokes it before this deletion applies.
       await sessionStore.set(OTHER_DID, savedSession());
       await database
         .update(atprotoConnections)
         .set({ updatedAt: staleDate })
         .where(eq(atprotoConnections.did, OTHER_DID));
+      // A stale unbound row whose credentials are already destroyed is
+      // deletable garbage.
+      await sessionStore.set("did:plc:revokedorphan", savedSession());
+      await disconnectAtprotoConnection(database, "did:plc:revokedorphan");
+      await database
+        .update(atprotoConnections)
+        .set({ updatedAt: staleDate })
+        .where(eq(atprotoConnections.did, "did:plc:revokedorphan"));
 
       await sweepExpiredAtprotoState(database);
 
@@ -323,8 +335,9 @@ describe("atproto database stores", () => {
       const dids = (await database.select().from(atprotoConnections).all()).map(
         (r) => r.did,
       );
-      expect(dids).toHaveLength(1);
+      expect(dids).toHaveLength(2);
       expect(dids).toContain(DID);
+      expect(dids).toContain(OTHER_DID);
     });
   });
 });

--- a/apps/app/tests/unit/auth/atproto-unlink-guard.test.ts
+++ b/apps/app/tests/unit/auth/atproto-unlink-guard.test.ts
@@ -137,9 +137,32 @@ describe("atproto connection procedures", () => {
     const status = await api().atproto.getConnectionStatus();
     expect(status).toEqual({
       isConnected: true,
+      needsReconnect: false,
       handle: "guarded.example.com",
       isConfigured: true,
     });
+  });
+
+  it("surfaces a bound connection whose credentials were destroyed as reconnectable", async () => {
+    await seedLinked({ extraProviderId: "credential" });
+    await session.database
+      .update(atprotoConnections)
+      .set({ session: null, status: "disconnected" })
+      .where(eq(atprotoConnections.did, DID));
+
+    const status = await api().atproto.getConnectionStatus();
+    expect(status).toEqual({
+      isConnected: false,
+      needsReconnect: true,
+      handle: "guarded.example.com",
+      isConfigured: true,
+    });
+
+    // The sign-in method still exists, so disconnect must work from here.
+    await api().atproto.unlinkAccount();
+    expect(await atprotoAccountRows()).toHaveLength(0);
+    const after = await api().atproto.getConnectionStatus();
+    expect(after.needsReconnect).toBe(false);
   });
 
   it("refuses to unlink the sole sign-in method", async () => {

--- a/apps/app/tests/unit/auth/atproto-unlink-guard.test.ts
+++ b/apps/app/tests/unit/auth/atproto-unlink-guard.test.ts
@@ -7,7 +7,12 @@ import {
   openBenchmarkDatabase,
 } from "../../../scripts/performance/database";
 import type { ORPCContext } from "~/server/orpc/base";
-import { account, atprotoConnections, user } from "~/server/db/schema";
+import {
+  account,
+  appConfig,
+  atprotoConnections,
+  user,
+} from "~/server/db/schema";
 
 /**
  * The ConnectionsDialog procedures: unlink must refuse to remove the
@@ -124,6 +129,20 @@ describe("atproto connection procedures", () => {
     });
   }
 
+  async function setEnabledSigninProviders(providers: string[]) {
+    await session.database
+      .insert(appConfig)
+      .values({
+        key: "enabled-signin-providers",
+        value: JSON.stringify(providers),
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: appConfig.key,
+        set: { value: JSON.stringify(providers), updatedAt: new Date() },
+      });
+  }
+
   async function atprotoAccountRows() {
     return session.database
       .select()
@@ -186,6 +205,7 @@ describe("atproto connection procedures", () => {
 
   it("counts a generic OAuth account only while that provider is configured", async () => {
     await seedLinked({ extraProviderId: "oidc" });
+    await setEnabledSigninProviders(["email", "oauth", "atproto"]);
 
     // Provider env has since been removed: the OAuth row is unusable.
     testState.oauthConfigured = false;
@@ -194,6 +214,20 @@ describe("atproto connection procedures", () => {
     );
 
     testState.oauthConfigured = true;
+    await api().atproto.unlinkAccount();
+    expect(await atprotoAccountRows()).toHaveLength(0);
+  });
+
+  it("counts a credential account only while email sign-in is enabled", async () => {
+    await seedLinked({ extraProviderId: "credential" });
+    // The admin narrowed sign-in to atproto only: the credential row is no
+    // way back in, so unlinking would lock this user out.
+    await setEnabledSigninProviders(["atproto"]);
+    await expect(api().atproto.unlinkAccount()).rejects.toThrow(
+      /only way to sign in/,
+    );
+
+    await setEnabledSigninProviders(["email", "atproto"]);
     await api().atproto.unlinkAccount();
     expect(await atprotoAccountRows()).toHaveLength(0);
   });

--- a/apps/app/tests/unit/auth/atproto-unlink-guard.test.ts
+++ b/apps/app/tests/unit/auth/atproto-unlink-guard.test.ts
@@ -1,0 +1,184 @@
+import { createRouterClient } from "@orpc/server";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyMigrations,
+  createLocalBenchmarkTarget,
+  openBenchmarkDatabase,
+} from "../../../scripts/performance/database";
+import type { ORPCContext } from "~/server/orpc/base";
+import { account, atprotoConnections, user } from "~/server/db/schema";
+
+/**
+ * The ConnectionsDialog procedures: unlink must refuse to remove the
+ * user's sole sign-in method, and a second link attempt while connected is
+ * rejected before any OAuth round trip starts.
+ */
+
+const testState = vi.hoisted(
+  (): { database: unknown; oauthConfigured: boolean } => ({
+    database: undefined,
+    oauthConfigured: false,
+  }),
+);
+
+const revokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/server/db", () => ({
+  get db() {
+    return testState.database;
+  },
+}));
+vi.mock("~/server/auth", () => ({ auth: {} }));
+vi.mock("~/server/auth/constants", () => ({
+  isAtprotoConfigured: () => true,
+  isOAuthConfigured: () => testState.oauthConfigured,
+}));
+vi.mock("~/server/auth/atproto/client", () => ({
+  getAtprotoClient: async () => ({ revoke: revokeMock }),
+}));
+vi.mock("~/env", () => ({
+  env: {
+    OAUTH_PROVIDER_ID: "oidc",
+    PUBLIC_BASE_URL: "https://serial.test",
+  },
+}));
+
+const atprotoRouter = await import("~/server/api/routers/atprotoRouter");
+
+type Session = ReturnType<typeof openBenchmarkDatabase>;
+type Target = ReturnType<typeof createLocalBenchmarkTarget>;
+
+const DID = "did:plc:guarded";
+
+describe("atproto connection procedures", () => {
+  let session: Session;
+  let target: Target;
+
+  beforeEach(async () => {
+    target = createLocalBenchmarkTarget();
+    session = openBenchmarkDatabase({ url: target.url });
+    await applyMigrations(session.baseClient);
+    testState.database = session.database;
+    testState.oauthConfigured = false;
+    revokeMock.mockReset();
+
+    await session.database.insert(user).values({
+      id: "user-1",
+      name: "user-1",
+      email: "user-1@example.com",
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  });
+
+  afterEach(() => {
+    session.close();
+    target.cleanup();
+    testState.database = undefined;
+  });
+
+  function api() {
+    return createRouterClient(
+      { atproto: atprotoRouter },
+      {
+        context: {
+          headers: new Headers(),
+          session: { id: "session-1" },
+          user: { id: "user-1" },
+          db: session.database,
+        } as unknown as ORPCContext,
+      },
+    );
+  }
+
+  async function seedLinked(options?: { extraProviderId?: string }) {
+    await session.database.insert(account).values({
+      id: "acc-atproto",
+      accountId: DID,
+      providerId: "atproto",
+      userId: "user-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    if (options?.extraProviderId) {
+      await session.database.insert(account).values({
+        id: "acc-extra",
+        accountId: "extra-account",
+        providerId: options.extraProviderId,
+        userId: "user-1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    }
+    await session.database.insert(atprotoConnections).values({
+      did: DID,
+      userId: "user-1",
+      session: "ciphertext",
+      scopes: "atproto",
+      handle: "guarded.example.com",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  async function atprotoAccountRows() {
+    return session.database
+      .select()
+      .from(account)
+      .where(eq(account.providerId, "atproto"))
+      .all();
+  }
+
+  it("reports the connected handle", async () => {
+    await seedLinked({ extraProviderId: "credential" });
+    const status = await api().atproto.getConnectionStatus();
+    expect(status).toEqual({
+      isConnected: true,
+      handle: "guarded.example.com",
+      isConfigured: true,
+    });
+  });
+
+  it("refuses to unlink the sole sign-in method", async () => {
+    await seedLinked();
+    await expect(api().atproto.unlinkAccount()).rejects.toThrow(
+      /only way to sign in/,
+    );
+    expect(await atprotoAccountRows()).toHaveLength(1);
+    expect(revokeMock).not.toHaveBeenCalled();
+  });
+
+  it("unlinks when a password credential remains", async () => {
+    await seedLinked({ extraProviderId: "credential" });
+    await api().atproto.unlinkAccount();
+
+    expect(revokeMock).toHaveBeenCalledWith(DID);
+    expect(await atprotoAccountRows()).toHaveLength(0);
+    const status = await api().atproto.getConnectionStatus();
+    expect(status.isConnected).toBe(false);
+  });
+
+  it("counts a generic OAuth account only while that provider is configured", async () => {
+    await seedLinked({ extraProviderId: "oidc" });
+
+    // Provider env has since been removed: the OAuth row is unusable.
+    testState.oauthConfigured = false;
+    await expect(api().atproto.unlinkAccount()).rejects.toThrow(
+      /only way to sign in/,
+    );
+
+    testState.oauthConfigured = true;
+    await api().atproto.unlinkAccount();
+    expect(await atprotoAccountRows()).toHaveLength(0);
+  });
+
+  it("rejects starting a link while already connected", async () => {
+    await seedLinked({ extraProviderId: "credential" });
+    await expect(
+      api().atproto.linkAccount({ identifier: "someone.example.com" }),
+    ).rejects.toThrow(/already have an Atmosphere account/);
+  });
+});

--- a/apps/app/tests/unit/auth/auth-classify.test.ts
+++ b/apps/app/tests/unit/auth/auth-classify.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * The path classifiers are the seam between Better Auth's hooks and the
+ * shared policy service. Two invariants are load-bearing for the atproto
+ * link design: the link callback must be excluded from both classifiers
+ * (a link is neither a sign-in to gate nor a sign-up to roll back), and
+ * the first registered redirect URI must stay the sign-in callback (the
+ * SDK exchanges against redirect_uris[0] unless told otherwise).
+ */
+
+vi.mock("~/env", () => ({
+  env: {
+    PUBLIC_BASE_URL: "https://serial.test",
+    BETTER_AUTH_SECRET: "test-secret",
+  },
+}));
+
+const { classifyAuthRequest, classifyCompletedAuth } =
+  await import("~/server/auth/classify");
+const { ATPROTO_ROUTES, getAtprotoClientMetadata, getAtprotoLinkRedirectUri } =
+  await import("~/server/auth/atproto/config");
+
+describe("classifyAuthRequest", () => {
+  it("classifies the atproto authorize and callback paths as sign-in", () => {
+    expect(classifyAuthRequest(ATPROTO_ROUTES.authorize)).toEqual({
+      provider: "atproto",
+      intent: "sign-in",
+    });
+    expect(classifyAuthRequest(ATPROTO_ROUTES.callback)).toEqual({
+      provider: "atproto",
+      intent: "sign-in",
+    });
+  });
+
+  it("excludes the link callback from sign-in gating", () => {
+    expect(classifyAuthRequest(ATPROTO_ROUTES.linkCallback)).toBeUndefined();
+  });
+
+  it("classifies the email and oauth paths", () => {
+    expect(classifyAuthRequest("/sign-up/email")).toEqual({
+      provider: "email",
+      intent: "sign-up",
+    });
+    expect(classifyAuthRequest("/sign-in/email")).toEqual({
+      provider: "email",
+      intent: "sign-in",
+    });
+    expect(classifyAuthRequest("/oauth2/callback/oidc")).toEqual({
+      provider: "oauth",
+      intent: "sign-in",
+    });
+  });
+});
+
+describe("classifyCompletedAuth", () => {
+  it("classifies the atproto sign-in callback as a completed callback", () => {
+    expect(classifyCompletedAuth(ATPROTO_ROUTES.callback)).toEqual({
+      provider: "atproto",
+      flow: "callback",
+    });
+  });
+
+  it("excludes the link callback from post-auth policy", () => {
+    expect(classifyCompletedAuth(ATPROTO_ROUTES.linkCallback)).toBeUndefined();
+  });
+});
+
+describe("atproto client metadata", () => {
+  it("keeps the sign-in callback as the default (first) redirect URI", () => {
+    const metadata = getAtprotoClientMetadata();
+    expect(metadata.redirect_uris[0]).toBe(
+      "https://serial.test/api/auth/atproto/callback",
+    );
+    expect(metadata.redirect_uris).toContain(getAtprotoLinkRedirectUri());
+  });
+});

--- a/apps/app/tests/unit/auth/post-auth-rollback.test.ts
+++ b/apps/app/tests/unit/auth/post-auth-rollback.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyMigrations,
+  createLocalBenchmarkTarget,
+  openBenchmarkDatabase,
+} from "../../../scripts/performance/database";
+import { appConfig, session as sessionTable, user } from "~/server/db/schema";
+
+/**
+ * The auto-signup rollback in applyPostAuthPolicy must only ever delete a
+ * user the callback itself just created. An established user signing in
+ * through a linked provider can arrive with exactly one session (all
+ * others expired), so session count alone must not trigger rollback —
+ * creation recency is required too.
+ */
+
+const dbHolder = vi.hoisted(() => {
+  const holder: { current: unknown } = { current: undefined };
+  return holder;
+});
+
+vi.mock("~/server/db", () => ({
+  get db() {
+    return dbHolder.current;
+  },
+}));
+
+vi.mock("~/server/auth/constants", () => ({
+  getConfiguredAuthProviders: () => ["email", "atproto"],
+}));
+
+const { applyPostAuthPolicy } = await import("~/server/auth/policy");
+
+type Session = ReturnType<typeof openBenchmarkDatabase>;
+type Target = ReturnType<typeof createLocalBenchmarkTarget>;
+
+describe("post-auth callback rollback", () => {
+  let session: Session;
+  let target: Target;
+
+  beforeEach(async () => {
+    target = createLocalBenchmarkTarget();
+    session = openBenchmarkDatabase({ url: target.url });
+    await applyMigrations(session.baseClient);
+    dbHolder.current = session.database;
+
+    // An older first user so the first-user promotion branch is skipped.
+    await session.database.insert(user).values({
+      id: "user-first",
+      name: "first",
+      email: "first@example.com",
+      emailVerified: true,
+      createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+      updatedAt: new Date(),
+    });
+    // Sign-ups fully disabled: any auto-created callback user is disallowed.
+    await session.database.insert(appConfig).values({
+      key: "public-signup-enabled",
+      value: "false",
+      updatedAt: new Date(),
+    });
+  });
+
+  afterEach(() => {
+    session.close();
+    target.cleanup();
+    dbHolder.current = undefined;
+  });
+
+  async function insertCallbackUser(id: string, createdAt: Date) {
+    await session.database.insert(user).values({
+      id,
+      name: id,
+      email: `${id}@example.com`,
+      emailVerified: false,
+      createdAt,
+      updatedAt: new Date(),
+    });
+    await session.database.insert(sessionTable).values({
+      id: `session-${id}`,
+      userId: id,
+      token: `token-${id}`,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  function completedAuth(id: string, rollbackNewUser: () => Promise<void>) {
+    return {
+      provider: "atproto" as const,
+      flow: "callback" as const,
+      user: { id, name: id, email: `${id}@example.com` },
+      rollbackNewUser,
+    };
+  }
+
+  it("rolls back a user the callback just auto-created", async () => {
+    await insertCallbackUser("user-new", new Date());
+    const rollback = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      applyPostAuthPolicy(completedAuth("user-new", rollback)),
+    ).rejects.toThrow(/Sign ups are currently disabled/);
+    expect(rollback).toHaveBeenCalledOnce();
+  });
+
+  it("never rolls back an established user arriving with a single session", async () => {
+    // Linked yesterday; every other session has since expired.
+    await insertCallbackUser(
+      "user-linked",
+      new Date(Date.now() - 24 * 60 * 60 * 1000),
+    );
+    const rollback = vi.fn().mockResolvedValue(undefined);
+
+    await applyPostAuthPolicy(completedAuth("user-linked", rollback));
+    expect(rollback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Link an Atmosphere (AT Protocol) account from the ConnectionsDialog: handle entry starts the OAuth flow via a new protected oRPC procedure, and a dedicated `/atproto/link-callback` redirect URI attaches the verified DID to the signed-in user
- Reject a DID already linked to another user, and a second DID for a user with one connected
- Connection row shows the current handle with a disconnect affordance mirroring the Instapaper states
- Unlink revokes the grant, destroys stored credentials, releases the connection row, removes the account row, and refuses when Atmosphere is the sole sign-in method
- Post-auth rollback now requires creation recency alongside session count so an established linked user signing in via callback can never be rolled back
- Settings dialog never surfaces the internal placeholder email and requires adding a real email before setting a password; password-reset email is skipped for placeholder addresses
- New unit coverage for link/unlink/guards and rollback recency; new self-hosted e2e for the connection row and disconnect flow (test-only atproto keys added to the self-hosted e2e env)