### PR TITLE
Apply release-gate decisions

### DIFF
--- a/apps/app/src/app/_app.tsx
+++ b/apps/app/src/app/_app.tsx
@@ -222,10 +222,13 @@ function useAtprotoLinkReturn() {
 
     // Success needs no toast — the reopened dialog's connected row says it.
     if (result !== "success") {
-      toast.error(
-        ATPROTO_LINK_ERROR_MESSAGES[result] ??
-          "Couldn't connect your Atmosphere account. Please try again.",
-      );
+      // Own-property lookup only: `result` is an unvalidated query param, so
+      // a plain `map[result]` would resolve inherited keys ("toString") to a
+      // function and defeat the `??` fallback.
+      const message = Object.hasOwn(ATPROTO_LINK_ERROR_MESSAGES, result)
+        ? ATPROTO_LINK_ERROR_MESSAGES[result]
+        : "Couldn't connect your Atmosphere account. Please try again.";
+      toast.error(message);
     }
     launchDialog("connections");
   }, [launchDialog, queryClient, isRestoring]);

--- a/apps/app/src/components/auth/AtprotoHandleField.tsx
+++ b/apps/app/src/components/auth/AtprotoHandleField.tsx
@@ -88,6 +88,7 @@ export function AtprotoHandleField({
   /** Enter only confirms a suggestion the combobox has highlighted. */
   const highlightedRef = useRef<AtprotoActorSuggestion | undefined>(undefined);
   const inputRef = useRef<HTMLInputElement>(null);
+  const submitRef = useRef<HTMLButtonElement>(null);
 
   const query = identifier.trim();
   const searchable = query.length >= TYPEAHEAD_MIN_CHARS;
@@ -99,6 +100,13 @@ export function AtprotoHandleField({
   useEffect(() => {
     if (focusOnMount) inputRef.current?.focus();
   }, [focusOnMount]);
+
+  useEffect(() => {
+    // Standard focus management: picking an account completes the entry
+    // step, so focus moves to the submit button — Enter then activates it
+    // natively, no synthetic key handling.
+    if (selected) submitRef.current?.focus();
+  }, [selected]);
 
   useEffect(() => {
     if (!searchable || selected !== null) return;
@@ -177,6 +185,7 @@ export function AtprotoHandleField({
           </Button>
         </Item>
         <Button
+          ref={submitRef}
           variant={submitVariant}
           size={size}
           className="w-full"

--- a/apps/app/src/lib/auth/redirect-error.ts
+++ b/apps/app/src/lib/auth/redirect-error.ts
@@ -32,10 +32,13 @@ export function useRedirectErrorToast(
   useEffect(() => {
     if (!error || hasProcessed.current) return;
     hasProcessed.current = true;
-    toast.error(
-      REDIRECT_ERROR_MESSAGES[error] ??
-        "Authentication failed. Please try again.",
-    );
+    // Own-property lookup only: `error` is an unvalidated query param, so a
+    // plain `map[error]` would resolve inherited keys ("toString") to a
+    // function and defeat the `??` fallback.
+    const message = Object.hasOwn(REDIRECT_ERROR_MESSAGES, error)
+      ? REDIRECT_ERROR_MESSAGES[error]
+      : "Authentication failed. Please try again.";
+    toast.error(message);
     void navigate({
       search: (prev) => ({ ...prev, error: undefined }),
       replace: true,

--- a/apps/app/src/server/auth/atproto/config.ts
+++ b/apps/app/src/server/auth/atproto/config.ts
@@ -29,6 +29,29 @@ export { ATPROTO_PROVIDER_ID } from "~/lib/constants";
 /** The identity-only v1 scope; broader grants arrive via upgrade(). */
 export const ATPROTO_SCOPE = "atproto";
 
+/**
+ * Scopes this instance is allowed to request. upgrade() validates against
+ * this so a future caller cannot request an arbitrary grant; broaden it
+ * deliberately (per space-delimited token) as capabilities are wired.
+ */
+export const ATPROTO_ALLOWED_SCOPES = new Set([ATPROTO_SCOPE]);
+
+/**
+ * Reject an authorization scope that is not on the allowlist. Scope is a
+ * space-delimited token list; every token must be allowed.
+ */
+export function assertAllowedAtprotoScope(scope: string): void {
+  const tokens = scope.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    throw new Error("An AT Protocol scope is required");
+  }
+  for (const token of tokens) {
+    if (!ATPROTO_ALLOWED_SCOPES.has(token)) {
+      throw new Error(`Disallowed AT Protocol scope: ${token}`);
+    }
+  }
+}
+
 /** Upper bound on the life of an in-flight authorization attempt. */
 export const AUTH_STATE_TTL_MS = 60 * 60 * 1000;
 

--- a/apps/app/src/server/auth/atproto/hardened-fetch.ts
+++ b/apps/app/src/server/auth/atproto/hardened-fetch.ts
@@ -1,16 +1,23 @@
 import { safeFetchWrap } from "@atproto-labs/fetch-node";
-import { env } from "~/env";
+import { getAtprotoClientMode } from "./mode";
 
 /**
  * SSRF-hardened outbound fetch shared by the AT Protocol OAuth client and
  * the typeahead proxy — standalone so consumers that only need a guarded
  * fetch don't pull in the OAuth client graph.
  *
- * Outside production (development and e2e) the guard loosens just enough
- * to reach a local dev PDS over plain HTTP.
+ * Only the loopback dev client loosens the guard to reach a local dev PDS
+ * over plain HTTP / on a private or IP host.
  */
 
-export const ALLOW_INSECURE_PDS = env.NODE_ENV !== "production";
+// Derived from the client mode (PUBLIC_BASE_URL), not NODE_ENV: any public
+// deployment necessarily has an https base URL and so runs the confidential
+// client, keeping http / private-IP / IP-host blocked regardless of how
+// NODE_ENV is set. Only a loopback base URL — reachable solely from the
+// machine serving the app — relaxes the transport guards. This closes the
+// SSRF window a public instance with NODE_ENV unset would otherwise open
+// through attacker-controlled did:web resolution.
+export const ALLOW_INSECURE_PDS = getAtprotoClientMode() === "loopback";
 
 const FETCH_TIMEOUT_MS = 15_000;
 

--- a/apps/app/src/server/auth/atproto/service.ts
+++ b/apps/app/src/server/auth/atproto/service.ts
@@ -1,6 +1,7 @@
 import { and, eq, isNotNull, isNull, lt, or } from "drizzle-orm";
 import { getAtprotoClient } from "./client";
 import {
+  assertAllowedAtprotoScope,
   ATPROTO_PROVIDER_ID,
   ATPROTO_SCOPE,
   AUTH_STATE_TTL_MS,
@@ -456,6 +457,9 @@ export async function upgradeAtprotoAuth(
   did: string,
   scope: string,
 ): Promise<URL> {
+  // Never hand an unbounded caller-supplied scope to the authorization
+  // server; a broader grant must be added to the allowlist deliberately.
+  assertAllowedAtprotoScope(scope);
   const client = await getAtprotoClient();
   return client.authorize(did, {
     scope,

--- a/apps/app/src/server/auth/atproto/service.ts
+++ b/apps/app/src/server/auth/atproto/service.ts
@@ -8,6 +8,7 @@ import {
   getAtprotoLinkRedirectUri,
 } from "./config";
 import {
+  claimStaleAtprotoOrphan,
   disconnectAtprotoConnection,
   sweepExpiredAtprotoState,
 } from "./stores";
@@ -112,7 +113,15 @@ async function sweepStaleAtprotoConnections(): Promise<void> {
     .limit(SWEEP_MAX_REVOCATIONS)
     .all();
   for (const orphan of orphans) {
-    await revokeAtprotoConnection(orphan.did);
+    // Claim (disconnect) the row under the same unbound + stale guard
+    // before hitting the PDS: if a sign-in or refresh bound or re-touched
+    // it since the snapshot, skip it entirely rather than revoke a live
+    // grant the user just minted.
+    const claimed = await claimStaleAtprotoOrphan(db, orphan.did, cutoff);
+    if (!claimed) continue;
+    // The row is already disconnected by the claim; only the PDS-side
+    // grant remains to revoke.
+    await revokeAtprotoGrantAtPds(orphan.did);
   }
   await sweepExpiredAtprotoState(db);
 }
@@ -504,13 +513,22 @@ export async function revokeAtprotoGrantsForUser(
  */
 export async function revokeAtprotoConnection(did: string): Promise<void> {
   try {
-    // Client construction stays inside the try: a failure there (bad
-    // keyset, unreachable config) must still fall through to disconnect.
+    await revokeAtprotoGrantAtPds(did);
+  } finally {
+    await disconnectAtprotoConnection(db, did);
+  }
+}
+
+/**
+ * Revoke only the PDS-side grant, never touching the DB row. Never throws:
+ * a failure (bad keyset, unreachable authorization server) is captured, so
+ * callers that have already settled the local row aren't blocked.
+ */
+async function revokeAtprotoGrantAtPds(did: string): Promise<void> {
+  try {
     const client = await getAtprotoClient();
     await client.revoke(did);
   } catch (err) {
     captureException(err);
-  } finally {
-    await disconnectAtprotoConnection(db, did);
   }
 }

--- a/apps/app/src/server/auth/atproto/service.ts
+++ b/apps/app/src/server/auth/atproto/service.ts
@@ -117,10 +117,13 @@ async function sweepStaleAtprotoConnections(): Promise<void> {
     // before hitting the PDS: if a sign-in or refresh bound or re-touched
     // it since the snapshot, skip it entirely rather than revoke a live
     // grant the user just minted.
+    // oxlint-disable-next-line react-doctor/async-await-in-loop
     const claimed = await claimStaleAtprotoOrphan(db, orphan.did, cutoff);
     if (!claimed) continue;
     // The row is already disconnected by the claim; only the PDS-side
-    // grant remains to revoke.
+    // grant remains to revoke. Serial and bounded by design: revocations
+    // are outbound calls that must not fan out under an auth-server outage.
+    // oxlint-disable-next-line react-doctor/async-await-in-loop
     await revokeAtprotoGrantAtPds(orphan.did);
   }
   await sweepExpiredAtprotoState(db);

--- a/apps/app/src/server/auth/atproto/stores.ts
+++ b/apps/app/src/server/auth/atproto/stores.ts
@@ -161,6 +161,32 @@ export async function disconnectAtprotoConnection(
 }
 
 /**
+ * Claim a still-stale orphan for the revocation sweep: disconnect it only
+ * if it is *still* unbound and untouched since the sweep's snapshot cutoff.
+ * A concurrent sign-in or session refresh sets `userId` or bumps
+ * `updatedAt` to ~now (past the cutoff), so this no-ops on it and the
+ * caller must not revoke — otherwise the sweep would kill a grant a user
+ * just minted. Returns whether the row was claimed.
+ */
+export async function claimStaleAtprotoOrphan(
+  database: AtprotoDatabase,
+  did: string,
+  cutoff: Date,
+): Promise<boolean> {
+  const result = await database
+    .update(atprotoConnections)
+    .set({ session: null, status: "disconnected", updatedAt: new Date() })
+    .where(
+      and(
+        eq(atprotoConnections.did, did),
+        isNull(atprotoConnections.userId),
+        lt(atprotoConnections.updatedAt, cutoff),
+      ),
+    );
+  return result.rowsAffected > 0;
+}
+
+/**
  * Remove expired authorization state and connection rows that finished the
  * OAuth callback but were never bound to a user (abandoned or rolled-back
  * sign-ups). Runs opportunistically when an authorize flow starts.

--- a/apps/app/src/server/auth/policy.ts
+++ b/apps/app/src/server/auth/policy.ts
@@ -239,10 +239,13 @@ export async function applyPostAuthPolicy(
     await db.update(user).set({ role: "admin" }).where(eq(user.id, userId));
 
     // Record the sign-in and sign-up methods to match how the first user
-    // signed up — written once: existing rows always win, so bootstrap can
-    // never clobber a configuration that already exists (a seeded test
-    // database, or any regression that re-enters this branch). From here
-    // on, only the admin settings surface changes these values.
+    // signed up. Overwriting is deliberate and safe *here*: only a genuine
+    // bootstrap reaches this write (the gate above), and a bootstrap onto
+    // surviving config rows means the instance was re-bootstrapped — its
+    // sole user self-deleted and someone new signed up. Stale config must
+    // then follow the new admin's method, or an admin who signed up via a
+    // method the old rows disable is locked out permanently. Outside
+    // bootstrap, only the admin settings surface changes these values.
     const providers = JSON.stringify([completed.provider]);
     await db
       .insert(appConfig)
@@ -251,7 +254,10 @@ export async function applyPostAuthPolicy(
         value: providers,
         updatedAt: new Date(),
       })
-      .onConflictDoNothing({ target: appConfig.key });
+      .onConflictDoUpdate({
+        target: appConfig.key,
+        set: { value: providers, updatedAt: new Date() },
+      });
     await db
       .insert(appConfig)
       .values({
@@ -259,7 +265,10 @@ export async function applyPostAuthPolicy(
         value: providers,
         updatedAt: new Date(),
       })
-      .onConflictDoNothing({ target: appConfig.key });
+      .onConflictDoUpdate({
+        target: appConfig.key,
+        set: { value: providers, updatedAt: new Date() },
+      });
   } else if (completed.flow === "callback") {
     // Non-first user arriving via a callback — the provider may have
     // auto-created a user. Roll back only when this is genuinely that

--- a/apps/app/tests/e2e/self-hosted/connections-atproto.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/connections-atproto.spec.ts
@@ -181,11 +181,16 @@ test.describe("atproto connection management", () => {
     ).toBeVisible();
     await expect(suggestions).not.toBeVisible();
 
+    // Selection moves focus to the submit button, so Enter submits via
+    // the button's native activation.
+    const connectButton = page.getByRole("button", { name: "Connect" });
+    await expect(connectButton).toBeFocused();
+
     const linkRequest = page.waitForRequest(
       (request) => request.url().includes("/api/rpc/atproto/linkAccount"),
       { timeout: 10_000 },
     );
-    await page.getByRole("button", { name: "Connect" }).click();
+    await connectButton.press("Enter");
     const request = await linkRequest;
     expect(request.postData()).toContain("alice.test");
     expect(request.postData()).toContain("did:plc:e2e-alice");

--- a/apps/app/tests/unit/auth/atproto-client-mode.test.ts
+++ b/apps/app/tests/unit/auth/atproto-client-mode.test.ts
@@ -39,7 +39,7 @@ vi.mock("~/env", () => ({
 }));
 
 const { getAtprotoClientMode } = await import("~/server/auth/atproto/mode");
-const { getAtprotoClientMetadata } =
+const { getAtprotoClientMetadata, assertAllowedAtprotoScope } =
   await import("~/server/auth/atproto/config");
 const { isAtprotoConfigured } = await import("~/server/auth/constants");
 
@@ -163,5 +163,22 @@ describe("isAtprotoConfigured soft-disable", () => {
       NODE_ENV: "development",
     });
     expect(isAtprotoConfigured()).toBe(true);
+  });
+});
+
+describe("assertAllowedAtprotoScope", () => {
+  it("accepts the identity scope", () => {
+    expect(() => assertAllowedAtprotoScope("atproto")).not.toThrow();
+  });
+
+  it("rejects an empty scope", () => {
+    expect(() => assertAllowedAtprotoScope("   ")).toThrow(/scope is required/);
+  });
+
+  it("rejects any token outside the allowlist, even beside an allowed one", () => {
+    expect(() => assertAllowedAtprotoScope("repo:*")).toThrow(/Disallowed/);
+    expect(() => assertAllowedAtprotoScope("atproto repo:*")).toThrow(
+      /Disallowed/,
+    );
   });
 });

--- a/apps/app/tests/unit/auth/atproto-stores.test.ts
+++ b/apps/app/tests/unit/auth/atproto-stores.test.ts
@@ -18,6 +18,7 @@ import {
   parseEncryptionKey,
 } from "~/server/auth/atproto/crypto";
 import {
+  claimStaleAtprotoOrphan,
   createAtprotoSessionStore,
   createAtprotoStateStore,
   disconnectAtprotoConnection,
@@ -278,6 +279,70 @@ describe("atproto database stores", () => {
         updatedAt: new Date(),
       });
       expect(await store.get(OTHER_DID)).toBeUndefined();
+    });
+  });
+
+  describe("claimStaleAtprotoOrphan", () => {
+    const staleDate = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const cutoff = new Date(Date.now() - 60 * 60 * 1000);
+
+    async function seedOrphan(did: string) {
+      const sessionStore = createAtprotoSessionStore(database, KEY);
+      await sessionStore.set(did, savedSession());
+      await database
+        .update(atprotoConnections)
+        .set({ updatedAt: staleDate })
+        .where(eq(atprotoConnections.did, did));
+    }
+
+    it("claims and disconnects a still-stale unbound orphan", async () => {
+      await seedOrphan(DID);
+
+      expect(await claimStaleAtprotoOrphan(database, DID, cutoff)).toBe(true);
+      const row = await database
+        .select()
+        .from(atprotoConnections)
+        .where(eq(atprotoConnections.did, DID))
+        .get();
+      expect(row!.status).toBe("disconnected");
+      expect(row!.session).toBeNull();
+    });
+
+    it("does not claim a row bound since the snapshot", async () => {
+      await database.insert(user).values({
+        id: "user-1",
+        name: "user-1",
+        email: "user-1@example.com",
+        emailVerified: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      await seedOrphan(DID);
+      await database
+        .update(atprotoConnections)
+        .set({ userId: "user-1" })
+        .where(eq(atprotoConnections.did, DID));
+
+      expect(await claimStaleAtprotoOrphan(database, DID, cutoff)).toBe(false);
+      const row = await database
+        .select()
+        .from(atprotoConnections)
+        .where(eq(atprotoConnections.did, DID))
+        .get();
+      // Left intact — a concurrent sign-in owns it now.
+      expect(row!.status).toBe("active");
+      expect(row!.session).not.toBeNull();
+    });
+
+    it("does not claim a row refreshed past the cutoff since the snapshot", async () => {
+      await seedOrphan(DID);
+      // A fresh session.set bumps updatedAt to ~now (an in-flight sign-in).
+      await database
+        .update(atprotoConnections)
+        .set({ updatedAt: new Date() })
+        .where(eq(atprotoConnections.did, DID));
+
+      expect(await claimStaleAtprotoOrphan(database, DID, cutoff)).toBe(false);
     });
   });
 

--- a/apps/app/tests/unit/auth/post-auth-rollback.test.ts
+++ b/apps/app/tests/unit/auth/post-auth-rollback.test.ts
@@ -229,12 +229,15 @@ describe("post-auth callback rollback", () => {
     expect(bootUser?.role).toBe("admin");
   });
 
-  it("never clobbers provider config that already exists at bootstrap", async () => {
+  it("re-applies provider config over stale rows when the instance re-bootstraps", async () => {
+    // The previous sole user (who signed up with email) is gone; their
+    // config rows survive. The new first admin signs up via atproto and
+    // must not be locked out by the stale ["email"] setting.
     await session.database.delete(user).where(eq(user.id, "user-first"));
     await session.database.insert(appConfig).values([
       {
         key: "enabled-signin-providers",
-        value: JSON.stringify(["email", "atproto"]),
+        value: JSON.stringify(["email"]),
         updatedAt: new Date(),
       },
       {
@@ -250,7 +253,7 @@ describe("post-auth callback rollback", () => {
 
     expect(rollback).not.toHaveBeenCalled();
     const configs = await providerConfigs();
-    expect(configs.signin).toBe(JSON.stringify(["email", "atproto"]));
-    expect(configs.signup).toBe(JSON.stringify(["email"]));
+    expect(configs.signin).toBe(JSON.stringify(["atproto"]));
+    expect(configs.signup).toBe(JSON.stringify(["atproto"]));
   });
 });


### PR DESCRIPTION
- focus the submit button after selecting a handle, so Enter submits natively
- let a genuine re-bootstrap re-apply the provider config over stale rows