### PR TITLE
Fire shortcuts while Alt is held

### DIFF
--- a/apps/app/src/components/CustomVideoPlayer/useYouTubeVideoShortcuts.tsx
+++ b/apps/app/src/components/CustomVideoPlayer/useYouTubeVideoShortcuts.tsx
@@ -4,6 +4,7 @@ import { YOUTUBE_FASTEST_SPEED, YOUTUBE_PLAYBACK_SPEEDS } from "./constants";
 import { useCustomVideoPlayerContext } from "./CustomVideoPlayerProvider";
 import { useView } from "~/components/feed/watch/[id]/useView";
 import { doesAnyFormElementHaveFocus } from "~/lib/doesAnyFormElementHaveFocus";
+import { getShortcutEventKey } from "~/lib/getShortcutEventKey";
 
 const SEEK_KEYS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
@@ -39,36 +40,40 @@ export function useVideoShortcuts({ disabled = false } = {}) {
     };
 
     const processKeyUp = (event: KeyboardEvent) => {
-      if (event.metaKey || event.ctrlKey || event.altKey) {
+      // Alt only peeks at the shortcut hints, so it never disqualifies a
+      // shortcut
+      if (event.metaKey || event.ctrlKey) {
         return;
       }
       if (doesAnyFormElementHaveFocus()) return;
 
       keypressTimeRef.current[event.key] = null;
 
-      if (event.key === " ") {
+      const key = getShortcutEventKey(event);
+
+      if (key === " ") {
         event.preventDefault();
         toggleVideoPlayback();
         return;
       }
-      if (event.key === "ArrowLeft") {
+      if (key === "ArrowLeft") {
         event.preventDefault();
         seekToSecond(videoProgress - 5 * playbackSpeed);
         return;
       }
-      if (event.key === "ArrowRight") {
+      if (key === "ArrowRight") {
         event.preventDefault();
         seekToSecond(videoProgress + 5 * playbackSpeed);
         toggleVideoPlayback();
         return;
       }
-      if (SEEK_KEYS.includes(event.key)) {
+      if (SEEK_KEYS.includes(key)) {
         event.preventDefault();
         const chunks = videoDuration / 10;
-        seekToSecond(chunks * parseInt(event.key));
+        seekToSecond(chunks * parseInt(key));
         return;
       }
-      if (event.key === "<" && event.shiftKey) {
+      if (key === "<" && event.shiftKey) {
         event.preventDefault();
         const currentSpeedIndex = YOUTUBE_PLAYBACK_SPEEDS.findIndex(
           (speed) => speed.value === playbackSpeed,
@@ -79,7 +84,7 @@ export function useVideoShortcuts({ disabled = false } = {}) {
         );
         return;
       }
-      if (event.key === ">" && event.shiftKey) {
+      if (key === ">" && event.shiftKey) {
         event.preventDefault();
         const currentSpeedIndex = YOUTUBE_PLAYBACK_SPEEDS.findIndex(
           (speed) => speed.value === playbackSpeed,
@@ -90,7 +95,7 @@ export function useVideoShortcuts({ disabled = false } = {}) {
         );
         return;
       }
-      if (event.key === "c") {
+      if (key === "c") {
         event.preventDefault();
         if (!captionsModuleLoaded) {
           toast.error("Play video to load available captions");
@@ -99,13 +104,13 @@ export function useVideoShortcuts({ disabled = false } = {}) {
         toggleCaptions();
         return;
       }
-      if (event.key === "m") {
+      if (key === "m") {
         event.preventDefault();
         toggleMute();
         return;
       }
       // Shift+F or ` for windowed fullscreen
-      if ((event.key === "F" && event.shiftKey) || event.key === "`") {
+      if ((key === "F" && event.shiftKey) || key === "`") {
         event.preventDefault();
         // If in native fullscreen, exit it and enter windowed fullscreen
         if (isNativeFullscreen) {
@@ -117,7 +122,7 @@ export function useVideoShortcuts({ disabled = false } = {}) {
         return;
       }
       // f for true/native fullscreen
-      if (event.key === "f" && !event.shiftKey) {
+      if (key === "f" && !event.shiftKey) {
         event.preventDefault();
         // Exit windowed fullscreen if active before entering native fullscreen
         if (view === "fullscreen") {

--- a/apps/app/src/components/CustomVideoPlayer/useYouTubeVideoShortcuts.tsx
+++ b/apps/app/src/components/CustomVideoPlayer/useYouTubeVideoShortcuts.tsx
@@ -32,11 +32,14 @@ export function useVideoShortcuts({ disabled = false } = {}) {
     if (disabled) return;
 
     const processKeyDown = (event: KeyboardEvent) => {
-      if (typeof keypressTimeRef.current[event.key] === "number") {
+      // Track by the normalized key so pressing Option mid-hold cannot
+      // strand an entry under the composed character
+      const key = getShortcutEventKey(event);
+      if (typeof keypressTimeRef.current[key] === "number") {
         return;
       }
 
-      keypressTimeRef.current[event.key] = Date.now();
+      keypressTimeRef.current[key] = Date.now();
     };
 
     const processKeyUp = (event: KeyboardEvent) => {
@@ -47,9 +50,9 @@ export function useVideoShortcuts({ disabled = false } = {}) {
       }
       if (doesAnyFormElementHaveFocus()) return;
 
-      keypressTimeRef.current[event.key] = null;
-
       const key = getShortcutEventKey(event);
+
+      keypressTimeRef.current[key] = null;
 
       if (key === " ") {
         event.preventDefault();

--- a/apps/app/src/components/feed/useManagementShortcuts.ts
+++ b/apps/app/src/components/feed/useManagementShortcuts.ts
@@ -31,30 +31,40 @@ export function useFeedManagementShortcuts({
     const target = event.target as HTMLElement;
     const isInDialog = target.closest('[role="dialog"]') !== null;
 
-    switch (getShortcutEventKey(event)) {
+    const key = getShortcutEventKey(event);
+    // Alt+letter is a browser menu accelerator on Windows/Linux; suppress
+    // it when a shortcut fires while peeking at the hints
+    const fire = (action: () => void) => {
+      if (event.altKey && key.length === 1) {
+        event.preventDefault();
+      }
+      action();
+    };
+
+    switch (key) {
       case "Escape":
         if (!isDialogOpen && !isInDialog) {
-          onEscape();
+          fire(onEscape);
         }
         break;
       case "s":
         if (!isDialogOpen) {
-          onSelectAll();
+          fire(onSelectAll);
         }
         break;
       case "e":
         if (canMutate && !isDialogOpen && hasSelection) {
-          onEdit();
+          fire(onEdit);
         }
         break;
       case "c":
         if (canMutate && !isDialogOpen && hasSelection) {
-          onClear();
+          fire(onClear);
         }
         break;
       case "d":
         if (canMutate && !isDialogOpen && hasSelection) {
-          onDelete();
+          fire(onDelete);
         }
         break;
     }

--- a/apps/app/src/components/feed/useManagementShortcuts.ts
+++ b/apps/app/src/components/feed/useManagementShortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent } from "react";
 import { doesAnyFormElementHaveFocus } from "~/lib/doesAnyFormElementHaveFocus";
+import { getShortcutEventKey } from "~/lib/getShortcutEventKey";
 import { useCanMutate } from "~/lib/data/offline-mutations";
 
 export function useFeedManagementShortcuts({
@@ -22,12 +23,15 @@ export function useFeedManagementShortcuts({
   const canMutate = useCanMutate();
   const onKeyDown = useEffectEvent((event: KeyboardEvent) => {
     if (event.repeat) return;
+    // Alt only peeks at the shortcut hints, so it never disqualifies a
+    // shortcut
+    if (event.metaKey || event.ctrlKey) return;
     if (doesAnyFormElementHaveFocus()) return;
 
     const target = event.target as HTMLElement;
     const isInDialog = target.closest('[role="dialog"]') !== null;
 
-    switch (event.key) {
+    switch (getShortcutEventKey(event)) {
       case "Escape":
         if (!isDialogOpen && !isInDialog) {
           onEscape();

--- a/apps/app/src/lib/getShortcutEventKey.ts
+++ b/apps/app/src/lib/getShortcutEventKey.ts
@@ -52,9 +52,13 @@ const isMacLike = () =>
  * named keys (arrows, Enter) always fall through to `event.key` because
  * Option does not compose them.
  *
- * Known limitation: the recovery table is US-QWERTY, so on a macOS
+ * Known limitations: the recovery table is US-QWERTY, so on a macOS
  * non-QWERTY layout an Option-held key recovers the QWERTY key for that
- * physical position.
+ * physical position, and codes outside the table (ISO-only keys such as
+ * IntlBackslash) fall through to the composed `event.key`, so their
+ * bindings do not match while Option is held. Chromium's
+ * `navigator.keyboard.getLayoutMap()` could lift both, at the cost of an
+ * async layout lookup.
  */
 export const getShortcutEventKey = (event: ShortcutKeyboardEvent): string => {
   if (!event.altKey || !isMacLike()) {
@@ -66,6 +70,8 @@ export const getShortcutEventKey = (event: ShortcutKeyboardEvent): string => {
   const { code } = event;
   if (code.startsWith("Key") && code.length === 4) {
     const letter = code.slice(3);
+    // Case follows Shift alone; Caps Lock is ignored, matching how bare
+    // shortcut bindings are declared
     return event.shiftKey ? letter : letter.toLowerCase();
   }
   const mapped = CODE_KEYS[code];

--- a/apps/app/src/lib/getShortcutEventKey.ts
+++ b/apps/app/src/lib/getShortcutEventKey.ts
@@ -1,0 +1,67 @@
+// [unshifted, shifted] logical keys for the printable physical key
+// positions, used to recover a shortcut key from `event.code` when the OS
+// composes `event.key` (macOS Option).
+const CODE_KEYS: Record<string, [string, string]> = {
+  Digit1: ["1", "!"],
+  Digit2: ["2", "@"],
+  Digit3: ["3", "#"],
+  Digit4: ["4", "$"],
+  Digit5: ["5", "%"],
+  Digit6: ["6", "^"],
+  Digit7: ["7", "&"],
+  Digit8: ["8", "*"],
+  Digit9: ["9", "("],
+  Digit0: ["0", ")"],
+  Backquote: ["`", "~"],
+  Minus: ["-", "_"],
+  Equal: ["=", "+"],
+  BracketLeft: ["[", "{"],
+  BracketRight: ["]", "}"],
+  Backslash: ["\\", "|"],
+  Semicolon: [";", ":"],
+  Quote: ["'", '"'],
+  Comma: [",", "<"],
+  Period: [".", ">"],
+  Slash: ["/", "?"],
+  Space: [" ", " "],
+};
+
+type ShortcutKeyboardEvent = {
+  altKey: boolean;
+  shiftKey: boolean;
+  code: string;
+  key: string;
+};
+
+// A key the OS composed under Option: either a dead key or a character
+// outside printable ASCII (Option+E → "´", Option+Space → nbsp).
+const isComposedKey = (key: string) =>
+  key === "Dead" || (key.length === 1 && key.charCodeAt(0) > 127);
+
+/**
+ * Alt is the "peek at shortcuts" key, so shortcuts must still match while it
+ * is held. When Alt composes `event.key` (macOS Option), recover the logical
+ * key from the physical `event.code`; otherwise `event.key` is layout-aware
+ * and stays the source of truth. Numpad and named keys (arrows, Enter)
+ * intentionally fall through to `event.key` because Option does not compose
+ * them.
+ *
+ * Known limitation: the recovery table is US-QWERTY, so a composed key on a
+ * macOS non-QWERTY layout recovers the QWERTY key for that physical
+ * position.
+ */
+export const getShortcutEventKey = (event: ShortcutKeyboardEvent): string => {
+  if (!event.altKey || !isComposedKey(event.key)) {
+    return event.key;
+  }
+  const { code } = event;
+  if (code.startsWith("Key") && code.length === 4) {
+    const letter = code.slice(3);
+    return event.shiftKey ? letter : letter.toLowerCase();
+  }
+  const mapped = CODE_KEYS[code];
+  if (mapped) {
+    return event.shiftKey ? mapped[1] : mapped[0];
+  }
+  return event.key;
+};

--- a/apps/app/src/lib/getShortcutEventKey.ts
+++ b/apps/app/src/lib/getShortcutEventKey.ts
@@ -38,8 +38,10 @@ type ShortcutKeyboardEvent = {
 const isMacLike = () =>
   typeof navigator !== "undefined" &&
   /mac|iphone|ipad/i.test(
+    // `||` rather than `??`: some privacy configurations expose
+    // `userAgentData` with an empty platform string
     (navigator as { userAgentData?: { platform?: string } }).userAgentData
-      ?.platform ?? navigator.platform,
+      ?.platform || navigator.platform,
   );
 
 /**

--- a/apps/app/src/lib/getShortcutEventKey.ts
+++ b/apps/app/src/lib/getShortcutEventKey.ts
@@ -33,25 +33,34 @@ type ShortcutKeyboardEvent = {
   key: string;
 };
 
-// A key the OS composed under Option: either a dead key or a character
-// outside printable ASCII (Option+E → "´", Option+Space → nbsp).
-const isComposedKey = (key: string) =>
-  key === "Dead" || (key.length === 1 && key.charCodeAt(0) > 127);
+// Only macOS composes `event.key` under Option; everywhere else the
+// layout-aware `event.key` already is the logical key.
+const isMacLike = () =>
+  typeof navigator !== "undefined" &&
+  /mac|iphone|ipad/i.test(
+    (navigator as { userAgentData?: { platform?: string } }).userAgentData
+      ?.platform ?? navigator.platform,
+  );
 
 /**
  * Alt is the "peek at shortcuts" key, so shortcuts must still match while it
- * is held. When Alt composes `event.key` (macOS Option), recover the logical
- * key from the physical `event.code`; otherwise `event.key` is layout-aware
- * and stays the source of truth. Numpad and named keys (arrows, Enter)
- * intentionally fall through to `event.key` because Option does not compose
- * them.
+ * is held. On macOS, Option composes printable `event.key` values into
+ * different characters (Option+E → "´", German Option+5 → "["), so recover
+ * the logical key from the physical `event.code` for every printable or
+ * dead key while Option is down. On other platforms Alt does not compose,
+ * so `event.key` is layout-aware and stays the source of truth. Numpad and
+ * named keys (arrows, Enter) always fall through to `event.key` because
+ * Option does not compose them.
  *
- * Known limitation: the recovery table is US-QWERTY, so a composed key on a
- * macOS non-QWERTY layout recovers the QWERTY key for that physical
- * position.
+ * Known limitation: the recovery table is US-QWERTY, so on a macOS
+ * non-QWERTY layout an Option-held key recovers the QWERTY key for that
+ * physical position.
  */
 export const getShortcutEventKey = (event: ShortcutKeyboardEvent): string => {
-  if (!event.altKey || !isComposedKey(event.key)) {
+  if (!event.altKey || !isMacLike()) {
+    return event.key;
+  }
+  if (event.key.length > 1 && event.key !== "Dead") {
     return event.key;
   }
   const { code } = event;

--- a/apps/app/src/lib/hooks/useShortcut.ts
+++ b/apps/app/src/lib/hooks/useShortcut.ts
@@ -8,6 +8,7 @@ import {
 import type { KeyboardEvent } from "react";
 import { useDialogStore } from "~/components/feed/dialogStore";
 import { doesAnyFormElementHaveFocus } from "~/lib/doesAnyFormElementHaveFocus";
+import { getShortcutEventKey } from "~/lib/getShortcutEventKey";
 
 /**
  * Borrowed from the ever-helpful Tania Rascia:
@@ -19,43 +20,6 @@ type UseShortcutOptions = {
   disableTextInputs?: boolean;
   disableDialogs?: boolean;
   allowRepeat?: boolean;
-};
-
-// Punctuation codes for keys used in shortcut bindings, as
-// [unshifted, shifted] pairs.
-const PUNCTUATION_CODE_KEYS: Record<string, [string, string]> = {
-  Backslash: ["\\", "|"],
-  BracketLeft: ["[", "{"],
-  BracketRight: ["]", "}"],
-  Minus: ["-", "_"],
-  Equal: ["=", "+"],
-  Space: [" ", " "],
-};
-
-/**
- * Alt is the "peek at shortcuts" key, so shortcuts must still match while it
- * is held. On macOS, Option composes `event.key` into a different character
- * (Option+E → "´"), so recover the logical key from `event.code` instead.
- */
-const getEventKey = (
-  event: Pick<KeyboardEvent<Element>, "altKey" | "shiftKey" | "code" | "key">,
-): string => {
-  if (!event.altKey) {
-    return event.key;
-  }
-  const { code } = event;
-  if (code.startsWith("Key") && code.length === 4) {
-    const letter = code.slice(3);
-    return event.shiftKey ? letter : letter.toLowerCase();
-  }
-  if (code.startsWith("Digit") && code.length === 6 && !event.shiftKey) {
-    return code.slice(5);
-  }
-  const punctuation = PUNCTUATION_CODE_KEYS[code];
-  if (punctuation) {
-    return event.shiftKey ? punctuation[1] : punctuation[0];
-  }
-  return event.key;
 };
 
 export const useShortcut = (
@@ -105,7 +69,22 @@ export const useShortcut = (
         Shift: event.shiftKey,
       };
 
-      const eventKey = getEventKey(event);
+      const eventKey = getShortcutEventKey(event);
+
+      // Alt only peeks at the shortcut hints, so an unbound Alt never
+      // disqualifies a match
+      const isEveryOtherModifierFalse = Object.entries(modifierMap).every(
+        ([name, pressed]) => name === "Alt" || !pressed,
+      );
+
+      const fireCallback = () => {
+        // Alt+key is a browser menu accelerator on Windows/Linux; suppress
+        // it when the shortcut fires while peeking at the hints
+        if (event.altKey) {
+          event.preventDefault();
+        }
+        return callbackRef.current(event);
+      };
 
       for (const currentShortcut of shortcutsKey.split("\n")) {
         // Handle combined modifier key shortcuts (e.g. pressing Control + D)
@@ -128,17 +107,13 @@ export const useShortcut = (
               if (pressedModifierSet.has(key)) {
                 return modifierMap[key];
               }
-              // Alt only peeks at the shortcut hints, so an unbound Alt
-              // never disqualifies a match
-              if (key === "Alt") {
-                return true;
-              }
-              // If modifier not provided, expect `false`
-              return !modifierMap[key];
+              // If modifier not provided, expect `false` (except Alt, which
+              // only peeks at the hints)
+              return key === "Alt" || !modifierMap[key];
             });
 
             if (doesEveryModifierMatch && finalKey === eventKey) {
-              return callbackRef.current(event);
+              return fireCallback();
             }
           } else {
             // If the shortcut doesn't begin with a modifier, it's a sequence
@@ -149,7 +124,7 @@ export const useShortcut = (
                 keyCombo.length === keyArray.length - 1
               ) {
                 // Run handler if the sequence is complete, then reset it
-                callbackRef.current(event);
+                fireCallback();
                 return setKeyCombo([]);
               }
 
@@ -165,12 +140,11 @@ export const useShortcut = (
 
         // Single key shortcuts (e.g. pressing D)
         if (currentShortcut === eventKey) {
-          // Expect all modifiers except the shortcut-hint Alt key to be false
-          if (event.ctrlKey || event.metaKey || event.shiftKey) {
+          if (!isEveryOtherModifierFalse) {
             return;
           }
 
-          return callbackRef.current(event);
+          return fireCallback();
         }
       }
     },

--- a/apps/app/src/lib/hooks/useShortcut.ts
+++ b/apps/app/src/lib/hooks/useShortcut.ts
@@ -116,8 +116,12 @@ export const useShortcut = (
               return fireCallback();
             }
           } else {
-            // If the shortcut doesn't begin with a modifier, it's a sequence
-            if (keyArray[keyCombo.length] === eventKey) {
+            // If the shortcut doesn't begin with a modifier, it's a sequence,
+            // which requires the same bare-key modifier state as single keys
+            if (
+              isEveryOtherModifierFalse &&
+              keyArray[keyCombo.length] === eventKey
+            ) {
               // Handle final key in the sequence
               if (
                 keyArray[keyArray.length - 1] === eventKey &&
@@ -128,7 +132,11 @@ export const useShortcut = (
                 return setKeyCombo([]);
               }
 
-              // Add to the sequence
+              // Add to the sequence; keep intermediate Alt-held keys away
+              // from browser menu accelerators too
+              if (event.altKey) {
+                event.preventDefault();
+              }
               return setKeyCombo((prevCombo) => [...prevCombo, eventKey]);
             }
             if (keyCombo.length > 0) {

--- a/apps/app/src/lib/hooks/useShortcut.ts
+++ b/apps/app/src/lib/hooks/useShortcut.ts
@@ -78,9 +78,11 @@ export const useShortcut = (
       );
 
       const fireCallback = () => {
-        // Alt+key is a browser menu accelerator on Windows/Linux; suppress
-        // it when the shortcut fires while peeking at the hints
-        if (event.altKey) {
+        // Alt+letter is a browser menu accelerator on Windows/Linux;
+        // suppress it when the shortcut fires while peeking at the hints.
+        // Named keys keep their default (Alt+Arrow is the browser history
+        // gesture there).
+        if (event.altKey && eventKey.length === 1) {
           event.preventDefault();
         }
         return callbackRef.current(event);
@@ -134,7 +136,7 @@ export const useShortcut = (
 
               // Add to the sequence; keep intermediate Alt-held keys away
               // from browser menu accelerators too
-              if (event.altKey) {
+              if (event.altKey && eventKey.length === 1) {
                 event.preventDefault();
               }
               return setKeyCombo((prevCombo) => [...prevCombo, eventKey]);

--- a/apps/app/src/lib/hooks/useShortcut.ts
+++ b/apps/app/src/lib/hooks/useShortcut.ts
@@ -21,6 +21,43 @@ type UseShortcutOptions = {
   allowRepeat?: boolean;
 };
 
+// Punctuation codes for keys used in shortcut bindings, as
+// [unshifted, shifted] pairs.
+const PUNCTUATION_CODE_KEYS: Record<string, [string, string]> = {
+  Backslash: ["\\", "|"],
+  BracketLeft: ["[", "{"],
+  BracketRight: ["]", "}"],
+  Minus: ["-", "_"],
+  Equal: ["=", "+"],
+  Space: [" ", " "],
+};
+
+/**
+ * Alt is the "peek at shortcuts" key, so shortcuts must still match while it
+ * is held. On macOS, Option composes `event.key` into a different character
+ * (Option+E → "´"), so recover the logical key from `event.code` instead.
+ */
+const getEventKey = (
+  event: Pick<KeyboardEvent<Element>, "altKey" | "shiftKey" | "code" | "key">,
+): string => {
+  if (!event.altKey) {
+    return event.key;
+  }
+  const { code } = event;
+  if (code.startsWith("Key") && code.length === 4) {
+    const letter = code.slice(3);
+    return event.shiftKey ? letter : letter.toLowerCase();
+  }
+  if (code.startsWith("Digit") && code.length === 6 && !event.shiftKey) {
+    return code.slice(5);
+  }
+  const punctuation = PUNCTUATION_CODE_KEYS[code];
+  if (punctuation) {
+    return event.shiftKey ? punctuation[1] : punctuation[0];
+  }
+  return event.key;
+};
+
 export const useShortcut = (
   shortcut: string | string[],
   callback: (event: KeyboardEvent<Element>) => void,
@@ -68,6 +105,8 @@ export const useShortcut = (
         Shift: event.shiftKey,
       };
 
+      const eventKey = getEventKey(event);
+
       for (const currentShortcut of shortcutsKey.split("\n")) {
         // Handle combined modifier key shortcuts (e.g. pressing Control + D)
         if (currentShortcut.includes("+")) {
@@ -89,19 +128,24 @@ export const useShortcut = (
               if (pressedModifierSet.has(key)) {
                 return modifierMap[key];
               }
+              // Alt only peeks at the shortcut hints, so an unbound Alt
+              // never disqualifies a match
+              if (key === "Alt") {
+                return true;
+              }
               // If modifier not provided, expect `false`
               return !modifierMap[key];
             });
 
-            if (doesEveryModifierMatch && finalKey === event.key) {
+            if (doesEveryModifierMatch && finalKey === eventKey) {
               return callbackRef.current(event);
             }
           } else {
             // If the shortcut doesn't begin with a modifier, it's a sequence
-            if (keyArray[keyCombo.length] === event.key) {
+            if (keyArray[keyCombo.length] === eventKey) {
               // Handle final key in the sequence
               if (
-                keyArray[keyArray.length - 1] === event.key &&
+                keyArray[keyArray.length - 1] === eventKey &&
                 keyCombo.length === keyArray.length - 1
               ) {
                 // Run handler if the sequence is complete, then reset it
@@ -110,7 +154,7 @@ export const useShortcut = (
               }
 
               // Add to the sequence
-              return setKeyCombo((prevCombo) => [...prevCombo, event.key]);
+              return setKeyCombo((prevCombo) => [...prevCombo, eventKey]);
             }
             if (keyCombo.length > 0) {
               // Reset key combo if it doesn't match the sequence
@@ -120,13 +164,9 @@ export const useShortcut = (
         }
 
         // Single key shortcuts (e.g. pressing D)
-        if (currentShortcut === event.key) {
-          // Expect all modifiers to be false
-          const isEveryModifierFalse = Object.values(modifierMap).every(
-            (value) => !value,
-          );
-
-          if (!isEveryModifierFalse) {
+        if (currentShortcut === eventKey) {
+          // Expect all modifiers except the shortcut-hint Alt key to be false
+          if (event.ctrlKey || event.metaKey || event.shiftKey) {
             return;
           }
 

--- a/apps/app/tests/unit/components/use-management-shortcuts.test.ts
+++ b/apps/app/tests/unit/components/use-management-shortcuts.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useFeedManagementShortcuts } from "~/components/feed/useManagementShortcuts";
+
+const mocks = vi.hoisted(() => ({
+  onEscape: vi.fn(),
+  onSelectAll: vi.fn(),
+  onEdit: vi.fn(),
+  onClear: vi.fn(),
+  onDelete: vi.fn(),
+}));
+
+vi.mock("~/lib/data/offline-mutations", () => ({
+  useCanMutate: () => true,
+}));
+
+vi.mock("~/lib/doesAnyFormElementHaveFocus", () => ({
+  doesAnyFormElementHaveFocus: () => false,
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const roots: Array<ReturnType<typeof createRoot>> = [];
+
+function mountManagementShortcuts() {
+  function ManagementShortcutHarness() {
+    useFeedManagementShortcuts({
+      onEscape: mocks.onEscape,
+      onSelectAll: mocks.onSelectAll,
+      onEdit: mocks.onEdit,
+      onClear: mocks.onClear,
+      onDelete: mocks.onDelete,
+      isDialogOpen: false,
+      hasSelection: true,
+    });
+    return null;
+  }
+
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  roots.push(root);
+  act(() => {
+    root.render(createElement(ManagementShortcutHarness));
+  });
+}
+
+function pressKey(init: KeyboardEventInit) {
+  // Dispatch from the body so `event.target` is a DOM element, as in a real
+  // browser; the hook's window listener sees it through bubbling.
+  const event = new KeyboardEvent("keydown", {
+    cancelable: true,
+    bubbles: true,
+    ...init,
+  });
+  act(() => {
+    document.body.dispatchEvent(event);
+  });
+  return event;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "platform", {
+    value: "MacIntel",
+    configurable: true,
+  });
+  mountManagementShortcuts();
+});
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    act(() => {
+      root.unmount();
+    });
+  }
+  document.body.replaceChildren();
+});
+
+describe("useFeedManagementShortcuts", () => {
+  it("fires the plain shortcut keys", () => {
+    pressKey({ key: "s", code: "KeyS" });
+    pressKey({ key: "e", code: "KeyE" });
+    pressKey({ key: "c", code: "KeyC" });
+    pressKey({ key: "d", code: "KeyD" });
+
+    expect(mocks.onSelectAll).toHaveBeenCalledTimes(1);
+    expect(mocks.onEdit).toHaveBeenCalledTimes(1);
+    expect(mocks.onClear).toHaveBeenCalledTimes(1);
+    expect(mocks.onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires while Alt composes the key on macOS and cancels the default", () => {
+    const event = pressKey({ key: "ß", code: "KeyS", altKey: true });
+
+    expect(mocks.onSelectAll).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("handles Escape while Alt is held without cancelling the default", () => {
+    const event = pressKey({ key: "Escape", code: "Escape", altKey: true });
+
+    expect(mocks.onEscape).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("ignores keys behind Ctrl and Meta", () => {
+    pressKey({ key: "s", code: "KeyS", metaKey: true });
+    pressKey({ key: "s", code: "KeyS", ctrlKey: true });
+    pressKey({ key: "d", code: "KeyD", metaKey: true });
+
+    expect(mocks.onSelectAll).not.toHaveBeenCalled();
+    expect(mocks.onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/tests/unit/components/use-youtube-video-shortcuts.test.ts
+++ b/apps/app/tests/unit/components/use-youtube-video-shortcuts.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useVideoShortcuts } from "~/components/CustomVideoPlayer/useYouTubeVideoShortcuts";
+
+const mocks = vi.hoisted(() => ({
+  toggleVideoPlayback: vi.fn(),
+  changeVideoPlaybackSpeed: vi.fn(),
+  seekToSecond: vi.fn(),
+  toggleCaptions: vi.fn(),
+  toggleNativeFullscreen: vi.fn(),
+  toggleMute: vi.fn(),
+  setView: vi.fn(),
+  toggleView: vi.fn(),
+}));
+
+vi.mock("~/components/CustomVideoPlayer/CustomVideoPlayerProvider", () => ({
+  useCustomVideoPlayerContext: () => ({
+    toggleVideoPlayback: mocks.toggleVideoPlayback,
+    playerState: "playing",
+    playbackSpeed: 1,
+    changeVideoPlaybackSpeed: mocks.changeVideoPlaybackSpeed,
+    videoDuration: 100,
+    seekToSecond: mocks.seekToSecond,
+    videoProgress: 50,
+    captionsModuleLoaded: true,
+    toggleCaptions: mocks.toggleCaptions,
+    toggleNativeFullscreen: mocks.toggleNativeFullscreen,
+    isNativeFullscreen: false,
+    toggleMute: mocks.toggleMute,
+  }),
+}));
+
+vi.mock("~/components/feed/watch/[id]/useView", () => ({
+  useView: () => ({
+    view: "default",
+    setView: mocks.setView,
+    toggleView: mocks.toggleView,
+  }),
+}));
+
+vi.mock("~/lib/doesAnyFormElementHaveFocus", () => ({
+  doesAnyFormElementHaveFocus: () => false,
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const roots: Array<ReturnType<typeof createRoot>> = [];
+
+function mountVideoShortcuts() {
+  function VideoShortcutHarness() {
+    useVideoShortcuts();
+    return null;
+  }
+
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  roots.push(root);
+  act(() => {
+    root.render(createElement(VideoShortcutHarness));
+  });
+}
+
+function releaseKey(init: KeyboardEventInit) {
+  act(() => {
+    window.dispatchEvent(
+      new KeyboardEvent("keyup", { cancelable: true, ...init }),
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "platform", {
+    value: "MacIntel",
+    configurable: true,
+  });
+  mountVideoShortcuts();
+});
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    act(() => {
+      root.unmount();
+    });
+  }
+  document.body.replaceChildren();
+});
+
+describe("useVideoShortcuts", () => {
+  it("toggles mute on m", () => {
+    releaseKey({ key: "m", code: "KeyM" });
+
+    expect(mocks.toggleMute).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles mute while Alt composes the key on macOS", () => {
+    releaseKey({ key: "µ", code: "KeyM", altKey: true });
+
+    expect(mocks.toggleMute).toHaveBeenCalledTimes(1);
+  });
+
+  it("enters fullscreen on f while Alt is held", () => {
+    releaseKey({ key: "ƒ", code: "KeyF", altKey: true });
+
+    expect(mocks.toggleNativeFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("changes playback speed on Shift+> while Alt is held", () => {
+    // German mac-style composition of Shift+Period under Option.
+    releaseKey({ key: "˘", code: "Period", altKey: true, shiftKey: true });
+
+    expect(mocks.changeVideoPlaybackSpeed).toHaveBeenCalledTimes(1);
+  });
+
+  it("still ignores keys behind Ctrl and Meta", () => {
+    releaseKey({ key: "m", code: "KeyM", ctrlKey: true });
+    releaseKey({ key: "m", code: "KeyM", metaKey: true });
+
+    expect(mocks.toggleMute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/tests/unit/hooks/use-shortcut.test.ts
+++ b/apps/app/tests/unit/hooks/use-shortcut.test.ts
@@ -229,6 +229,11 @@ describe("useShortcut", () => {
     setPlatform("MacIntel");
     pressKey({ key: "´", code: "KeyE", altKey: true });
     expect(onMac).toHaveBeenCalledTimes(1);
+
+    // An empty userAgentData platform falls back to navigator.platform.
+    setUserAgentDataPlatform("");
+    pressKey({ key: "´", code: "KeyE", altKey: true });
+    expect(onMac).toHaveBeenCalledTimes(2);
   });
 
   it("does not cancel named-key defaults while Alt is held", () => {
@@ -268,6 +273,16 @@ describe("useShortcut", () => {
 
     expect(plain.defaultPrevented).toBe(false);
     expect(withAlt.defaultPrevented).toBe(true);
+  });
+
+  it("leaves the default intact for an unbound printable key under Alt", () => {
+    const callback = vi.fn();
+    mountShortcut("e", callback);
+
+    const event = pressKey({ key: "ø", code: "KeyO", altKey: true });
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
   });
 
   it("still blocks single-key shortcuts behind Shift", () => {

--- a/apps/app/tests/unit/hooks/use-shortcut.test.ts
+++ b/apps/app/tests/unit/hooks/use-shortcut.test.ts
@@ -25,7 +25,7 @@ function mountShortcut(shortcut: string | string[], callback: () => void) {
   }
 
   const container = document.createElement("div");
-  document.body.appendChild(container);
+  document.body.append(container);
   const root = createRoot(container);
   roots.push(root);
   act(() => {
@@ -34,9 +34,11 @@ function mountShortcut(shortcut: string | string[], callback: () => void) {
 }
 
 function pressKey(init: KeyboardEventInit) {
+  const event = new KeyboardEvent("keydown", { cancelable: true, ...init });
   act(() => {
-    window.dispatchEvent(new KeyboardEvent("keydown", init));
+    window.dispatchEvent(event);
   });
+  return event;
 }
 
 afterEach(() => {
@@ -45,7 +47,7 @@ afterEach(() => {
       root.unmount();
     });
   }
-  document.body.innerHTML = "";
+  document.body.replaceChildren();
 });
 
 describe("useShortcut", () => {
@@ -86,22 +88,105 @@ describe("useShortcut", () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it("fires a punctuation shortcut while Alt is held", () => {
-    const callback = vi.fn();
-    mountShortcut("[", callback);
+  it("fires punctuation shortcuts while Alt is held", () => {
+    const openBracket = vi.fn();
+    const backslash = vi.fn();
+    mountShortcut("[", openBracket);
+    mountShortcut("\\", backslash);
 
     pressKey({ key: "“", code: "BracketLeft", altKey: true });
+    pressKey({ key: "«", code: "Backslash", altKey: true });
+
+    expect(openBracket).toHaveBeenCalledTimes(1);
+    expect(backslash).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires the space shortcut when Option composes a non-breaking space", () => {
+    const callback = vi.fn();
+    mountShortcut(" ", callback);
+
+    pressKey({ key: " ", code: "Space", altKey: true });
 
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it("fires a Shift combo shortcut while Alt is held", () => {
+  it("fires a Shift combo shortcut with and without Alt held", () => {
     const callback = vi.fn();
     mountShortcut("Shift+F", callback);
 
+    pressKey({ key: "F", code: "KeyF", shiftKey: true });
     pressKey({ key: "Ï", code: "KeyF", altKey: true, shiftKey: true });
 
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires a shifted punctuation combo while Alt is held", () => {
+    const callback = vi.fn();
+    mountShortcut("Shift+|", callback);
+
+    pressKey({ key: "»", code: "Backslash", altKey: true, shiftKey: true });
+
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires a shortcut that explicitly binds Alt", () => {
+    const callback = vi.fn();
+    mountShortcut("Alt+e", callback);
+
+    pressKey({ key: "´", code: "KeyE", altKey: true });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires a key sequence, including while Alt composes the keys", () => {
+    const callback = vi.fn();
+    mountShortcut("g+i", callback);
+
+    pressKey({ key: "g", code: "KeyG" });
+    pressKey({ key: "i", code: "KeyI" });
+
+    // Option+G composes to "©" and Option+I is a dead key on macOS.
+    pressKey({ key: "©", code: "KeyG", altKey: true });
+    pressKey({ key: "Dead", code: "KeyI", altKey: true });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps layout-aware keys when Alt does not compose them", () => {
+    // German QWERTZ: the key labeled Y reports code KeyZ but key "y".
+    const archive = vi.fn();
+    const undo = vi.fn();
+    mountShortcut("y", archive);
+    mountShortcut("z", undo);
+
+    pressKey({ key: "y", code: "KeyZ", altKey: true });
+
+    expect(archive).toHaveBeenCalledTimes(1);
+    expect(undo).not.toHaveBeenCalled();
+  });
+
+  it("leaves numpad and named keys untouched while Alt is held", () => {
+    const digit = vi.fn();
+    const arrow = vi.fn();
+    mountShortcut("1", digit);
+    mountShortcut("ArrowDown", arrow);
+
+    pressKey({ key: "1", code: "Numpad1", altKey: true });
+    pressKey({ key: "ArrowDown", code: "ArrowDown", altKey: true });
+
+    expect(digit).toHaveBeenCalledTimes(1);
+    expect(arrow).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents the browser default only when firing with Alt held", () => {
+    const callback = vi.fn();
+    mountShortcut("e", callback);
+
+    const plain = pressKey({ key: "e", code: "KeyE" });
+    const withAlt = pressKey({ key: "e", code: "KeyE", altKey: true });
+
+    expect(plain.defaultPrevented).toBe(false);
+    expect(withAlt.defaultPrevented).toBe(true);
   });
 
   it("still blocks single-key shortcuts behind Ctrl and Meta", () => {

--- a/apps/app/tests/unit/hooks/use-shortcut.test.ts
+++ b/apps/app/tests/unit/hooks/use-shortcut.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useShortcut } from "~/lib/hooks/useShortcut";
+
+vi.mock("~/components/feed/dialogStore", () => ({
+  useDialogStore: (selector: (store: { dialog: null }) => unknown) =>
+    selector({ dialog: null }),
+}));
+
+vi.mock("~/lib/doesAnyFormElementHaveFocus", () => ({
+  doesAnyFormElementHaveFocus: () => false,
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const roots: Array<ReturnType<typeof createRoot>> = [];
+
+function mountShortcut(shortcut: string | string[], callback: () => void) {
+  function ShortcutHarness() {
+    useShortcut(shortcut, callback);
+    return null;
+  }
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  act(() => {
+    root.render(createElement(ShortcutHarness));
+  });
+}
+
+function pressKey(init: KeyboardEventInit) {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", init));
+  });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    act(() => {
+      root.unmount();
+    });
+  }
+  document.body.innerHTML = "";
+});
+
+describe("useShortcut", () => {
+  it("fires a single-key shortcut without modifiers", () => {
+    const callback = vi.fn();
+    mountShortcut("e", callback);
+
+    pressKey({ key: "e", code: "KeyE" });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires a single-key shortcut while Alt is held", () => {
+    const callback = vi.fn();
+    mountShortcut("e", callback);
+
+    pressKey({ key: "e", code: "KeyE", altKey: true });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires while Alt is held even when macOS composes the key", () => {
+    const callback = vi.fn();
+    mountShortcut("e", callback);
+
+    // On macOS, Option+E reports the composed character as `key`.
+    pressKey({ key: "´", code: "KeyE", altKey: true });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires a digit shortcut while Alt is held", () => {
+    const callback = vi.fn();
+    mountShortcut("1", callback);
+
+    pressKey({ key: "¡", code: "Digit1", altKey: true });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires a punctuation shortcut while Alt is held", () => {
+    const callback = vi.fn();
+    mountShortcut("[", callback);
+
+    pressKey({ key: "“", code: "BracketLeft", altKey: true });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires a Shift combo shortcut while Alt is held", () => {
+    const callback = vi.fn();
+    mountShortcut("Shift+F", callback);
+
+    pressKey({ key: "Ï", code: "KeyF", altKey: true, shiftKey: true });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("still blocks single-key shortcuts behind Ctrl and Meta", () => {
+    const callback = vi.fn();
+    mountShortcut("e", callback);
+
+    pressKey({ key: "e", code: "KeyE", ctrlKey: true });
+    pressKey({ key: "e", code: "KeyE", metaKey: true });
+    pressKey({ key: "e", code: "KeyE", altKey: true, ctrlKey: true });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("still blocks Shift combos behind Ctrl and Meta", () => {
+    const callback = vi.fn();
+    mountShortcut("Shift+F", callback);
+
+    pressKey({ key: "F", code: "KeyF", shiftKey: true, ctrlKey: true });
+    pressKey({ key: "F", code: "KeyF", shiftKey: true, metaKey: true });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/tests/unit/hooks/use-shortcut.test.ts
+++ b/apps/app/tests/unit/hooks/use-shortcut.test.ts
@@ -2,7 +2,7 @@
 
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useShortcut } from "~/lib/hooks/useShortcut";
 
 vi.mock("~/components/feed/dialogStore", () => ({
@@ -17,6 +17,13 @@ vi.mock("~/lib/doesAnyFormElementHaveFocus", () => ({
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
 const roots: Array<ReturnType<typeof createRoot>> = [];
+
+function setPlatform(platform: string) {
+  Object.defineProperty(navigator, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
 
 function mountShortcut(shortcut: string | string[], callback: () => void) {
   function ShortcutHarness() {
@@ -40,6 +47,12 @@ function pressKey(init: KeyboardEventInit) {
   });
   return event;
 }
+
+beforeEach(() => {
+  // Key recovery from `event.code` only happens on macOS, where Option
+  // composes `event.key`.
+  setPlatform("MacIntel");
+});
 
 afterEach(() => {
   for (const root of roots.splice(0)) {
@@ -77,6 +90,19 @@ describe("useShortcut", () => {
     pressKey({ key: "´", code: "KeyE", altKey: true });
 
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers keys that Option composes into plain ASCII", () => {
+    // German macOS layout: Option+5 reports "[", a live binding of its own.
+    const viewFive = vi.fn();
+    const prevView = vi.fn();
+    mountShortcut("5", viewFive);
+    mountShortcut("[", prevView);
+
+    pressKey({ key: "[", code: "Digit5", altKey: true });
+
+    expect(viewFive).toHaveBeenCalledTimes(1);
+    expect(prevView).not.toHaveBeenCalled();
   });
 
   it("fires a digit shortcut while Alt is held", () => {
@@ -129,12 +155,15 @@ describe("useShortcut", () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it("fires a shortcut that explicitly binds Alt", () => {
+  it("fires a shortcut that explicitly binds Alt, and only with Alt", () => {
     const callback = vi.fn();
     mountShortcut("Alt+e", callback);
 
-    pressKey({ key: "´", code: "KeyE", altKey: true });
+    pressKey({ key: "e", code: "KeyE" });
+    pressKey({ key: "´", code: "KeyE", altKey: true, ctrlKey: true });
+    expect(callback).not.toHaveBeenCalled();
 
+    pressKey({ key: "´", code: "KeyE", altKey: true });
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -152,8 +181,22 @@ describe("useShortcut", () => {
     expect(callback).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps layout-aware keys when Alt does not compose them", () => {
-    // German QWERTZ: the key labeled Y reports code KeyZ but key "y".
+  it("does not advance a key sequence while Ctrl or Meta is held", () => {
+    const callback = vi.fn();
+    mountShortcut("g+i", callback);
+
+    pressKey({ key: "g", code: "KeyG", ctrlKey: true });
+    pressKey({ key: "i", code: "KeyI", ctrlKey: true });
+    pressKey({ key: "g", code: "KeyG", metaKey: true });
+    pressKey({ key: "i", code: "KeyI", metaKey: true });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("keeps layout-aware keys where Alt does not compose them", () => {
+    // Windows QWERTZ: the key labeled Y reports code KeyZ but key "y", and
+    // Alt does not compose, so `event.key` stays authoritative.
+    setPlatform("Win32");
     const archive = vi.fn();
     const undo = vi.fn();
     mountShortcut("y", archive);
@@ -187,6 +230,18 @@ describe("useShortcut", () => {
 
     expect(plain.defaultPrevented).toBe(false);
     expect(withAlt.defaultPrevented).toBe(true);
+  });
+
+  it("still blocks single-key shortcuts behind Shift", () => {
+    const callback = vi.fn();
+    // "[" reports the same key with Shift held, so this exercises the
+    // modifier gate rather than a key mismatch.
+    mountShortcut("[", callback);
+
+    pressKey({ key: "[", code: "BracketLeft", shiftKey: true });
+    pressKey({ key: "“", code: "BracketLeft", altKey: true, shiftKey: true });
+
+    expect(callback).not.toHaveBeenCalled();
   });
 
   it("still blocks single-key shortcuts behind Ctrl and Meta", () => {

--- a/apps/app/tests/unit/hooks/use-shortcut.test.ts
+++ b/apps/app/tests/unit/hooks/use-shortcut.test.ts
@@ -25,6 +25,13 @@ function setPlatform(platform: string) {
   });
 }
 
+function setUserAgentDataPlatform(platform: string | undefined) {
+  Object.defineProperty(navigator, "userAgentData", {
+    value: platform === undefined ? undefined : { platform },
+    configurable: true,
+  });
+}
+
 function mountShortcut(shortcut: string | string[], callback: () => void) {
   function ShortcutHarness() {
     useShortcut(shortcut, callback);
@@ -55,6 +62,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setUserAgentDataPlatform(undefined);
   for (const root of roots.splice(0)) {
     act(() => {
       root.unmount();
@@ -208,6 +216,36 @@ describe("useShortcut", () => {
     expect(undo).not.toHaveBeenCalled();
   });
 
+  it("prefers userAgentData.platform over navigator.platform", () => {
+    const onMac = vi.fn();
+    mountShortcut("e", onMac);
+
+    setUserAgentDataPlatform("macOS");
+    setPlatform("Win32");
+    pressKey({ key: "´", code: "KeyE", altKey: true });
+    expect(onMac).toHaveBeenCalledTimes(1);
+
+    setUserAgentDataPlatform("Windows");
+    setPlatform("MacIntel");
+    pressKey({ key: "´", code: "KeyE", altKey: true });
+    expect(onMac).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel named-key defaults while Alt is held", () => {
+    // Alt+Arrow is the browser history gesture on Windows/Linux.
+    const callback = vi.fn();
+    mountShortcut("ArrowLeft", callback);
+
+    const event = pressKey({
+      key: "ArrowLeft",
+      code: "ArrowLeft",
+      altKey: true,
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   it("leaves numpad and named keys untouched while Alt is held", () => {
     const digit = vi.fn();
     const arrow = vi.fn();
@@ -234,8 +272,9 @@ describe("useShortcut", () => {
 
   it("still blocks single-key shortcuts behind Shift", () => {
     const callback = vi.fn();
-    // "[" reports the same key with Shift held, so this exercises the
-    // modifier gate rather than a key mismatch.
+    // The first press reports "[" unchanged under Shift, so it exercises
+    // the modifier gate; the second recovers the shifted "{" and pins that
+    // Alt+Shift cannot reach a bare binding either way.
     mountShortcut("[", callback);
 
     pressKey({ key: "[", code: "BracketLeft", shiftKey: true });


### PR DESCRIPTION
- Treat Alt as a transparent "peek" key in `useShortcut`: single keys, Shift combos, and key sequences now fire while Alt is held, while Ctrl/Meta/Shift still disqualify as before
- Recover the logical key from `event.code` while Alt is held, since macOS Option composes `event.key` into a different character
- Add unit tests for `useShortcut` covering Alt-held matching, macOS composed keys, and modifier blocking