### PR TITLE
Fix callback signup notification

### DIFF
--- a/apps/app/src/server/auth/policy.ts
+++ b/apps/app/src/server/auth/policy.ts
@@ -6,6 +6,7 @@ import { db } from "../db";
 import { account, appConfig, session, user } from "../db/schema";
 import type { AuthProvider } from "~/lib/constants";
 import NewUserNotificationEmail from "~/emails/new-user-notification";
+import { isAtprotoPlaceholderEmail } from "~/lib/auth/atproto";
 import {
   getAvailableSignupProviders,
   getEnabledAuthProviders,
@@ -15,7 +16,6 @@ import {
   getAccountProviderId,
   getConfiguredAuthProviders,
 } from "~/server/auth/constants";
-import { isAtprotoPlaceholderEmail } from "~/lib/auth/atproto";
 import { IS_EMAIL_ENABLED, sendEmail } from "~/server/email";
 import {
   redeemInvitationToken,

--- a/apps/app/src/server/auth/policy.ts
+++ b/apps/app/src/server/auth/policy.ts
@@ -15,6 +15,7 @@ import {
   getAccountProviderId,
   getConfiguredAuthProviders,
 } from "~/server/auth/constants";
+import { isAtprotoPlaceholderEmail } from "~/lib/auth/atproto";
 import { IS_EMAIL_ENABLED, sendEmail } from "~/server/email";
 import {
   redeemInvitationToken,
@@ -235,6 +236,12 @@ export async function applyPostAuthPolicy(
       Date.now() - firstUser.createdAt.getTime() <=
         AUTO_SIGNUP_ROLLBACK_WINDOW_MS);
 
+  // Whether this callback auto-created its user within this request. A
+  // callback completes plain sign-ins as well as auto-signups, so both the
+  // rollback below and the admin notification at the end consume this one
+  // determination rather than forking parallel recency checks.
+  let callbackAutoCreatedUser = false;
+
   if (isFirstUserBootstrap && !IS_DEMO_INSTANCE) {
     await db.update(user).set({ role: "admin" }).where(eq(user.id, userId));
 
@@ -309,11 +316,12 @@ export async function applyPostAuthPolicy(
       accountRows.length === 1 &&
       accountRows[0]!.providerId === getAccountProviderId(completed.provider);
 
-    if (
+    callbackAutoCreatedUser =
       wasJustCreated &&
       (sessionCount?.count ?? 0) <= 1 &&
-      isSoleProviderAccount
-    ) {
+      isSoleProviderAccount;
+
+    if (callbackAutoCreatedUser) {
       const configs = await db.select().from(appConfig).all();
       const publicSignupConfig = configs.find(
         (c) => c.key === "public-signup-enabled",
@@ -338,8 +346,15 @@ export async function applyPostAuthPolicy(
     }
   }
 
-  // Send admin notification email for non-first user sign-ups
-  if (firstUser?.id !== userId && IS_EMAIL_ENABLED) {
+  // Send admin notification email for non-first user sign-ups. An email
+  // sign-up flow always just created its user; a callback also completes
+  // plain sign-ins by established users, so only its genuine auto-signup
+  // notifies.
+  if (
+    firstUser?.id !== userId &&
+    IS_EMAIL_ENABLED &&
+    (completed.flow === "sign-up" || callbackAutoCreatedUser)
+  ) {
     try {
       const notifyConfig = await db
         .select()
@@ -353,10 +368,15 @@ export async function applyPostAuthPolicy(
         .get();
 
       if (notifyConfig?.value === "true" && emailConfig?.value) {
+        // A DID-only Atmosphere sign-up carries the internal placeholder
+        // address; the notification omits it (the name is already the
+        // handle) rather than surfacing a synthetic email to the admin.
         const html = await render(
           createElement(NewUserNotificationEmail, {
             userName: completed.user.name,
-            userEmail: completed.user.email,
+            userEmail: isAtprotoPlaceholderEmail(completed.user.email)
+              ? undefined
+              : completed.user.email,
           }),
         );
 

--- a/apps/app/tests/unit/auth/signup-notification.test.ts
+++ b/apps/app/tests/unit/auth/signup-notification.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  applyMigrations,
+  createLocalBenchmarkTarget,
+  openBenchmarkDatabase,
+} from "../../../scripts/performance/database";
+import {
+  account,
+  appConfig,
+  session as sessionTable,
+  user,
+} from "~/server/db/schema";
+
+/**
+ * The admin "new user signed up" notification must fire only when a user
+ * was actually created by the completing flow. A callback completes plain
+ * sign-ins as well as auto-signups, so it notifies only when the shared
+ * auto-created determination (creation recency, session count, sole
+ * provider account row) holds; email sign-up always just created its
+ * user. A DID-only Atmosphere sign-up notifies without surfacing the
+ * internal placeholder address.
+ */
+
+const dbHolder = vi.hoisted(() => {
+  const holder: { current: unknown } = { current: undefined };
+  return holder;
+});
+
+vi.mock("~/server/db", () => ({
+  get db() {
+    return dbHolder.current;
+  },
+}));
+
+vi.mock("~/server/auth/constants", () => ({
+  getConfiguredAuthProviders: () => ["email", "atproto"],
+  getAccountProviderId: (provider: string) =>
+    provider === "email" ? "credential" : provider,
+}));
+
+vi.mock("~/server/email", () => ({
+  IS_EMAIL_ENABLED: true,
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { applyPostAuthPolicy } = await import("~/server/auth/policy");
+const { sendEmail } = await import("~/server/email");
+
+type Session = ReturnType<typeof openBenchmarkDatabase>;
+type Target = ReturnType<typeof createLocalBenchmarkTarget>;
+
+describe("admin signup notification", () => {
+  let session: Session;
+  let target: Target;
+
+  beforeEach(async () => {
+    vi.mocked(sendEmail).mockClear();
+    target = createLocalBenchmarkTarget();
+    session = openBenchmarkDatabase({ url: target.url });
+    await applyMigrations(session.baseClient);
+    dbHolder.current = session.database;
+
+    // An older first user so the first-user promotion branch is skipped.
+    await session.database.insert(user).values({
+      id: "user-first",
+      name: "first",
+      email: "first@example.com",
+      emailVerified: true,
+      createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+      updatedAt: new Date(),
+    });
+    // Sign-ups open and the notification setting enabled.
+    await session.database.insert(appConfig).values([
+      {
+        key: "public-signup-enabled",
+        value: "true",
+        updatedAt: new Date(),
+      },
+      {
+        key: "enabled-signup-providers",
+        value: JSON.stringify(["email", "atproto"]),
+        updatedAt: new Date(),
+      },
+      {
+        key: "admin-notify-on-signup",
+        value: "true",
+        updatedAt: new Date(),
+      },
+      {
+        key: "admin-notify-email",
+        value: "admin@example.com",
+        updatedAt: new Date(),
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    session.close();
+    target.cleanup();
+    dbHolder.current = undefined;
+  });
+
+  async function insertCallbackUser(
+    id: string,
+    createdAt: Date,
+    options: { email?: string; accountProviderIds?: string[] } = {},
+  ) {
+    await session.database.insert(user).values({
+      id,
+      name: id,
+      email: options.email ?? `${id}@example.com`,
+      emailVerified: false,
+      createdAt,
+      updatedAt: new Date(),
+    });
+    for (const providerId of options.accountProviderIds ?? ["atproto"]) {
+      await session.database.insert(account).values({
+        id: `account-${id}-${providerId}`,
+        accountId: `${providerId}-${id}`,
+        providerId,
+        userId: id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    }
+    await session.database.insert(sessionTable).values({
+      id: `session-${id}`,
+      userId: id,
+      token: `token-${id}`,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  function completedAuth(
+    id: string,
+    flow: "sign-up" | "callback",
+    options: { provider?: "email" | "atproto"; email?: string } = {},
+  ) {
+    return {
+      provider: options.provider ?? ("atproto" as const),
+      flow,
+      user: { id, name: id, email: options.email ?? `${id}@example.com` },
+      rollbackNewUser: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it("notifies when a callback auto-creates its user", async () => {
+    await insertCallbackUser("user-new", new Date());
+
+    await applyPostAuthPolicy(completedAuth("user-new", "callback"));
+
+    expect(sendEmail).toHaveBeenCalledOnce();
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "admin@example.com",
+        subject: "New user signed up: user-new",
+      }),
+    );
+  });
+
+  it("does not notify when an established user signs back in via callback", async () => {
+    // Linked yesterday; signing back in issues a fresh session either way.
+    await insertCallbackUser(
+      "user-linked",
+      new Date(Date.now() - 24 * 60 * 60 * 1000),
+    );
+
+    await applyPostAuthPolicy(completedAuth("user-linked", "callback"));
+
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when a callback implicitly links a just-created user", async () => {
+    // Signed up with email moments ago (which notified), then the callback
+    // linked the atproto account — not a second sign-up.
+    await insertCallbackUser("user-just-linked", new Date(), {
+      accountProviderIds: ["credential", "atproto"],
+    });
+
+    await applyPostAuthPolicy(completedAuth("user-just-linked", "callback"));
+
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("notifies on an email sign-up flow", async () => {
+    await insertCallbackUser("user-email", new Date(), {
+      accountProviderIds: ["credential"],
+    });
+
+    await applyPostAuthPolicy(
+      completedAuth("user-email", "sign-up", { provider: "email" }),
+    );
+
+    expect(sendEmail).toHaveBeenCalledOnce();
+  });
+
+  it("does not notify for the first user", async () => {
+    await applyPostAuthPolicy(
+      completedAuth("user-first", "sign-up", {
+        provider: "email",
+        email: "first@example.com",
+      }),
+    );
+
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("notifies for a DID-only sign-up without surfacing the placeholder email", async () => {
+    const placeholder = "did-plc-abc123.deadbeef@atproto.invalid";
+    await insertCallbackUser("user-did-only", new Date(), {
+      email: placeholder,
+    });
+
+    await applyPostAuthPolicy(
+      completedAuth("user-did-only", "callback", { email: placeholder }),
+    );
+
+    expect(sendEmail).toHaveBeenCalledOnce();
+    const [message] = vi.mocked(sendEmail).mock.calls[0]!;
+    expect(message.html).not.toContain("atproto.invalid");
+    expect(message.html).toContain("Not provided");
+  });
+});

--- a/apps/app/tests/unit/auth/signup-notification.test.ts
+++ b/apps/app/tests/unit/auth/signup-notification.test.ts
@@ -100,7 +100,7 @@ describe("admin signup notification", () => {
     dbHolder.current = undefined;
   });
 
-  async function insertCallbackUser(
+  async function insertUserWithAccounts(
     id: string,
     createdAt: Date,
     options: { email?: string; accountProviderIds?: string[] } = {},
@@ -136,7 +136,7 @@ describe("admin signup notification", () => {
   function completedAuth(
     id: string,
     flow: "sign-up" | "callback",
-    options: { provider?: "email" | "atproto"; email?: string } = {},
+    options: { provider?: "email" | "oauth" | "atproto"; email?: string } = {},
   ) {
     return {
       provider: options.provider ?? ("atproto" as const),
@@ -147,7 +147,7 @@ describe("admin signup notification", () => {
   }
 
   it("notifies when a callback auto-creates its user", async () => {
-    await insertCallbackUser("user-new", new Date());
+    await insertUserWithAccounts("user-new", new Date());
 
     await applyPostAuthPolicy(completedAuth("user-new", "callback"));
 
@@ -162,7 +162,7 @@ describe("admin signup notification", () => {
 
   it("does not notify when an established user signs back in via callback", async () => {
     // Linked yesterday; signing back in issues a fresh session either way.
-    await insertCallbackUser(
+    await insertUserWithAccounts(
       "user-linked",
       new Date(Date.now() - 24 * 60 * 60 * 1000),
     );
@@ -172,10 +172,24 @@ describe("admin signup notification", () => {
     expect(sendEmail).not.toHaveBeenCalled();
   });
 
+  it("does not notify when an established user signs back in via generic OAuth", async () => {
+    await insertUserWithAccounts(
+      "user-oauth",
+      new Date(Date.now() - 24 * 60 * 60 * 1000),
+      { accountProviderIds: ["oauth"] },
+    );
+
+    await applyPostAuthPolicy(
+      completedAuth("user-oauth", "callback", { provider: "oauth" }),
+    );
+
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
   it("does not notify when a callback implicitly links a just-created user", async () => {
     // Signed up with email moments ago (which notified), then the callback
     // linked the atproto account — not a second sign-up.
-    await insertCallbackUser("user-just-linked", new Date(), {
+    await insertUserWithAccounts("user-just-linked", new Date(), {
       accountProviderIds: ["credential", "atproto"],
     });
 
@@ -185,7 +199,7 @@ describe("admin signup notification", () => {
   });
 
   it("notifies on an email sign-up flow", async () => {
-    await insertCallbackUser("user-email", new Date(), {
+    await insertUserWithAccounts("user-email", new Date(), {
       accountProviderIds: ["credential"],
     });
 
@@ -209,7 +223,7 @@ describe("admin signup notification", () => {
 
   it("notifies for a DID-only sign-up without surfacing the placeholder email", async () => {
     const placeholder = "did-plc-abc123.deadbeef@atproto.invalid";
-    await insertCallbackUser("user-did-only", new Date(), {
+    await insertUserWithAccounts("user-did-only", new Date(), {
       email: placeholder,
     });
 


### PR DESCRIPTION
- Gate the admin "new user signed up" notification on the user actually having been created by the completing flow: callbacks notify only when the shared auto-created determination (creation recency, session count, sole-provider account row) holds; email sign-up keeps notifying unconditionally
- Compute that determination once and thread it to both the auto-signup rollback and the notification
- Omit the internal atproto placeholder email from the notification body for DID-only Atmosphere sign-ups; the name field already carries the handle
- Add unit coverage for callback sign-in, callback auto-signup, implicit linking, email sign-up, first user, and DID-only presentation