### PR TITLE
Fix beta CI

### DIFF
--- a/apps/app/scripts/test-e2e-cleanup.ts
+++ b/apps/app/scripts/test-e2e-cleanup.ts
@@ -200,6 +200,7 @@ async function waitForCleanup(
   ports: number[],
 ) {
   const deadline = Date.now() + CLEANUP_TIMEOUT_MS;
+  const processGroupIdSet = new Set(processGroupIds);
   let remainingObserved: ProcessRow[] = [];
   let remainingGroup: ProcessRow[] = [];
   let portsAvailable = false;
@@ -214,7 +215,7 @@ async function waitForCleanup(
       return current?.command === observed.command;
     });
     remainingGroup = processes.filter((process) =>
-      processGroupIds.includes(process.processGroupId),
+      processGroupIdSet.has(process.processGroupId),
     );
     portsAvailable = await arePortsAvailable(ports);
 

--- a/apps/app/src/app/_app.feeds.tsx
+++ b/apps/app/src/app/_app.feeds.tsx
@@ -3,51 +3,35 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ItemGroup } from "@serial/ui";
 import { ImportIcon, PlusIcon, Trash2Icon } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
-import { ViewCategoriesInput } from "~/components/view-dialog";
+import { useMemo, useState } from "react";
 import { ButtonWithShortcut } from "~/components/ButtonWithShortcut";
 import { useDialogStore } from "~/components/feed/dialogStore";
 import { FeedListItem } from "~/components/feed/FeedListItem";
 import { FeedManagementTabs } from "~/components/feed/FeedManagementTabs";
 import { useFeedManagementShortcuts } from "~/components/feed/useManagementShortcuts";
 import { FeedEmptyState } from "~/components/feed/view-lists/EmptyStates";
-import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
-import { Badge } from "~/components/ui/badge";
+import { ActiveFeedLimitStatus } from "~/components/feed/manage/ActiveFeedLimitStatus";
+import {
+  FeedActiveSwitch,
+  FeedRowBadges,
+} from "~/components/feed/manage/FeedRowControls";
+import {
+  DeleteFeedsDialog,
+  EditFeedsDialog,
+} from "~/components/feed/manage/ManageFeedsDialogs";
+import { useBulkFeedEditing } from "~/components/feed/manage/useBulkFeedEditing";
+import {
+  filterFeeds,
+  sortIdsByName,
+  useFeedMaps,
+} from "~/components/feed/manage/useFeedMaps";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
-import { ChipCombobox } from "~/components/ui/chip-combobox";
 import { Input } from "~/components/ui/input";
-import { Progress } from "~/components/ui/progress";
-import { ControlledResponsiveDialog } from "~/components/ui/responsive-dropdown";
-import { Switch } from "~/components/ui/switch";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "~/components/ui/tooltip";
-import { useContentCategories } from "~/lib/data/content-categories";
-import { useFeedCategories } from "~/lib/data/feed-categories";
-import {
-  useBulkAssignFeedCategoryMutation,
-  useBulkRemoveFeedCategoryMutation,
-} from "~/lib/data/feed-categories/mutations";
 import { useFeeds } from "~/lib/data/feeds";
-import {
-  useBulkDeleteFeedsMutation,
-  useBulkSetActiveMutation,
-  useSetFeedActiveMutation,
-} from "~/lib/data/feeds/mutations";
+import { useSetFeedActiveMutation } from "~/lib/data/feeds/mutations";
 import { useSubscription } from "~/lib/data/subscription";
-import { useViewFeeds } from "~/lib/data/view-feeds";
-import {
-  useBulkAssignViewFeedMutation,
-  useBulkRemoveViewFeedMutation,
-} from "~/lib/data/view-feeds/mutations";
-import { useViews } from "~/lib/data/views";
-import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
-import { useQuickCreateViewMutation } from "~/lib/data/views/mutations";
-import { IS_DEMO_INSTANCE } from "~/lib/demo";
+import { useScrollEdgeState } from "~/lib/hooks/useScrollEdgeState";
 import { useShiftSelect } from "~/lib/hooks/useShiftSelect";
 import { OfflineMutationBoundary } from "~/components/OfflineMutationBoundary";
 import { useCanMutate } from "~/lib/data/offline-mutations";
@@ -67,146 +51,43 @@ function ManageFeedsPage() {
 function ManageFeedsPageContent() {
   const canMutate = useCanMutate();
   const { feeds } = useFeeds();
-  const { feedCategories } = useFeedCategories();
-  const { contentCategories } = useContentCategories();
-  const { views } = useViews();
-  const { viewFeeds } = useViewFeeds();
   const { launchDialog } = useDialogStore();
   const { billingEnabled, activeFeeds, maxActiveFeeds, planName } =
     useSubscription();
   const { mutate: setFeedActive, isPending: isTogglingActive } =
     useSetFeedActiveMutation();
-  const { mutateAsync: bulkSetActive } = useBulkSetActiveMutation();
 
   const [selectedFeedIds, setSelectedFeedIds] = useState<Set<number>>(
     new Set(),
   );
   const [searchQuery, setSearchQuery] = useState("");
-  const [isScrolled, setIsScrolled] = useState(false);
-  const [isAtBottom, setIsAtBottom] = useState(false);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const headerRef = useRef<HTMLDivElement>(null);
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const { headerRef, bottomRef, isScrolled, isAtBottom } = useScrollEdgeState();
 
-  useEffect(() => {
-    if (!headerRef.current) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setIsScrolled(!entry?.isIntersecting);
-      },
-      { threshold: 0 },
-    );
-
-    observer.observe(headerRef.current);
-    return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    if (!bottomRef.current) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setIsAtBottom(entry?.isIntersecting ?? false);
-      },
-      { threshold: 0 },
-    );
-
-    observer.observe(bottomRef.current);
-    return () => observer.disconnect();
-  }, []);
-  const [showEditDialog, setShowEditDialog] = useState(false);
-  const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
-  const [selectedViewIds, setSelectedViewIds] = useState<number[]>([]);
-  const [bulkActiveState, setBulkActiveState] = useState(false);
-
-  const { mutateAsync: bulkDeleteFeeds, isPending: isDeletingFeeds } =
-    useBulkDeleteFeedsMutation();
-  const { mutateAsync: bulkAssignCategory, isPending: isAssigningCategory } =
-    useBulkAssignFeedCategoryMutation();
-  const { mutateAsync: bulkRemoveCategory, isPending: isRemovingCategory } =
-    useBulkRemoveFeedCategoryMutation();
-  const { mutateAsync: bulkAssignView, isPending: isAssigningView } =
-    useBulkAssignViewFeedMutation();
-  const { mutateAsync: bulkRemoveView, isPending: isRemovingView } =
-    useBulkRemoveViewFeedMutation();
-  const { mutateAsync: quickCreateView } = useQuickCreateViewMutation();
-
-  const feedCategoriesMap = useMemo(() => {
-    const map = new Map<number, number[]>();
-    feedCategories.forEach((fc) => {
-      const existing = map.get(fc.feedId) ?? [];
-      existing.push(fc.categoryId);
-      map.set(fc.feedId, existing);
-    });
-    return map;
-  }, [feedCategories]);
-
-  const feedViewsMap = useMemo(() => {
-    const map = new Map<number, number[]>();
-    viewFeeds.forEach((vf) => {
-      const existing = map.get(vf.feedId) ?? [];
-      existing.push(vf.viewId);
-      map.set(vf.feedId, existing);
-    });
-    return map;
-  }, [viewFeeds]);
-
-  const categoryNamesMap = useMemo(() => {
-    const map = new Map<number, string>();
-    contentCategories.forEach((c) => {
-      map.set(c.id, c.name);
-    });
-    return map;
-  }, [contentCategories]);
-
-  const viewNamesMap = useMemo(() => {
-    const map = new Map<number, string>();
-    views
-      .filter((v) => v.id !== UNCATEGORIZED_VIEW_ID)
-      .forEach((v) => {
-        map.set(v.id, v.name);
-      });
-    return map;
-  }, [views]);
-
-  const customViewOptions = useMemo(() => {
-    return views
-      .filter((v) => v.id !== UNCATEGORIZED_VIEW_ID)
-      .map((v) => ({ id: v.id, label: v.name }));
-  }, [views]);
-
-  const filteredFeeds = useMemo(() => {
-    const sorted = [...feeds].sort((a, b) => a.name.localeCompare(b.name));
-    if (!searchQuery.trim()) return sorted;
-
-    const lowercaseQuery = searchQuery.toLowerCase();
-    const matches = (name: string | undefined) =>
-      !!name && name.toLowerCase().includes(lowercaseQuery);
-
-    return sorted.filter((feed) => {
-      if (matches(feed.name)) return true;
-
-      const categoryIds = feedCategoriesMap.get(feed.id);
-      if (categoryIds?.some((id) => matches(categoryNamesMap.get(id)))) {
-        return true;
-      }
-
-      const viewIds = feedViewsMap.get(feed.id);
-      if (viewIds?.some((id) => matches(viewNamesMap.get(id)))) {
-        return true;
-      }
-
-      return false;
-    });
-  }, [
-    feeds,
-    searchQuery,
+  const {
     feedCategoriesMap,
     feedViewsMap,
     categoryNamesMap,
     viewNamesMap,
-  ]);
+    customViewOptions,
+  } = useFeedMaps();
+
+  const filteredFeeds = useMemo(
+    () =>
+      filterFeeds(feeds, searchQuery, {
+        feedCategoriesMap,
+        feedViewsMap,
+        categoryNamesMap,
+        viewNamesMap,
+      }),
+    [
+      feeds,
+      searchQuery,
+      feedCategoriesMap,
+      feedViewsMap,
+      categoryNamesMap,
+      viewNamesMap,
+    ],
+  );
 
   const filteredFeedIds = useMemo(
     () => filteredFeeds.map((f) => f.id),
@@ -234,92 +115,35 @@ function ManageFeedsPageContent() {
     }
   };
 
-  const handleDelete = () => {
-    if (!canMutate) return;
-    const feedIds = Array.from(selectedFeedIds);
-    const count = feedIds.length;
-    setShowDeleteDialog(false);
-    setSelectedFeedIds(new Set());
-
-    toast.promise(bulkDeleteFeeds({ feedIds }), {
-      loading: `Deleting ${count} feed${count > 1 ? "s" : ""}...`,
-      success: `Deleted ${count} feed${count > 1 ? "s" : ""}!`,
-      error: "Failed to delete feeds",
-    });
-  };
-
-  const getSharedCategories = () => {
-    const feedIds = Array.from(selectedFeedIds);
-    if (feedIds.length === 0) return [];
-
-    const firstFeedCategories = feedCategoriesMap.get(feedIds[0]!) ?? [];
-    const categorySets = feedIds.map(
-      (feedId) => new Set(feedCategoriesMap.get(feedId) ?? []),
-    );
-    return firstFeedCategories.filter((categoryId) =>
-      categorySets.every((categorySet) => categorySet.has(categoryId)),
-    );
-  };
-
-  const getSharedViews = () => {
-    const feedIds = Array.from(selectedFeedIds);
-    if (feedIds.length === 0) return [];
-
-    const firstFeedViews = feedViewsMap.get(feedIds[0]!) ?? [];
-    const viewSets = feedIds.map(
-      (feedId) => new Set(feedViewsMap.get(feedId) ?? []),
-    );
-    return firstFeedViews.filter((viewId) =>
-      viewSets.every((viewSet) => viewSet.has(viewId)),
-    );
-  };
-
-  const openEditDialog = () => {
-    setSelectedCategoryIds(getSharedCategories());
-    setSelectedViewIds(getSharedViews());
-    // If all selected feeds are active, show active; otherwise show deactivated
-    const allActive = Array.from(selectedFeedIds).every(
-      (id) => feeds.find((f) => f.id === id)?.isActive,
-    );
-    setBulkActiveState(allActive);
-    setShowEditDialog(true);
-  };
-
-  const handleClear = () => {
-    const feedIds = Array.from(selectedFeedIds);
-    const count = feedIds.length;
-
-    // Get all categories any selected feed currently has
-    const allCurrentCategories = new Set<number>();
-    feedIds.forEach((feedId) => {
-      const categories = feedCategoriesMap.get(feedId) ?? [];
-      categories.forEach((c) => allCurrentCategories.add(c));
-    });
-
-    // Get all views any selected feed currently has
-    const allCurrentViews = new Set<number>();
-    feedIds.forEach((feedId) => {
-      const views = feedViewsMap.get(feedId) ?? [];
-      views.forEach((v) => allCurrentViews.add(v));
-    });
-
-    if (allCurrentCategories.size === 0 && allCurrentViews.size === 0) return;
-
-    const promises: Array<Promise<void>> = [
-      ...Array.from(allCurrentCategories).map((categoryId) =>
-        bulkRemoveCategory({ feedIds, categoryId }),
-      ),
-      ...Array.from(allCurrentViews).map((viewId) =>
-        bulkRemoveView({ feedIds, viewId }),
-      ),
-    ];
-
-    toast.promise(Promise.all(promises), {
-      loading: `Clearing ${count} feed${count > 1 ? "s" : ""}...`,
-      success: `Cleared ${count} feed${count > 1 ? "s" : ""}!`,
-      error: "Failed to clear feeds",
-    });
-  };
+  const {
+    showDeleteDialog,
+    setShowDeleteDialog,
+    showEditDialog,
+    setShowEditDialog,
+    selectedCategoryIds,
+    setSelectedCategoryIds,
+    selectedViewIds,
+    setSelectedViewIds,
+    bulkActiveState,
+    setBulkActiveState,
+    isDeletingFeeds,
+    isSavingEdit,
+    isClearing,
+    handleDelete,
+    openEditDialog,
+    handleClear,
+    handleEditSave,
+  } = useBulkFeedEditing({
+    canMutate,
+    feeds,
+    selectedFeedIds,
+    setSelectedFeedIds,
+    feedCategoriesMap,
+    feedViewsMap,
+    activeFeeds,
+    maxActiveFeeds,
+    launchDialog,
+  });
 
   useFeedManagementShortcuts({
     onEscape: deselectAll,
@@ -330,96 +154,6 @@ function ManageFeedsPageContent() {
     isDialogOpen: showDeleteDialog || showEditDialog,
     hasSelection: selectedCount > 0,
   });
-
-  const handleEditSave = () => {
-    if (!canMutate) return;
-    const feedIds = Array.from(selectedFeedIds);
-    const count = feedIds.length;
-    const sharedCategories = getSharedCategories();
-    const sharedViews = getSharedViews();
-
-    // Active state
-    const feedsToToggle = feedIds.filter((id) => {
-      const feed = feeds.find((f) => f.id === id);
-      return feed && feed.isActive !== bulkActiveState;
-    });
-
-    if (bulkActiveState && feedsToToggle.length > 0 && maxActiveFeeds >= 0) {
-      const wouldBeActive = activeFeeds + feedsToToggle.length;
-
-      if (wouldBeActive > maxActiveFeeds) {
-        const overLimit = wouldBeActive - maxActiveFeeds;
-
-        if (IS_DEMO_INSTANCE) {
-          toast.warning(
-            `${overLimit} feed${overLimit > 1 ? "s would" : " would"} exceed the limit of active feeds you can have on the demo instance.`,
-          );
-        } else {
-          toast.warning(
-            `${overLimit} feed${overLimit > 1 ? "s would" : " would"} exceed your plan limit. To unlock more active feeds, you can switch to a higher plan.`,
-            {
-              action: {
-                label: "Upgrade",
-                onClick: () =>
-                  launchDialog("subscription", { subscriptionView: "picker" }),
-              },
-            },
-          );
-        }
-
-        return;
-      }
-    }
-
-    const promises: Array<Promise<void>> = [];
-
-    // Bulk active state toggle
-    if (feedsToToggle.length > 0) {
-      promises.push(
-        bulkSetActive({ feedIds: feedsToToggle, isActive: bulkActiveState }),
-      );
-    }
-
-    // Categories
-    const categoriesToAdd = selectedCategoryIds;
-    const selectedCategoryIdSet = new Set(selectedCategoryIds);
-    const categoriesToRemove = sharedCategories.filter(
-      (id) => !selectedCategoryIdSet.has(id),
-    );
-    categoriesToAdd.forEach((categoryId) => {
-      promises.push(bulkAssignCategory({ feedIds, categoryId }));
-    });
-    categoriesToRemove.forEach((categoryId) => {
-      promises.push(bulkRemoveCategory({ feedIds, categoryId }));
-    });
-
-    // Views
-    const viewsToAdd = selectedViewIds;
-    const selectedViewIdSet = new Set(selectedViewIds);
-    const viewsToRemove = sharedViews.filter(
-      (id) => !selectedViewIdSet.has(id),
-    );
-    viewsToAdd.forEach((viewId) => {
-      promises.push(bulkAssignView({ feedIds, viewId }));
-    });
-    viewsToRemove.forEach((viewId) => {
-      promises.push(bulkRemoveView({ feedIds, viewId }));
-    });
-
-    setSelectedCategoryIds([]);
-    setSelectedViewIds([]);
-    setShowEditDialog(false);
-
-    if (promises.length === 0) {
-      return;
-    }
-
-    toast.promise(Promise.all(promises), {
-      loading: `Updating ${count} feed${count > 1 ? "s" : ""}...`,
-      success: `Updated ${count} feed${count > 1 ? "s" : ""}!`,
-      error: "Failed to update feeds",
-    });
-  };
 
   if (!feeds.length) {
     return (
@@ -471,43 +205,13 @@ function ManageFeedsPageContent() {
             </ButtonWithShortcut>
           </div>
         </div>
-        {(billingEnabled || IS_DEMO_INSTANCE) &&
-          maxActiveFeeds > 0 &&
-          (IS_DEMO_INSTANCE
-            ? activeFeeds <= maxActiveFeeds
-            : activeFeeds < maxActiveFeeds) && (
-            <div className="mt-3 space-y-1.5">
-              <div className="flex items-center justify-between">
-                <p className="text-muted-foreground text-sm">
-                  {activeFeeds} / {maxActiveFeeds} feeds active
-                </p>
-              </div>
-              <Progress
-                value={Math.min(100, (activeFeeds / maxActiveFeeds) * 100)}
-              />
-            </div>
-          )}
-        {billingEnabled &&
-          maxActiveFeeds > 0 &&
-          activeFeeds >= maxActiveFeeds && (
-            <Alert className="mt-4">
-              <AlertTitle>Max active feeds reached</AlertTitle>
-              <AlertDescription>
-                The {planName} plan supports a maximum of {maxActiveFeeds}{" "}
-                feeds. You can add more than this, but only your active feeds
-                will receive new content.
-                <Button
-                  type="button"
-                  onClick={() =>
-                    launchDialog("subscription", { subscriptionView: "picker" })
-                  }
-                  className="mt-4"
-                >
-                  Upgrade your plan
-                </Button>
-              </AlertDescription>
-            </Alert>
-          )}
+        <ActiveFeedLimitStatus
+          billingEnabled={billingEnabled}
+          activeFeeds={activeFeeds}
+          maxActiveFeeds={maxActiveFeeds}
+          planName={planName}
+          launchDialog={launchDialog}
+        />
       </div>
 
       <div
@@ -547,20 +251,14 @@ function ManageFeedsPageContent() {
         <ItemGroup className="-mx-3 gap-0">
           {filteredFeeds.map((feed) => {
             const isSelected = selectedFeedIds.has(feed.id);
-            const feedCategoryIds = (feedCategoriesMap.get(feed.id) ?? [])
-              .slice()
-              .sort((a, b) =>
-                (categoryNamesMap.get(a) ?? "").localeCompare(
-                  categoryNamesMap.get(b) ?? "",
-                ),
-              );
-            const feedViewIds = (feedViewsMap.get(feed.id) ?? [])
-              .slice()
-              .sort((a, b) =>
-                (viewNamesMap.get(a) ?? "").localeCompare(
-                  viewNamesMap.get(b) ?? "",
-                ),
-              );
+            const feedCategoryIds = sortIdsByName(
+              feedCategoriesMap.get(feed.id) ?? [],
+              categoryNamesMap,
+            );
+            const feedViewIds = sortIdsByName(
+              feedViewsMap.get(feed.id) ?? [],
+              viewNamesMap,
+            );
 
             return (
               <FeedListItem
@@ -581,58 +279,27 @@ function ManageFeedsPageContent() {
                 }
                 details={
                   <>
-                    {feedCategoryIds.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {feedCategoryIds.map((categoryId) => {
-                          const categoryName = categoryNamesMap.get(categoryId);
-                          if (!categoryName) return null;
-                          return (
-                            <Badge key={`cat-${categoryId}`} variant="outline">
-                              {categoryName}
-                            </Badge>
-                          );
-                        })}
-                      </div>
-                    )}
-                    {feedViewIds.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {feedViewIds.map((viewId) => {
-                          const viewName = viewNamesMap.get(viewId);
-                          if (!viewName) return null;
-                          return (
-                            <Badge key={`view-${viewId}`} variant="secondary">
-                              {viewName}
-                            </Badge>
-                          );
-                        })}
-                      </div>
-                    )}
+                    <FeedRowBadges
+                      ids={feedCategoryIds}
+                      namesMap={categoryNamesMap}
+                      variant="outline"
+                      keyPrefix="cat"
+                    />
+                    <FeedRowBadges
+                      ids={feedViewIds}
+                      namesMap={viewNamesMap}
+                      variant="secondary"
+                      keyPrefix="view"
+                    />
                   </>
                 }
                 actions={
-                  <Switch
-                    checked={feed.isActive}
-                    disabled={isTogglingActive}
-                    onCheckedChange={(checked) => {
-                      if (
-                        !checked ||
-                        activeFeeds < maxActiveFeeds ||
-                        maxActiveFeeds < 0
-                      ) {
-                        setFeedActive({ feedId: feed.id, isActive: checked });
-                      } else {
-                        if (IS_DEMO_INSTANCE) {
-                          toast.error(
-                            "Feed limit reached. This is the limit for the demo instance.",
-                          );
-                        } else {
-                          toast.error(
-                            "Feed limit reached. Upgrade your plan to activate more feeds.",
-                          );
-                        }
-                      }
-                    }}
-                    onClick={(e) => e.stopPropagation()}
+                  <FeedActiveSwitch
+                    feed={feed}
+                    isTogglingActive={isTogglingActive}
+                    setFeedActive={setFeedActive}
+                    activeFeeds={activeFeeds}
+                    maxActiveFeeds={maxActiveFeeds}
                   />
                 }
               />
@@ -659,12 +326,7 @@ function ManageFeedsPageContent() {
               <ButtonWithShortcut
                 variant="outline"
                 onClick={openEditDialog}
-                disabled={
-                  isAssigningCategory ||
-                  isRemovingCategory ||
-                  isAssigningView ||
-                  isRemovingView
-                }
+                disabled={isSavingEdit}
                 shortcut="e"
               >
                 Edit
@@ -672,7 +334,7 @@ function ManageFeedsPageContent() {
               <ButtonWithShortcut
                 variant="outline"
                 onClick={handleClear}
-                disabled={isRemovingCategory || isRemovingView}
+                disabled={isClearing}
                 shortcut="c"
               >
                 Clear
@@ -691,109 +353,30 @@ function ManageFeedsPageContent() {
         </div>
       )}
 
-      <ControlledResponsiveDialog
+      <DeleteFeedsDialog
         open={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}
-        title="Delete Feeds"
-        description={`Are you sure you want to delete ${selectedCount} feed${selectedCount > 1 ? "s" : ""}? This action cannot be undone.`}
-      >
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            className="flex-1"
-            onClick={() => setShowDeleteDialog(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="destructive"
-            className="flex-1"
-            onClick={handleDelete}
-            disabled={!canMutate || isDeletingFeeds}
-          >
-            {isDeletingFeeds ? "Deleting..." : "Delete"}
-          </Button>
-        </div>
-      </ControlledResponsiveDialog>
+        selectedCount={selectedCount}
+        canMutate={canMutate}
+        isDeletingFeeds={isDeletingFeeds}
+        onDelete={handleDelete}
+      />
 
-      <ControlledResponsiveDialog
+      <EditFeedsDialog
         open={showEditDialog}
         onOpenChange={setShowEditDialog}
-        title="Edit Feeds"
-        description={`Edit ${selectedCount} feed${selectedCount > 1 ? "s" : ""}.`}
-        headerRight={
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center">
-                <Switch
-                  checked={bulkActiveState}
-                  onCheckedChange={setBulkActiveState}
-                />
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>
-              {bulkActiveState ? "Feeds active" : "Feeds inactive"}
-            </TooltipContent>
-          </Tooltip>
-        }
-        footer={
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              className="flex-1"
-              onClick={() => setShowEditDialog(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              className="flex-1"
-              onClick={handleEditSave}
-              disabled={
-                !canMutate ||
-                isAssigningCategory ||
-                isRemovingCategory ||
-                isAssigningView ||
-                isRemovingView
-              }
-            >
-              {isAssigningCategory ||
-              isRemovingCategory ||
-              isAssigningView ||
-              isRemovingView
-                ? "Saving..."
-                : "Save"}
-            </Button>
-          </div>
-        }
-      >
-        <div className="grid gap-4">
-          <ChipCombobox
-            label="Views"
-            placeholder="Search views..."
-            options={customViewOptions}
-            selectedIds={selectedViewIds}
-            onAdd={(id) => setSelectedViewIds([...selectedViewIds, id])}
-            onRemove={(id) =>
-              setSelectedViewIds(selectedViewIds.filter((v) => v !== id))
-            }
-            onCreate={async (name) => {
-              try {
-                const created = await quickCreateView({ name });
-                if (created) {
-                  setSelectedViewIds([...selectedViewIds, created.id]);
-                }
-              } catch {
-                toast.error("Failed to create view.");
-              }
-            }}
-            createLabel="Create view"
-          />
-          <ViewCategoriesInput
-            selectedCategories={selectedCategoryIds}
-            setSelectedCategories={setSelectedCategoryIds}
-          />
-        </div>
-      </ControlledResponsiveDialog>
+        selectedCount={selectedCount}
+        bulkActiveState={bulkActiveState}
+        setBulkActiveState={setBulkActiveState}
+        canMutate={canMutate}
+        isSaving={isSavingEdit}
+        onSave={handleEditSave}
+        customViewOptions={customViewOptions}
+        selectedViewIds={selectedViewIds}
+        setSelectedViewIds={setSelectedViewIds}
+        selectedCategoryIds={selectedCategoryIds}
+        setSelectedCategoryIds={setSelectedCategoryIds}
+      />
     </div>
   );
 }

--- a/apps/app/src/app/_app.import.tsx
+++ b/apps/app/src/app/_app.import.tsx
@@ -1,38 +1,24 @@
 "use client";
 
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { ItemGroup } from "@serial/ui";
+import { createFileRoute } from "@tanstack/react-router";
 import { useSetAtom } from "jotai";
-import {
-  AlertTriangleIcon,
-  CheckIcon,
-  Loader2Icon,
-  MinusIcon,
-  PauseIcon,
-  PlusIcon,
-  XIcon,
-} from "lucide-react";
+import { Loader2Icon } from "lucide-react";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { toast } from "sonner";
-import { ImportDropzone } from "../components/feed/import/ImportDropzone";
 import { getInitialFeedDataFromFileInputElement } from "../components/feed/import/utils/getInitialFeedDataFromFileInputElement";
-import type { CardRadioOption } from "~/components/ui/card-radio-group";
 import type {
   ImportFeedDataFromFilesError,
   ImportFeedDataItem,
 } from "../components/feed/import/utils/shared";
+import type { ImportMode } from "~/components/feed/import/importPageShared";
 import { useDialogStore } from "~/components/feed/dialogStore";
-import { FeedAvatar, FeedListItem } from "~/components/feed/FeedListItem";
-import { ImportLoading } from "~/components/ImportLoading";
-import { Badge } from "~/components/ui/badge";
-import { Button } from "~/components/ui/button";
-import { CardRadioGroup } from "~/components/ui/card-radio-group";
+import { ImportFeedList } from "~/components/feed/import/ImportFeedList";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "~/components/ui/tooltip";
-import { getGuidesUrl } from "~/lib/constants";
+  ImportFinished,
+  ImportInstructions,
+} from "~/components/feed/import/ImportScreens";
+import { ImportLoading } from "~/components/ImportLoading";
+import { Button } from "~/components/ui/button";
 import { shouldAlwaysKeepSSEConnectionAlive } from "~/lib/data/atoms";
 import { useFeeds } from "~/lib/data/feeds";
 import { useImportDropStore } from "~/lib/data/import-drop";
@@ -41,69 +27,133 @@ import { dataRequestActions } from "~/lib/data/directRequests";
 import { IS_DEMO_INSTANCE } from "~/lib/demo";
 import { useCanMutate } from "~/lib/data/offline-mutations";
 
-function ImportedFeedStatus({
-  feedUrl,
-  feeds,
-}: {
-  feedUrl: string;
-  feeds: Array<{ url: string; isActive: boolean }>;
-}) {
-  const importedFeed = feeds.find((f) => f.url === feedUrl);
-  const isInactive = importedFeed && !importedFeed.isActive;
-
-  return (
-    <Tooltip>
-      <TooltipTrigger>
-        {isInactive ? <PauseIcon size={20} /> : <CheckIcon size={20} />}
-      </TooltipTrigger>
-      <TooltipContent>
-        {isInactive ? "Feed inactive" : "Imported Successfully!"}
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
 export const Route = createFileRoute("/_app/import")({
   component: EditFeedsPage,
 });
 
-type ImportMode = "tags" | "views" | "ignore";
+function useIsAtBottom(dep: unknown) {
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const [isAtBottom, setIsAtBottom] = useState(false);
 
-function getFeedWebsiteUrl(feed: ImportFeedDataItem) {
-  if (feed.websiteUrl) return feed.websiteUrl;
+  useEffect(() => {
+    if (!bottomRef.current) return;
 
-  try {
-    return new URL(feed.feedUrl).origin;
-  } catch {
-    return feed.feedUrl;
-  }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsAtBottom(entry?.isIntersecting ?? false);
+      },
+      { threshold: 0 },
+    );
+
+    observer.observe(bottomRef.current);
+    return () => observer.disconnect();
+  }, [dep]);
+
+  return { bottomRef, isAtBottom };
 }
 
-const IMPORT_MODE_OPTIONS: Array<CardRadioOption<ImportMode>> = [
-  {
-    value: "views",
-    title: "Import sections as Views",
-    description:
-      "Each section in the file becomes a view, and feeds are linked directly to it.",
-  },
-  {
-    value: "tags",
-    title: "Import sections as Tags",
-    description:
-      "Each section in the file becomes a tag, and feeds are tagged with it.",
-  },
-  {
-    value: "ignore",
-    title: "Ignore sections",
-    description:
-      "Import the feeds without preserving any of the section groupings.",
-  },
-];
+// Keep SSE open during import so visibility changes don't disconnect the
+// streaming import. Reset when the import loader is hidden.
+function useKeepSSEAliveDuringImport({
+  isFetchingRss,
+  hasStartedImport,
+}: {
+  isFetchingRss: boolean;
+  hasStartedImport: boolean;
+}) {
+  const setShouldAlwaysKeepSSEConnectionAlive = useSetAtom(
+    shouldAlwaysKeepSSEConnectionAlive,
+  );
+
+  useEffect(() => {
+    if (!isFetchingRss && hasStartedImport) {
+      setShouldAlwaysKeepSSEConnectionAlive(false);
+    }
+  }, [isFetchingRss, hasStartedImport, setShouldAlwaysKeepSSEConnectionAlive]);
+
+  useEffect(() => {
+    return () => {
+      setShouldAlwaysKeepSSEConnectionAlive(false);
+    };
+  }, [setShouldAlwaysKeepSSEConnectionAlive]);
+
+  return setShouldAlwaysKeepSSEConnectionAlive;
+}
+
+function useImportDeactivatedToast(
+  isImportComplete: boolean,
+  importDeactivatedCount: number,
+) {
+  const { launchDialog } = useDialogStore();
+
+  useEffect(() => {
+    if (isImportComplete && importDeactivatedCount > 0) {
+      const count = importDeactivatedCount;
+
+      if (IS_DEMO_INSTANCE) {
+        toast.warning(
+          `${count} feed${count > 1 ? "s were" : " was"} added as inactive. This is the limit for the demo instance.`,
+        );
+      } else {
+        toast.warning(
+          `${count} feed${count > 1 ? "s were" : " was"} added as inactive. To unlock more active feeds, you can switch to a higher plan.`,
+          {
+            action: {
+              label: "Upgrade",
+              onClick: () =>
+                launchDialog("subscription", { subscriptionView: "picker" }),
+            },
+          },
+        );
+      }
+    }
+  }, [isImportComplete, importDeactivatedCount, launchDialog]);
+}
+
+function ImportFooter({
+  isAtBottom,
+  channelImportCount,
+  isImportPending,
+  hasStartedImport,
+  onFeedImport,
+}: {
+  isAtBottom: boolean;
+  channelImportCount: number | undefined;
+  isImportPending: boolean;
+  hasStartedImport: boolean;
+  onFeedImport: () => void;
+}) {
+  return (
+    <div
+      data-testid="import-footer"
+      className={`bg-background sticky bottom-0 z-10 border-t transition-[border-color] ${
+        isAtBottom ? "border-transparent" : "border-border"
+      }`}
+    >
+      <div className="mx-auto max-w-2xl px-6 py-4">
+        <Button
+          className="w-full gap-2"
+          size="lg"
+          onClick={onFeedImport}
+          disabled={channelImportCount === 0 || isImportPending}
+        >
+          {isImportPending && !hasStartedImport ? (
+            <>
+              Importing...
+              <Loader2Icon size={16} className="animate-spin" />
+            </>
+          ) : (
+            <>Import {channelImportCount} feeds</>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
 
 function EditFeedsPage() {
   const canMutate = useCanMutate();
   const inputElementRef = useRef<HTMLInputElement | null>(null);
-  const bottomRef = useRef<HTMLDivElement | null>(null);
 
   const [feedsFoundFromFile, setFeedsFoundFromFile] = useState<
     ImportFeedDataItem[] | null
@@ -111,7 +161,6 @@ function EditFeedsPage() {
   const [hasStartedImport, setHasStartedImport] = useState(false);
   const [isImportComplete, setIsImportComplete] = useState(false);
   const [isImportPending, setIsImportPending] = useState(false);
-  const [isAtBottom, setIsAtBottom] = useState(false);
   const [importMode, setImportMode] = useState<ImportMode>("views");
 
   const [fileInputErrorList, setFileInputErrorList] =
@@ -127,19 +176,7 @@ function EditFeedsPage() {
     inputElementRef.current?.setAttribute("data-ready", "true");
   }, []);
 
-  useEffect(() => {
-    if (!bottomRef.current) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setIsAtBottom(entry?.isIntersecting ?? false);
-      },
-      { threshold: 0 },
-    );
-
-    observer.observe(bottomRef.current);
-    return () => observer.disconnect();
-  }, [feedsFoundFromFile]);
+  const { bottomRef, isAtBottom } = useIsAtBottom(feedsFoundFromFile);
 
   const channelImportCount = feedsFoundFromFile?.filter(
     (feed) => feed.shouldImport,
@@ -150,12 +187,12 @@ function EditFeedsPage() {
   const importResults = useImportResults();
   const isFetchingRss = loading.mode === "importing";
   const { failedImportUrls, importDeactivatedCount } = importResults;
-  const { launchDialog } = useDialogStore();
 
   const isPostImportScreen = isImportComplete || hasStartedImport;
-  const setShouldAlwaysKeepSSEConnectionAlive = useSetAtom(
-    shouldAlwaysKeepSSEConnectionAlive,
-  );
+  const setShouldAlwaysKeepSSEConnectionAlive = useKeepSSEAliveDuringImport({
+    isFetchingRss,
+    hasStartedImport,
+  });
 
   const applyFileResult = (
     feedResult:
@@ -190,20 +227,6 @@ function EditFeedsPage() {
     return () => cancelAnimationFrame(frame);
   }, [pendingDropResult, clearPendingDropResult]);
 
-  // Keep SSE open during import so visibility changes don't disconnect the
-  // streaming import. Reset when the import loader is hidden.
-  useEffect(() => {
-    if (!isFetchingRss && hasStartedImport) {
-      setShouldAlwaysKeepSSEConnectionAlive(false);
-    }
-  }, [isFetchingRss, hasStartedImport, setShouldAlwaysKeepSSEConnectionAlive]);
-
-  useEffect(() => {
-    return () => {
-      setShouldAlwaysKeepSSEConnectionAlive(false);
-    };
-  }, [setShouldAlwaysKeepSSEConnectionAlive]);
-
   useEffect(() => {
     if (isImportPending && loading.mode === "importing" && !hasStartedImport) {
       const id = requestAnimationFrame(() => setHasStartedImport(true));
@@ -211,28 +234,7 @@ function EditFeedsPage() {
     }
   }, [isImportPending, loading.mode, hasStartedImport]);
 
-  useEffect(() => {
-    if (isImportComplete && importDeactivatedCount > 0) {
-      const count = importDeactivatedCount;
-
-      if (IS_DEMO_INSTANCE) {
-        toast.warning(
-          `${count} feed${count > 1 ? "s were" : " was"} added as inactive. This is the limit for the demo instance.`,
-        );
-      } else {
-        toast.warning(
-          `${count} feed${count > 1 ? "s were" : " was"} added as inactive. To unlock more active feeds, you can switch to a higher plan.`,
-          {
-            action: {
-              label: "Upgrade",
-              onClick: () =>
-                launchDialog("subscription", { subscriptionView: "picker" }),
-            },
-          },
-        );
-      }
-    }
-  }, [isImportComplete, importDeactivatedCount, launchDialog]);
+  useImportDeactivatedToast(isImportComplete, importDeactivatedCount);
 
   const onSelectFiles = async () => {
     if (!inputElementRef.current) return;
@@ -286,51 +288,9 @@ function EditFeedsPage() {
       <div className="mx-auto max-w-2xl p-6">
         <h2 className="font-sans text-lg">Import Feeds</h2>
         {!isPostImportScreen && (
-          <>
-            <p className="mt-2">Serial supports importing:</p>
-            <ul className="mb-6 list-disc pl-4">
-              <li>
-                <code className="bg-muted text-foreground rounded px-1 py-0.5">
-                  subscriptions.csv
-                </code>{" "}
-                files from{" "}
-                <a
-                  href={getGuidesUrl("/how-to-export-youtube-subscriptions")}
-                  className="underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  a Google Takeout export
-                </a>
-              </li>
-              <li>
-                <code className="bg-muted text-foreground rounded px-1 py-0.5">
-                  *.opml
-                </code>{" "}
-                files from another RSS reader&apos;s export
-              </li>
-            </ul>
-            <ImportDropzone
-              inputId="import-file-input"
-              onSelectFile={onSelectFiles}
-            />
-          </>
+          <ImportInstructions onSelectFiles={onSelectFiles} />
         )}
-        {isPostImportScreen && (
-          <>
-            <p className="mt-2 mb-4">
-              Import finished! Your list has been added.
-            </p>
-            <div className="flex gap-2">
-              <Link to="/">
-                <Button>Back to home</Button>
-              </Link>
-              <Button variant="outline" onClick={onReset}>
-                Import more
-              </Button>
-            </div>
-          </>
-        )}
+        {isPostImportScreen && <ImportFinished onReset={onReset} />}
         <input
           id="import-file-input"
           ref={inputElementRef}
@@ -349,249 +309,27 @@ function EditFeedsPage() {
           </div>
         )}
         {!!feedsFoundFromFile && (
-          <>
-            {!isPostImportScreen &&
-              feedsFoundFromFile.some((f) => f.categories.length > 0) && (
-                <div className="mt-12 grid gap-3">
-                  <h3 className="font-semibold">Sections</h3>
-                  <CardRadioGroup
-                    value={importMode}
-                    onValueChange={setImportMode}
-                    options={IMPORT_MODE_OPTIONS}
-                    orientation="vertical"
-                  />
-                </div>
-              )}
-            <div className="mt-12">
-              {!isPostImportScreen && (
-                <div className="flex items-center justify-between">
-                  <h3 className="font-semibold">Feeds To Import</h3>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      if (channelImportCount === 0) {
-                        setFeedsFoundFromFile((prevChannels) => {
-                          if (!prevChannels) return prevChannels;
-                          return prevChannels.map((channel) => {
-                            // Don't enable import for already-added feeds
-                            const isAlreadyAdded = feeds.some(
-                              (feed) => feed.url === channel.feedUrl,
-                            );
-                            if (!isAlreadyAdded) {
-                              channel.shouldImport = true;
-                            }
-                            return channel;
-                          });
-                        });
-                      } else {
-                        setFeedsFoundFromFile((prevChannels) => {
-                          if (!prevChannels) return prevChannels;
-                          return prevChannels.map((channel) => {
-                            channel.shouldImport = false;
-                            return channel;
-                          });
-                        });
-                      }
-                    }}
-                  >
-                    {channelImportCount === 0 ? "Select All" : "Deselect All"}
-                  </Button>
-                </div>
-              )}
-              <ItemGroup className="mt-4">
-                {[...feedsFoundFromFile]
-                  .sort((a, b) => {
-                    if (!a.title && !b.title) return 0;
-                    if (!a.title) return -1;
-                    if (!b.title) return -1;
-                    return a.title.localeCompare(b.title);
-                  })
-                  .map((channel) => {
-                    const displayTitle = channel.title ?? channel.feedUrl;
-                    // Check if feed already exists in the feeds store
-                    const isAlreadyAdded = feeds.some(
-                      (feed) => feed.url === channel.feedUrl,
-                    );
-                    // Check if feed was imported by looking in the feeds store
-                    const wasImported = isPostImportScreen && isAlreadyAdded;
-                    const websiteUrl = getFeedWebsiteUrl(channel);
-                    const setShouldImport = (shouldImport: boolean) => {
-                      if (isAlreadyAdded || isPostImportScreen) return;
-
-                      setFeedsFoundFromFile((prevChannels) => {
-                        if (!prevChannels) return prevChannels;
-
-                        return prevChannels.map((previousChannel) =>
-                          previousChannel.feedUrl === channel.feedUrl
-                            ? { ...previousChannel, shouldImport }
-                            : previousChannel,
-                        );
-                      });
-                    };
-
-                    return (
-                      <FeedListItem
-                        key={channel.feedUrl}
-                        title={displayTitle}
-                        titleHref={websiteUrl}
-                        description={
-                          <a
-                            href={channel.feedUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="pointer-events-auto relative z-10"
-                            onClick={(event) => event.stopPropagation()}
-                          >
-                            {channel.feedUrl}
-                          </a>
-                        }
-                        platform={channel.platform}
-                        variant="outline"
-                        size="xs"
-                        interactive={!isPostImportScreen && !isAlreadyAdded}
-                        disabled={isAlreadyAdded}
-                        selected={!isPostImportScreen && channel.shouldImport}
-                        onClick={() => setShouldImport(!channel.shouldImport)}
-                        media={
-                          !isPostImportScreen && isAlreadyAdded ? (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="pointer-events-auto inline-flex">
-                                  <FeedAvatar
-                                    title={displayTitle}
-                                    platform={channel.platform}
-                                    fallback={
-                                      <AlertTriangleIcon
-                                        size={14}
-                                        aria-label="Feed already exists"
-                                      />
-                                    }
-                                  />
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                Feed already exists
-                              </TooltipContent>
-                            </Tooltip>
-                          ) : (
-                            <FeedAvatar
-                              title={displayTitle}
-                              platform={channel.platform}
-                            />
-                          )
-                        }
-                        details={
-                          <>
-                            {!isPostImportScreen &&
-                              channel.categories.map((category) => (
-                                <Badge key={category} variant="outline">
-                                  {category}
-                                </Badge>
-                              ))}
-                          </>
-                        }
-                        actions={
-                          <>
-                            {!isPostImportScreen && (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Button
-                                    type="button"
-                                    variant={
-                                      channel.shouldImport ? "default" : "ghost"
-                                    }
-                                    size="icon"
-                                    className="size-7"
-                                    aria-label={`${channel.shouldImport ? "Deselect" : "Select"} ${displayTitle}`}
-                                    disabled={isAlreadyAdded}
-                                    onClick={() =>
-                                      setShouldImport(!channel.shouldImport)
-                                    }
-                                  >
-                                    {channel.shouldImport ? (
-                                      <CheckIcon size={16} />
-                                    ) : (
-                                      <PlusIcon size={16} />
-                                    )}
-                                  </Button>
-                                </TooltipTrigger>
-                                {!isAlreadyAdded && (
-                                  <TooltipContent>
-                                    {channel.shouldImport
-                                      ? "Deselect"
-                                      : "Select"}{" "}
-                                    feed
-                                  </TooltipContent>
-                                )}
-                              </Tooltip>
-                            )}
-                            {isPostImportScreen &&
-                              wasImported &&
-                              channel.shouldImport && (
-                                <ImportedFeedStatus
-                                  feedUrl={channel.feedUrl}
-                                  feeds={feeds}
-                                />
-                              )}
-                            {isPostImportScreen &&
-                              channel.shouldImport &&
-                              failedImportUrls.has(channel.feedUrl) && (
-                                <Tooltip>
-                                  <TooltipTrigger>
-                                    <XIcon size={20} />
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    Failed to import
-                                  </TooltipContent>
-                                </Tooltip>
-                              )}
-                            {isPostImportScreen && !channel.shouldImport && (
-                              <Tooltip>
-                                <TooltipTrigger>
-                                  <MinusIcon size={20} />
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  This feed was excluded from the import.
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </>
-                        }
-                      />
-                    );
-                  })}
-              </ItemGroup>
-              <div ref={bottomRef} />
-            </div>
-          </>
+          <ImportFeedList
+            feedsFoundFromFile={feedsFoundFromFile}
+            feeds={feeds}
+            isPostImportScreen={isPostImportScreen}
+            importMode={importMode}
+            setImportMode={setImportMode}
+            channelImportCount={channelImportCount}
+            failedImportUrls={failedImportUrls}
+            setFeedsFoundFromFile={setFeedsFoundFromFile}
+            bottomRef={bottomRef}
+          />
         )}
       </div>
       {!!feedsFoundFromFile && !isPostImportScreen && (
-        <div
-          data-testid="import-footer"
-          className={`bg-background sticky bottom-0 z-10 border-t transition-[border-color] ${
-            isAtBottom ? "border-transparent" : "border-border"
-          }`}
-        >
-          <div className="mx-auto max-w-2xl px-6 py-4">
-            <Button
-              className="w-full gap-2"
-              size="lg"
-              onClick={onFeedImport}
-              disabled={channelImportCount === 0 || isImportPending}
-            >
-              {isImportPending && !hasStartedImport ? (
-                <>
-                  Importing...
-                  <Loader2Icon size={16} className="animate-spin" />
-                </>
-              ) : (
-                <>Import {channelImportCount} feeds</>
-              )}
-            </Button>
-          </div>
-        </div>
+        <ImportFooter
+          isAtBottom={isAtBottom}
+          channelImportCount={channelImportCount}
+          isImportPending={isImportPending}
+          hasStartedImport={hasStartedImport}
+          onFeedImport={onFeedImport}
+        />
       )}
     </fieldset>
   );

--- a/apps/app/src/app/_app.read.$id.tsx
+++ b/apps/app/src/app/_app.read.$id.tsx
@@ -27,18 +27,12 @@ import { useDebouncedSaveProgress } from "~/lib/hooks/useDebouncedSaveProgress";
 import { useRefreshFeedItem } from "~/lib/hooks/useRefreshFeedItem";
 import { useRestoreArticleProgress } from "~/lib/hooks/useRestoreArticleProgress";
 import { useScrollDirection } from "~/lib/hooks/useScrollDirection";
-import { detectTruncatedContent } from "~/lib/utils/detectTruncatedContent";
-import {
-  hasRespondedToTruncationAlert,
-  setTruncationAlertResponded,
-} from "~/lib/utils/truncationAlert";
-import { useEditFeedMutation } from "~/lib/data/feeds/mutations";
 import { REMOTE_IMAGE_PROPS } from "~/lib/remoteMedia";
-import { useFeedCategories } from "~/lib/data/feed-categories/store";
-import { useViewFeeds } from "~/lib/data/view-feeds/store";
-import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
-import { Button } from "~/components/ui/button";
 import { ArticleSidebars } from "~/components/feed/read/ArticleSidebars";
+import {
+  TruncationAlert,
+  useTruncationAlert,
+} from "~/components/feed/read/TruncationAlert";
 import { useRetentionPin } from "~/lib/hooks/useRetentionPin";
 import { useBookmarkValue } from "~/lib/data/bookmarks";
 import { BookmarkReader } from "~/components/content-reader/BookmarkReader";
@@ -54,6 +48,16 @@ const parser = unified()
   .use(rehypeParse, { fragment: true })
   .use(rehypeSanitize)
   .use(rehypeStringify);
+
+function getReaderContent(
+  feedItem: { content?: string } | undefined,
+  articleStyle: "simplified" | "full",
+) {
+  if (articleStyle === "simplified") {
+    return String(parser.processSync(feedItem?.content ?? ""));
+  }
+  return feedItem?.content ?? "";
+}
 
 export const Route = createFileRoute("/_app/read/$id")({
   component: ReadPage,
@@ -85,45 +89,8 @@ function ReadPage() {
   );
 }
 
-function FeedReader({
-  id,
-  hasRefreshedFeedItem,
-}: {
-  id: string;
-  hasRefreshedFeedItem: boolean;
-}) {
-  const canMutate = useCanMutate();
-  useRetentionPin("feed-item", id);
-
-  const [articleStyle] = useFlagState("ARTICLE_STYLE");
-
-  const feedItem = useFeedItemValue(id);
-
-  const { feeds } = useFeeds();
-  const feedCategories = useFeedCategories();
-  const viewFeeds = useViewFeeds();
-
-  const feed = feeds.find((f) => f.id === feedItem?.feedId);
-
-  const { zoom } = useZoom();
-  const articleWidthLayout = getArticleWidthLayout(zoom);
-
-  let content = feedItem?.content ?? "";
-
-  if (articleStyle === "simplified") {
-    content = String(parser.processSync(feedItem?.content ?? ""));
-  }
-
-  const articleRef = useRef<HTMLDivElement>(null);
-  const [articleElement, setArticleElement] = useState<HTMLDivElement | null>(
-    null,
-  );
-  const updateArticleRef = useCallback((element: HTMLDivElement | null) => {
-    articleRef.current = element;
-    setArticleElement(element);
-  }, []);
-
-  // Show/hide header and footer bars based on scroll direction
+// Show/hide header and footer bars based on scroll direction
+function useReaderBars() {
   const setBarsHidden = useSetAtom(barsHiddenAtom);
   const barsHidden = useAtomValue(barsHiddenAtom);
   const handleScrollDirection = useCallback(
@@ -140,6 +107,43 @@ function FeedReader({
       setBarsHidden(false);
     };
   }, [setBarsHidden]);
+
+  return barsHidden;
+}
+
+function FeedReader({
+  id,
+  hasRefreshedFeedItem,
+}: {
+  id: string;
+  hasRefreshedFeedItem: boolean;
+}) {
+  const canMutate = useCanMutate();
+  useRetentionPin("feed-item", id);
+
+  const [articleStyle] = useFlagState("ARTICLE_STYLE");
+
+  const feedItem = useFeedItemValue(id);
+
+  const { feeds } = useFeeds();
+
+  const feed = feeds.find((f) => f.id === feedItem?.feedId);
+
+  const { zoom } = useZoom();
+  const articleWidthLayout = getArticleWidthLayout(zoom);
+
+  const content = getReaderContent(feedItem, articleStyle);
+
+  const articleRef = useRef<HTMLDivElement>(null);
+  const [articleElement, setArticleElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const updateArticleRef = useCallback((element: HTMLDivElement | null) => {
+    articleRef.current = element;
+    setArticleElement(element);
+  }, []);
+
+  const barsHidden = useReaderBars();
 
   // Shortcut to open original URL
   useOpenOriginalShortcut(feedItem?.url);
@@ -166,53 +170,9 @@ function FeedReader({
     },
   });
 
-  // Truncation alert
-  const { mutate: editFeed } = useEditFeedMutation();
-
-  const [alertDismissed, setAlertDismissed] = useState(false);
-
-  const feedId = feed?.id;
-  const platform = feed?.platform;
-  const hasTruncationAlertResponse = feedId
-    ? hasRespondedToTruncationAlert(feedId)
-    : false;
-
-  const shouldCheckTruncatedContent =
-    !alertDismissed &&
-    platform === "website" &&
-    !!feedId &&
-    !hasTruncationAlertResponse &&
-    !!feedItem;
-  const shouldShowTruncationAlert =
-    shouldCheckTruncatedContent &&
-    feedItem !== undefined &&
-    detectTruncatedContent(feedItem.content, feedItem.contentSnippet);
-
-  const handleAlertResponse = (openLocation: "serial" | "origin") => {
-    if (!feedId || !canMutate) return;
-
-    const categoryIds = feedCategories
-      .filter((fc) => fc.feedId === feedId)
-      .map((fc) => fc.categoryId);
-    const viewIds = viewFeeds
-      .filter((vf) => vf.feedId === feedId)
-      .map((vf) => vf.viewId);
-
-    editFeed({
-      feedId,
-      categoryIds,
-      viewIds,
-      openLocation,
-      name: feed?.name ?? "",
-    });
-
-    setTruncationAlertResponded(feedId);
-    setAlertDismissed(true);
-
-    if (openLocation === "origin" && feedItem?.url) {
-      window.open(feedItem.url, "_blank", "noopener,noreferrer");
-    }
-  };
+  const { shouldShowTruncationAlert, handleAlertResponse } = useTruncationAlert(
+    { feed, feedItem, canMutate },
+  );
 
   return (
     <div
@@ -261,31 +221,10 @@ function FeedReader({
         </div>
       </div>
       {shouldShowTruncationAlert && (
-        <div className="w-full px-6">
-          <Alert>
-            <AlertTitle>Possible partial content detected</AlertTitle>
-            <AlertDescription className="mt-2 text-base">
-              It looks like this feed might not be providing all of its content
-              in its feed. Would you like to open future items in the original
-              website?
-            </AlertDescription>
-            <div className="mt-4 flex gap-2">
-              <Button
-                variant="outline"
-                disabled={!canMutate}
-                onClick={() => handleAlertResponse("serial")}
-              >
-                No, view in reader
-              </Button>
-              <Button
-                disabled={!canMutate}
-                onClick={() => handleAlertResponse("origin")}
-              >
-                Yes, open in website
-              </Button>
-            </div>
-          </Alert>
-        </div>
+        <TruncationAlert
+          canMutate={canMutate}
+          onRespond={handleAlertResponse}
+        />
       )}
       <div
         className={clsx(

--- a/apps/app/src/components/AddFeedDialog.tsx
+++ b/apps/app/src/components/AddFeedDialog.tsx
@@ -413,84 +413,28 @@ function FeedActiveSwitch({
 function EditFeedDialogFooter({
   canMutate,
   isFormDisabled,
-  selectedFeedId,
-  name,
-  selectedCategories,
-  selectedViewIds,
-  selectedOpenLocation,
-  onClose,
+  actions,
 }: {
   canMutate: boolean;
   isFormDisabled: boolean;
-  selectedFeedId: null | number;
-  name: string;
-  selectedCategories: number[];
-  selectedViewIds: number[];
-  selectedOpenLocation: FeedOpenLocation;
-  onClose: () => void;
+  actions: ReturnType<typeof useEditFeedDialogActions>;
 }) {
-  const [isUpdatingFeed, setIsUpdatingFeed] = useState(false);
-  const [isDeletingFeed, setIsDeletingFeed] = useState(false);
-
-  const { mutateAsync: editFeed } = useEditFeedMutation();
-  const { mutateAsync: deleteFeed } = useDeleteFeedMutation();
-
   return (
     <div className="flex gap-2">
       <Button
-        disabled={!canMutate || isDeletingFeed}
+        disabled={!canMutate || actions.isDeletingFeed}
         className="flex-1"
         variant="destructive"
-        onClick={async () => {
-          if (selectedFeedId === null || !canMutate) return;
-
-          setIsDeletingFeed(true);
-          try {
-            const deleteFeedPromise = deleteFeed(selectedFeedId);
-            toast.promise(deleteFeedPromise, {
-              loading: "Deleting feed...",
-              success: () => {
-                return "Feed deleted!";
-              },
-              error: () => {
-                return "Something went wrong deleting your feed.";
-              },
-            });
-            onClose();
-          } catch {
-            // Error handled by toast.promise
-          }
-
-          setIsDeletingFeed(false);
-        }}
+        onClick={actions.handleDelete}
       >
-        {isDeletingFeed ? "Deleting..." : "Delete"}
+        {actions.isDeletingFeed ? "Deleting..." : "Delete"}
       </Button>
       <Button
-        disabled={!canMutate || isFormDisabled || isUpdatingFeed}
-        onClick={async () => {
-          if (selectedFeedId === null || !canMutate) return;
-
-          setIsUpdatingFeed(true);
-          try {
-            await editFeed({
-              feedId: selectedFeedId,
-              categoryIds: selectedCategories,
-              viewIds: selectedViewIds,
-              openLocation: selectedOpenLocation,
-              name,
-            });
-            toast.success("Feed updated!");
-            onClose();
-          } catch {
-            // Error handled by toast
-          }
-
-          setIsUpdatingFeed(false);
-        }}
+        disabled={!canMutate || isFormDisabled || actions.isUpdatingFeed}
+        onClick={actions.handleSave}
         className="flex-1"
       >
-        {isUpdatingFeed ? "Saving..." : "Save"}
+        {actions.isUpdatingFeed ? "Saving..." : "Save"}
       </Button>
     </div>
   );
@@ -500,13 +444,15 @@ function FeedNameField({
   name,
   setName,
   feed,
+  hasCopied,
+  onCopy,
 }: {
   name: string;
   setName: (name: string) => void;
   feed: ApplicationFeed | undefined;
+  hasCopied: boolean;
+  onCopy: () => void;
 }) {
-  const [hasCopied, setHasCopied] = useState(false);
-
   const websiteUrl = getFeedWebsiteUrl(feed);
   const platformName =
     PLATFORM_TO_FORMATTED_NAME_MAP[feed?.platform ?? "youtube"];
@@ -529,12 +475,7 @@ function FeedNameField({
               variant="outline"
               size="icon"
               className="shrink-0"
-              onClick={() => {
-                navigator.clipboard.writeText(feed?.url ?? "");
-                toast.success("Feed URL copied!");
-                setHasCopied(true);
-                setTimeout(() => setHasCopied(false), 2000);
-              }}
+              onClick={onCopy}
             >
               {hasCopied ? <CheckIcon size={16} /> : <LinkIcon size={16} />}
             </Button>
@@ -559,6 +500,104 @@ function FeedNameField({
       </div>
     </div>
   );
+}
+
+function useEditFeedDialogActions({
+  canMutate,
+  selectedFeedId,
+  name,
+  selectedCategories,
+  selectedViewIds,
+  selectedOpenLocation,
+  feedUrl,
+  onClose,
+}: {
+  canMutate: boolean;
+  selectedFeedId: null | number;
+  name: string;
+  selectedCategories: number[];
+  selectedViewIds: number[];
+  selectedOpenLocation: FeedOpenLocation;
+  feedUrl: string | undefined;
+  onClose: () => void;
+}) {
+  const [isUpdatingFeed, setIsUpdatingFeed] = useState(false);
+  const [isDeletingFeed, setIsDeletingFeed] = useState(false);
+  const [hasCopied, setHasCopied] = useState(false);
+  const isUpdatingFeedRef = useRef(false);
+  const isDeletingFeedRef = useRef(false);
+
+  const { mutateAsync: editFeed } = useEditFeedMutation();
+  const { mutateAsync: deleteFeed } = useDeleteFeedMutation();
+
+  const handleDelete = async () => {
+    if (selectedFeedId === null || !canMutate || isDeletingFeedRef.current) {
+      return;
+    }
+
+    isDeletingFeedRef.current = true;
+    setIsDeletingFeed(true);
+    try {
+      const deleteFeedPromise = deleteFeed(selectedFeedId);
+      toast.promise(deleteFeedPromise, {
+        loading: "Deleting feed...",
+        success: () => {
+          return "Feed deleted!";
+        },
+        error: () => {
+          return "Something went wrong deleting your feed.";
+        },
+      });
+      onClose();
+      await deleteFeedPromise;
+    } catch {
+      // Error handled by toast.promise
+    } finally {
+      isDeletingFeedRef.current = false;
+      setIsDeletingFeed(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (selectedFeedId === null || !canMutate || isUpdatingFeedRef.current) {
+      return;
+    }
+
+    isUpdatingFeedRef.current = true;
+    setIsUpdatingFeed(true);
+    try {
+      await editFeed({
+        feedId: selectedFeedId,
+        categoryIds: selectedCategories,
+        viewIds: selectedViewIds,
+        openLocation: selectedOpenLocation,
+        name,
+      });
+      toast.success("Feed updated!");
+      onClose();
+    } catch {
+      // Error handled by toast
+    } finally {
+      isUpdatingFeedRef.current = false;
+      setIsUpdatingFeed(false);
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(feedUrl ?? "");
+    toast.success("Feed URL copied!");
+    setHasCopied(true);
+    setTimeout(() => setHasCopied(false), 2000);
+  };
+
+  return {
+    isUpdatingFeed,
+    isDeletingFeed,
+    hasCopied,
+    handleDelete,
+    handleSave,
+    handleCopy,
+  };
 }
 
 function EditFeedViewsField({
@@ -674,6 +713,16 @@ export function EditFeedDialog({
     setSelectedOpenLocation,
     feed,
   } = useEditFeedForm(selectedFeedId);
+  const actions = useEditFeedDialogActions({
+    canMutate,
+    selectedFeedId,
+    name,
+    selectedCategories,
+    selectedViewIds,
+    selectedOpenLocation,
+    feedUrl: feed?.url,
+    onClose,
+  });
 
   const isFormDisabled = !name;
 
@@ -693,17 +742,18 @@ export function EditFeedDialog({
         <EditFeedDialogFooter
           canMutate={canMutate}
           isFormDisabled={isFormDisabled}
-          selectedFeedId={selectedFeedId}
-          name={name}
-          selectedCategories={selectedCategories}
-          selectedViewIds={selectedViewIds}
-          selectedOpenLocation={selectedOpenLocation}
-          onClose={onClose}
+          actions={actions}
         />
       }
     >
       <div className="grid gap-6">
-        <FeedNameField name={name} setName={setName} feed={feed} />
+        <FeedNameField
+          name={name}
+          setName={setName}
+          feed={feed}
+          hasCopied={actions.hasCopied}
+          onCopy={actions.handleCopy}
+        />
         <EditFeedViewsField
           canMutate={canMutate}
           selectedViewIds={selectedViewIds}

--- a/apps/app/src/components/AddFeedDialog.tsx
+++ b/apps/app/src/components/AddFeedDialog.tsx
@@ -20,7 +20,12 @@ import { SelectableChipList } from "./ui/selectable-chip-list";
 import { Switch } from "./ui/switch";
 import { ToggleGroupItem } from "./ui/toggle-group";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
-import type { FeedOpenLocation } from "~/server/db/schema";
+import type { Dispatch, SetStateAction } from "react";
+import type {
+  ApplicationFeed,
+  ApplicationView,
+  FeedOpenLocation,
+} from "~/server/db/schema";
 import type { ContentPlatform } from "~/lib/content/descriptor";
 import type { BookmarkSaveResult } from "~/server/bookmarks/contracts";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
@@ -286,44 +291,10 @@ function FeedOpenLocationToggleGroup({
   );
 }
 
-export function EditFeedDialog({
-  selectedFeedId,
-  onClose,
-}: {
-  selectedFeedId: null | number;
-  onClose: () => void;
-}) {
-  const canMutate = useCanMutate();
-  const [isUpdatingFeed, setIsUpdatingFeed] = useState(false);
-  const [isDeletingFeed, setIsDeletingFeed] = useState(false);
-  const [hasCopied, setHasCopied] = useState(false);
-
-  const { mutateAsync: editFeed } = useEditFeedMutation();
-  const { mutateAsync: deleteFeed } = useDeleteFeedMutation();
-  const { mutate: setFeedActive } = useSetFeedActiveMutation();
-  const { mutateAsync: quickCreateView } = useQuickCreateViewMutation();
-  const { mutateAsync: createContentCategory } =
-    useCreateContentCategoryMutation();
-
-  const [name, setName] = useState<string>("");
-  const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
-  const [selectedViewIds, setSelectedViewIds] = useState<number[]>([]);
-  const [selectedOpenLocation, setSelectedOpenLocation] =
-    useState<FeedOpenLocation>("serial");
-  const initializedFeedIdRef = useRef<number | null>(null);
-
-  const isFormDisabled = !name;
-
-  const { feeds } = useFeeds();
-  const { feedCategories } = useFeedCategories();
-  const { viewFeeds } = useViewFeeds();
-  const { views } = useViews();
-  const { contentCategories } = useContentCategories();
-  const viewOptions = useViewOptions();
-  const tagOptions = contentCategories.map((category) => ({
-    id: category.id,
-    label: category.name,
-  }));
+function getPrioritizedTagIds(
+  views: ApplicationView[],
+  selectedViewIds: number[],
+) {
   const selectedViewIdSet = new Set(selectedViewIds);
   const prioritizedTagIds = new Set<number>();
   for (const view of views) {
@@ -335,6 +306,34 @@ export function EditFeedDialog({
       }
     }
   }
+  return prioritizedTagIds;
+}
+
+function getFeedWebsiteUrl(feed: ApplicationFeed | undefined) {
+  if (!feed?.url) return "#";
+  try {
+    const url = new URL(feed.url);
+    if (feed.platform === "youtube") {
+      const channelId = url.searchParams.get("channel_id");
+      if (channelId) return `https://www.youtube.com/channel/${channelId}`;
+    }
+    return url.origin;
+  } catch {
+    return "#";
+  }
+}
+
+function useEditFeedForm(selectedFeedId: null | number) {
+  const [name, setName] = useState<string>("");
+  const [selectedCategories, setSelectedCategories] = useState<number[]>([]);
+  const [selectedViewIds, setSelectedViewIds] = useState<number[]>([]);
+  const [selectedOpenLocation, setSelectedOpenLocation] =
+    useState<FeedOpenLocation>("serial");
+  const initializedFeedIdRef = useRef<number | null>(null);
+
+  const { feeds } = useFeeds();
+  const { feedCategories } = useFeedCategories();
+  const { viewFeeds } = useViewFeeds();
 
   useEffect(() => {
     if (selectedFeedId == null) {
@@ -362,24 +361,321 @@ export function EditFeedDialog({
     initializedFeedIdRef.current = selectedFeedId;
   }, [feedCategories, viewFeeds, selectedFeedId, feeds]);
 
-  const feed = feeds.find((v) => v.id === selectedFeedId);
+  return {
+    name,
+    setName,
+    selectedCategories,
+    setSelectedCategories,
+    selectedViewIds,
+    setSelectedViewIds,
+    selectedOpenLocation,
+    setSelectedOpenLocation,
+    feed: feeds.find((v) => v.id === selectedFeedId),
+  };
+}
 
-  const websiteUrl = (() => {
-    if (!feed?.url) return "#";
-    try {
-      const url = new URL(feed.url);
-      if (feed.platform === "youtube") {
-        const channelId = url.searchParams.get("channel_id");
-        if (channelId) return `https://www.youtube.com/channel/${channelId}`;
-      }
-      return url.origin;
-    } catch {
-      return "#";
-    }
-  })();
+function FeedActiveSwitch({
+  canMutate,
+  feed,
+  selectedFeedId,
+}: {
+  canMutate: boolean;
+  feed: ApplicationFeed | undefined;
+  selectedFeedId: null | number;
+}) {
+  const { mutate: setFeedActive } = useSetFeedActiveMutation();
 
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex items-center">
+          <Switch
+            disabled={!canMutate}
+            checked={feed?.isActive ?? true}
+            onCheckedChange={(checked) => {
+              if (selectedFeedId !== null) {
+                setFeedActive({
+                  feedId: selectedFeedId,
+                  isActive: checked,
+                });
+              }
+            }}
+          />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        {feed?.isActive ? "Feed active" : "Feed inactive"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function EditFeedDialogFooter({
+  canMutate,
+  isFormDisabled,
+  selectedFeedId,
+  name,
+  selectedCategories,
+  selectedViewIds,
+  selectedOpenLocation,
+  onClose,
+}: {
+  canMutate: boolean;
+  isFormDisabled: boolean;
+  selectedFeedId: null | number;
+  name: string;
+  selectedCategories: number[];
+  selectedViewIds: number[];
+  selectedOpenLocation: FeedOpenLocation;
+  onClose: () => void;
+}) {
+  const [isUpdatingFeed, setIsUpdatingFeed] = useState(false);
+  const [isDeletingFeed, setIsDeletingFeed] = useState(false);
+
+  const { mutateAsync: editFeed } = useEditFeedMutation();
+  const { mutateAsync: deleteFeed } = useDeleteFeedMutation();
+
+  return (
+    <div className="flex gap-2">
+      <Button
+        disabled={!canMutate || isDeletingFeed}
+        className="flex-1"
+        variant="destructive"
+        onClick={async () => {
+          if (selectedFeedId === null || !canMutate) return;
+
+          setIsDeletingFeed(true);
+          try {
+            const deleteFeedPromise = deleteFeed(selectedFeedId);
+            toast.promise(deleteFeedPromise, {
+              loading: "Deleting feed...",
+              success: () => {
+                return "Feed deleted!";
+              },
+              error: () => {
+                return "Something went wrong deleting your feed.";
+              },
+            });
+            onClose();
+          } catch {
+            // Error handled by toast.promise
+          }
+
+          setIsDeletingFeed(false);
+        }}
+      >
+        {isDeletingFeed ? "Deleting..." : "Delete"}
+      </Button>
+      <Button
+        disabled={!canMutate || isFormDisabled || isUpdatingFeed}
+        onClick={async () => {
+          if (selectedFeedId === null || !canMutate) return;
+
+          setIsUpdatingFeed(true);
+          try {
+            await editFeed({
+              feedId: selectedFeedId,
+              categoryIds: selectedCategories,
+              viewIds: selectedViewIds,
+              openLocation: selectedOpenLocation,
+              name,
+            });
+            toast.success("Feed updated!");
+            onClose();
+          } catch {
+            // Error handled by toast
+          }
+
+          setIsUpdatingFeed(false);
+        }}
+        className="flex-1"
+      >
+        {isUpdatingFeed ? "Saving..." : "Save"}
+      </Button>
+    </div>
+  );
+}
+
+function FeedNameField({
+  name,
+  setName,
+  feed,
+}: {
+  name: string;
+  setName: (name: string) => void;
+  feed: ApplicationFeed | undefined;
+}) {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  const websiteUrl = getFeedWebsiteUrl(feed);
   const platformName =
     PLATFORM_TO_FORMATTED_NAME_MAP[feed?.platform ?? "youtube"];
+
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="name">Name</Label>
+      <div className="flex gap-2">
+        <Input
+          id="name"
+          type="text"
+          value={name}
+          placeholder="My Feed"
+          onChange={(e) => setName(e.target.value)}
+          className="flex-1"
+        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              className="shrink-0"
+              onClick={() => {
+                navigator.clipboard.writeText(feed?.url ?? "");
+                toast.success("Feed URL copied!");
+                setHasCopied(true);
+                setTimeout(() => setHasCopied(false), 2000);
+              }}
+            >
+              {hasCopied ? <CheckIcon size={16} /> : <LinkIcon size={16} />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Copy Feed URL</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="outline" size="icon" className="shrink-0" asChild>
+              <a
+                href={websiteUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Open in ${platformName}`}
+              >
+                <ExternalLinkIcon size={16} />
+              </a>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Open in {platformName}</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}
+
+function EditFeedViewsField({
+  canMutate,
+  selectedViewIds,
+  setSelectedViewIds,
+}: {
+  canMutate: boolean;
+  selectedViewIds: number[];
+  setSelectedViewIds: Dispatch<SetStateAction<number[]>>;
+}) {
+  const viewOptions = useViewOptions();
+  const { mutateAsync: quickCreateView } = useQuickCreateViewMutation();
+
+  return (
+    <SelectableChipList
+      label="Views"
+      options={viewOptions}
+      selectedIds={selectedViewIds}
+      onToggle={(id) =>
+        toggleSelectedId(selectedViewIds, setSelectedViewIds, id)
+      }
+      onCreate={async (viewName) => {
+        if (!canMutate) return;
+        try {
+          const createdView = await quickCreateView({ name: viewName });
+          if (createdView) {
+            setSelectedViewIds((ids) =>
+              ids.includes(createdView.id) ? ids : [...ids, createdView.id],
+            );
+          }
+        } catch {
+          toast.error("Failed to create view.");
+          throw new Error("Failed to create view.");
+        }
+      }}
+      createLabel="Create view"
+      createPlaceholder="New view name..."
+    />
+  );
+}
+
+function EditFeedTagsField({
+  canMutate,
+  selectedCategories,
+  setSelectedCategories,
+  selectedViewIds,
+}: {
+  canMutate: boolean;
+  selectedCategories: number[];
+  setSelectedCategories: Dispatch<SetStateAction<number[]>>;
+  selectedViewIds: number[];
+}) {
+  const { views } = useViews();
+  const { contentCategories } = useContentCategories();
+  const { mutateAsync: createContentCategory } =
+    useCreateContentCategoryMutation();
+
+  const tagOptions = contentCategories.map((category) => ({
+    id: category.id,
+    label: category.name,
+  }));
+  const prioritizedTagIds = getPrioritizedTagIds(views, selectedViewIds);
+
+  return (
+    <SelectableChipList
+      label="Tags"
+      options={tagOptions}
+      selectedIds={selectedCategories}
+      prioritizedIds={prioritizedTagIds}
+      onToggle={(id) =>
+        toggleSelectedId(selectedCategories, setSelectedCategories, id)
+      }
+      onCreate={async (tagName) => {
+        if (!canMutate) return;
+        try {
+          const createdTag = await createContentCategory({
+            name: tagName,
+            feedCategorizations: [],
+          });
+          if (createdTag) {
+            setSelectedCategories((ids) =>
+              ids.includes(createdTag.id) ? ids : [...ids, createdTag.id],
+            );
+          }
+        } catch {
+          toast.error("Failed to create tag.");
+          throw new Error("Failed to create tag.");
+        }
+      }}
+      createLabel="Create tag"
+      createPlaceholder="New tag name..."
+    />
+  );
+}
+
+export function EditFeedDialog({
+  selectedFeedId,
+  onClose,
+}: {
+  selectedFeedId: null | number;
+  onClose: () => void;
+}) {
+  const canMutate = useCanMutate();
+  const {
+    name,
+    setName,
+    selectedCategories,
+    setSelectedCategories,
+    selectedViewIds,
+    setSelectedViewIds,
+    selectedOpenLocation,
+    setSelectedOpenLocation,
+    feed,
+  } = useEditFeedForm(selectedFeedId);
+
+  const isFormDisabled = !name;
 
   return (
     <ControlledResponsiveDialog
@@ -387,191 +683,37 @@ export function EditFeedDialog({
       onOpenChange={onClose}
       title="Edit Feed"
       headerRight={
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center">
-              <Switch
-                disabled={!canMutate}
-                checked={feed?.isActive ?? true}
-                onCheckedChange={(checked) => {
-                  if (selectedFeedId !== null) {
-                    setFeedActive({
-                      feedId: selectedFeedId,
-                      isActive: checked,
-                    });
-                  }
-                }}
-              />
-            </div>
-          </TooltipTrigger>
-          <TooltipContent>
-            {feed?.isActive ? "Feed active" : "Feed inactive"}
-          </TooltipContent>
-        </Tooltip>
+        <FeedActiveSwitch
+          canMutate={canMutate}
+          feed={feed}
+          selectedFeedId={selectedFeedId}
+        />
       }
       footer={
-        <div className="flex gap-2">
-          <Button
-            disabled={!canMutate || isDeletingFeed}
-            className="flex-1"
-            variant="destructive"
-            onClick={async () => {
-              if (selectedFeedId === null || !canMutate) return;
-
-              setIsDeletingFeed(true);
-              try {
-                const deleteFeedPromise = deleteFeed(selectedFeedId);
-                toast.promise(deleteFeedPromise, {
-                  loading: "Deleting feed...",
-                  success: () => {
-                    return "Feed deleted!";
-                  },
-                  error: () => {
-                    return "Something went wrong deleting your feed.";
-                  },
-                });
-                onClose();
-              } catch {
-                // Error handled by toast.promise
-              }
-
-              setIsDeletingFeed(false);
-            }}
-          >
-            {isDeletingFeed ? "Deleting..." : "Delete"}
-          </Button>
-          <Button
-            disabled={!canMutate || isFormDisabled || isUpdatingFeed}
-            onClick={async () => {
-              if (selectedFeedId === null || !canMutate) return;
-
-              setIsUpdatingFeed(true);
-              try {
-                await editFeed({
-                  feedId: selectedFeedId,
-                  categoryIds: selectedCategories,
-                  viewIds: selectedViewIds,
-                  openLocation: selectedOpenLocation,
-                  name,
-                });
-                toast.success("Feed updated!");
-                onClose();
-              } catch {
-                // Error handled by toast
-              }
-
-              setIsUpdatingFeed(false);
-            }}
-            className="flex-1"
-          >
-            {isUpdatingFeed ? "Saving..." : "Save"}
-          </Button>
-        </div>
+        <EditFeedDialogFooter
+          canMutate={canMutate}
+          isFormDisabled={isFormDisabled}
+          selectedFeedId={selectedFeedId}
+          name={name}
+          selectedCategories={selectedCategories}
+          selectedViewIds={selectedViewIds}
+          selectedOpenLocation={selectedOpenLocation}
+          onClose={onClose}
+        />
       }
     >
       <div className="grid gap-6">
-        <div className="grid gap-2">
-          <Label htmlFor="name">Name</Label>
-          <div className="flex gap-2">
-            <Input
-              id="name"
-              type="text"
-              value={name}
-              placeholder="My Feed"
-              onChange={(e) => setName(e.target.value)}
-              className="flex-1"
-            />
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="shrink-0"
-                  onClick={() => {
-                    navigator.clipboard.writeText(feed?.url ?? "");
-                    toast.success("Feed URL copied!");
-                    setHasCopied(true);
-                    setTimeout(() => setHasCopied(false), 2000);
-                  }}
-                >
-                  {hasCopied ? <CheckIcon size={16} /> : <LinkIcon size={16} />}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Copy Feed URL</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="shrink-0"
-                  asChild
-                >
-                  <a
-                    href={websiteUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`Open in ${platformName}`}
-                  >
-                    <ExternalLinkIcon size={16} />
-                  </a>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Open in {platformName}</TooltipContent>
-            </Tooltip>
-          </div>
-        </div>
-        <SelectableChipList
-          label="Views"
-          options={viewOptions}
-          selectedIds={selectedViewIds}
-          onToggle={(id) =>
-            toggleSelectedId(selectedViewIds, setSelectedViewIds, id)
-          }
-          onCreate={async (viewName) => {
-            if (!canMutate) return;
-            try {
-              const createdView = await quickCreateView({ name: viewName });
-              if (createdView) {
-                setSelectedViewIds((ids) =>
-                  ids.includes(createdView.id) ? ids : [...ids, createdView.id],
-                );
-              }
-            } catch {
-              toast.error("Failed to create view.");
-              throw new Error("Failed to create view.");
-            }
-          }}
-          createLabel="Create view"
-          createPlaceholder="New view name..."
+        <FeedNameField name={name} setName={setName} feed={feed} />
+        <EditFeedViewsField
+          canMutate={canMutate}
+          selectedViewIds={selectedViewIds}
+          setSelectedViewIds={setSelectedViewIds}
         />
-        <SelectableChipList
-          label="Tags"
-          options={tagOptions}
-          selectedIds={selectedCategories}
-          prioritizedIds={prioritizedTagIds}
-          onToggle={(id) =>
-            toggleSelectedId(selectedCategories, setSelectedCategories, id)
-          }
-          onCreate={async (tagName) => {
-            if (!canMutate) return;
-            try {
-              const createdTag = await createContentCategory({
-                name: tagName,
-                feedCategorizations: [],
-              });
-              if (createdTag) {
-                setSelectedCategories((ids) =>
-                  ids.includes(createdTag.id) ? ids : [...ids, createdTag.id],
-                );
-              }
-            } catch {
-              toast.error("Failed to create tag.");
-              throw new Error("Failed to create tag.");
-            }
-          }}
-          createLabel="Create tag"
-          createPlaceholder="New tag name..."
+        <EditFeedTagsField
+          canMutate={canMutate}
+          selectedCategories={selectedCategories}
+          setSelectedCategories={setSelectedCategories}
+          selectedViewIds={selectedViewIds}
         />
         <FeedOpenLocationToggleGroup
           feedPlatform={feed?.platform ?? "youtube"}

--- a/apps/app/src/components/admin/PublicSignupToggle.tsx
+++ b/apps/app/src/components/admin/PublicSignupToggle.tsx
@@ -59,12 +59,8 @@ function ProviderToggle({
   );
 }
 
-export function PublicSignupToggle() {
+function usePublicSignupMutations() {
   const queryClient = useQueryClient();
-
-  const { data, isLoading } = useQuery(
-    orpc.admin.getPublicSignupSetting.queryOptions(),
-  );
 
   const signupMutation = useMutation(
     orpc.admin.setPublicSignupSetting.mutationOptions({
@@ -112,30 +108,28 @@ export function PublicSignupToggle() {
     }),
   );
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center gap-3 rounded-lg border p-4">
-        <Loader2Icon className="animate-spin" size={16} />
-        <span className="text-muted-foreground text-sm">Loading...</span>
-      </div>
-    );
-  }
+  return { signupMutation, signinMutation, signupProvidersMutation };
+}
 
-  const globalEnabled = data?.enabled ?? false;
-  const signinProviders = data?.signinProviders ?? ["email"];
-  const signupProviders = data?.signupProviders ?? ["email"];
-  const oauthConfigured = data?.isOAuthConfigured ?? false;
-  const atprotoConfigured = data?.isAtprotoConfigured ?? false;
-  const oauthProviderName = data?.oauthProviderName ?? "OAuth";
-  const adminSigninMethods = data?.adminSigninMethods ?? ["email"];
+type PublicSignupMutations = ReturnType<typeof usePublicSignupMutations>;
 
-  const toggleSignin = (provider: AuthProvider, checked: boolean) => {
-    const next = checked
-      ? [...signinProviders, provider]
-      : signinProviders.filter((p) => p !== provider);
-    signinMutation.mutate({ providers: next });
-  };
-
+function SignupMethodsCard({
+  globalEnabled,
+  signupProviders,
+  oauthConfigured,
+  atprotoConfigured,
+  oauthProviderName,
+  signupMutation,
+  signupProvidersMutation,
+}: {
+  globalEnabled: boolean;
+  signupProviders: AuthProvider[];
+  oauthConfigured: boolean;
+  atprotoConfigured: boolean;
+  oauthProviderName: string;
+  signupMutation: PublicSignupMutations["signupMutation"];
+  signupProvidersMutation: PublicSignupMutations["signupProvidersMutation"];
+}) {
   const toggleSignup = (provider: AuthProvider, checked: boolean) => {
     const next = checked
       ? [...signupProviders, provider]
@@ -143,6 +137,90 @@ export function PublicSignupToggle() {
     signupProvidersMutation.mutate({
       providers: next,
     });
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border p-4">
+      <span className="text-muted-foreground text-xs">Sign-up methods</span>
+
+      {globalEnabled && (
+        <>
+          <ProviderToggle
+            id="signup-email-toggle"
+            label="Email"
+            checked={signupProviders.includes("email")}
+            onToggle={(checked) => toggleSignup("email", checked)}
+            isPending={signupProvidersMutation.isPending}
+          />
+
+          {oauthConfigured && (
+            <ProviderToggle
+              id="signup-oauth-toggle"
+              label={oauthProviderName}
+              checked={signupProviders.includes("oauth")}
+              onToggle={(checked) => toggleSignup("oauth", checked)}
+              isPending={signupProvidersMutation.isPending}
+            />
+          )}
+
+          {atprotoConfigured && (
+            <ProviderToggle
+              id="signup-atproto-toggle"
+              label="Atmosphere"
+              checked={signupProviders.includes("atproto")}
+              onToggle={(checked) => toggleSignup("atproto", checked)}
+              isPending={signupProvidersMutation.isPending}
+            />
+          )}
+        </>
+      )}
+
+      <div
+        className={`flex items-center justify-between ${globalEnabled ? "mt-2 border-t pt-4" : ""}`}
+      >
+        <div className="flex flex-1 flex-col gap-1">
+          <Label htmlFor="public-signup-toggle" className="font-medium">
+            Allow public sign up
+          </Label>
+          <span className="text-muted-foreground text-sm">
+            {globalEnabled
+              ? "Anyone can create an account"
+              : "Only admins can create accounts"}
+          </span>
+        </div>
+        <Switch
+          id="public-signup-toggle"
+          checked={globalEnabled}
+          onCheckedChange={(checked) =>
+            signupMutation.mutate({ enabled: checked })
+          }
+          disabled={signupMutation.isPending}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SigninMethodsCard({
+  signinProviders,
+  oauthConfigured,
+  atprotoConfigured,
+  oauthProviderName,
+  adminSigninMethods,
+  signinMutation,
+}: {
+  signinProviders: AuthProvider[];
+  oauthConfigured: boolean;
+  atprotoConfigured: boolean;
+  oauthProviderName: string;
+  adminSigninMethods: AuthProvider[];
+  signinMutation: PublicSignupMutations["signinMutation"];
+}) {
+  const toggleSignin = (provider: AuthProvider, checked: boolean) => {
+    const next = checked
+      ? [...signinProviders, provider]
+      : signinProviders.filter((p) => p !== provider);
+    signinMutation.mutate({ providers: next });
   };
 
   const getSigninLockedTooltip = (provider: AuthProvider) => {
@@ -153,100 +231,80 @@ export function PublicSignupToggle() {
   };
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-col gap-2 rounded-lg border p-4">
-        <span className="text-muted-foreground text-xs">Sign-up methods</span>
+    <div className="flex flex-col gap-2 rounded-lg border p-4">
+      <span className="text-muted-foreground text-xs">Sign-in methods</span>
 
-        {globalEnabled && (
-          <>
-            <ProviderToggle
-              id="signup-email-toggle"
-              label="Email"
-              checked={signupProviders.includes("email")}
-              onToggle={(checked) => toggleSignup("email", checked)}
-              isPending={signupProvidersMutation.isPending}
-            />
+      <ProviderToggle
+        id="signin-email-toggle"
+        label="Email"
+        checked={signinProviders.includes("email")}
+        onToggle={(checked) => toggleSignin("email", checked)}
+        isPending={signinMutation.isPending}
+        lockedTooltip={getSigninLockedTooltip("email")}
+      />
 
-            {oauthConfigured && (
-              <ProviderToggle
-                id="signup-oauth-toggle"
-                label={oauthProviderName}
-                checked={signupProviders.includes("oauth")}
-                onToggle={(checked) => toggleSignup("oauth", checked)}
-                isPending={signupProvidersMutation.isPending}
-              />
-            )}
-
-            {atprotoConfigured && (
-              <ProviderToggle
-                id="signup-atproto-toggle"
-                label="Atmosphere"
-                checked={signupProviders.includes("atproto")}
-                onToggle={(checked) => toggleSignup("atproto", checked)}
-                isPending={signupProvidersMutation.isPending}
-              />
-            )}
-          </>
-        )}
-
-        <div
-          className={`flex items-center justify-between ${globalEnabled ? "mt-2 border-t pt-4" : ""}`}
-        >
-          <div className="flex flex-1 flex-col gap-1">
-            <Label htmlFor="public-signup-toggle" className="font-medium">
-              Allow public sign up
-            </Label>
-            <span className="text-muted-foreground text-sm">
-              {globalEnabled
-                ? "Anyone can create an account"
-                : "Only admins can create accounts"}
-            </span>
-          </div>
-          <Switch
-            id="public-signup-toggle"
-            checked={globalEnabled}
-            onCheckedChange={(checked) =>
-              signupMutation.mutate({ enabled: checked })
-            }
-            disabled={signupMutation.isPending}
-          />
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2 rounded-lg border p-4">
-        <span className="text-muted-foreground text-xs">Sign-in methods</span>
-
+      {oauthConfigured && (
         <ProviderToggle
-          id="signin-email-toggle"
-          label="Email"
-          checked={signinProviders.includes("email")}
-          onToggle={(checked) => toggleSignin("email", checked)}
+          id="signin-oauth-toggle"
+          label={oauthProviderName}
+          checked={signinProviders.includes("oauth")}
+          onToggle={(checked) => toggleSignin("oauth", checked)}
           isPending={signinMutation.isPending}
-          lockedTooltip={getSigninLockedTooltip("email")}
+          lockedTooltip={getSigninLockedTooltip("oauth")}
         />
+      )}
 
-        {oauthConfigured && (
-          <ProviderToggle
-            id="signin-oauth-toggle"
-            label={oauthProviderName}
-            checked={signinProviders.includes("oauth")}
-            onToggle={(checked) => toggleSignin("oauth", checked)}
-            isPending={signinMutation.isPending}
-            lockedTooltip={getSigninLockedTooltip("oauth")}
-          />
-        )}
+      {atprotoConfigured && (
+        <ProviderToggle
+          id="signin-atproto-toggle"
+          label="Atmosphere"
+          checked={signinProviders.includes("atproto")}
+          onToggle={(checked) => toggleSignin("atproto", checked)}
+          isPending={signinMutation.isPending}
+          lockedTooltip={getSigninLockedTooltip("atproto")}
+        />
+      )}
+    </div>
+  );
+}
 
-        {atprotoConfigured && (
-          <ProviderToggle
-            id="signin-atproto-toggle"
-            label="Atmosphere"
-            checked={signinProviders.includes("atproto")}
-            onToggle={(checked) => toggleSignin("atproto", checked)}
-            isPending={signinMutation.isPending}
-            lockedTooltip={getSigninLockedTooltip("atproto")}
-          />
-        )}
+export function PublicSignupToggle() {
+  const { data, isLoading } = useQuery(
+    orpc.admin.getPublicSignupSetting.queryOptions(),
+  );
+
+  const { signupMutation, signinMutation, signupProvidersMutation } =
+    usePublicSignupMutations();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-3 rounded-lg border p-4">
+        <Loader2Icon className="animate-spin" size={16} />
+        <span className="text-muted-foreground text-sm">Loading...</span>
       </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <SignupMethodsCard
+        globalEnabled={data?.enabled ?? false}
+        signupProviders={data?.signupProviders ?? ["email"]}
+        oauthConfigured={data?.isOAuthConfigured ?? false}
+        atprotoConfigured={data?.isAtprotoConfigured ?? false}
+        oauthProviderName={data?.oauthProviderName ?? "OAuth"}
+        signupMutation={signupMutation}
+        signupProvidersMutation={signupProvidersMutation}
+      />
+
+      <SigninMethodsCard
+        signinProviders={data?.signinProviders ?? ["email"]}
+        oauthConfigured={data?.isOAuthConfigured ?? false}
+        atprotoConfigured={data?.isAtprotoConfigured ?? false}
+        oauthProviderName={data?.oauthProviderName ?? "OAuth"}
+        adminSigninMethods={data?.adminSigninMethods ?? ["email"]}
+        signinMutation={signinMutation}
+      />
     </div>
   );
 }

--- a/apps/app/src/components/auth/AtprotoHandleField.tsx
+++ b/apps/app/src/components/auth/AtprotoHandleField.tsx
@@ -8,6 +8,7 @@ import {
 import clsx from "clsx";
 import { AtSignIcon, Loader2, XIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent, RefObject } from "react";
 import type { AtprotoActorSuggestion } from "~/server/auth/atproto/typeahead";
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
@@ -81,9 +82,6 @@ export function AtprotoHandleField({
 }: AtprotoHandleFieldProps) {
   const [identifier, setIdentifier] = useState("");
   const [selected, setSelected] = useState<AtprotoActorSuggestion | null>(null);
-  const [suggestions, setSuggestions] = useState<AtprotoActorSuggestion[]>([]);
-  /** The query the current suggestions answer; stale results never render. */
-  const [suggestionsFor, setSuggestionsFor] = useState("");
   const [dismissed, setDismissed] = useState(false);
   /** Enter only confirms a suggestion the combobox has highlighted. */
   const highlightedRef = useRef<AtprotoActorSuggestion | undefined>(undefined);
@@ -92,9 +90,12 @@ export function AtprotoHandleField({
 
   const query = identifier.trim();
   const searchable = query.length >= TYPEAHEAD_MIN_CHARS;
-  const suggestionsCurrent = searchable && suggestionsFor === query;
-  const visibleSuggestions =
-    suggestionsCurrent && !dismissed ? suggestions : [];
+  const visibleSuggestions = useAtprotoTypeahead(
+    query,
+    searchable,
+    selected,
+    dismissed,
+  );
   const open = visibleSuggestions.length > 0;
 
   useEffect(() => {
@@ -107,36 +108,6 @@ export function AtprotoHandleField({
     // natively, no synthetic key handling.
     if (selected) submitRef.current?.focus();
   }, [selected]);
-
-  useEffect(() => {
-    if (!searchable || selected !== null) return;
-
-    const controller = new AbortController();
-    const timeoutId = window.setTimeout(() => {
-      void authClient
-        .$fetch<{ actors: AtprotoActorSuggestion[] }>(
-          `${TYPEAHEAD_PATH}?q=${encodeURIComponent(query)}`,
-          { signal: controller.signal },
-        )
-        .then(({ data }) => {
-          setSuggestions(data?.actors ?? []);
-          setSuggestionsFor(query);
-        })
-        .catch(() => {
-          // A real failure degrades silently; an abort just means a newer
-          // query superseded this one, so its results stay.
-          if (!controller.signal.aborted) {
-            setSuggestions([]);
-            setSuggestionsFor(query);
-          }
-        });
-    }, TYPEAHEAD_DEBOUNCE_MS);
-
-    return () => {
-      controller.abort();
-      window.clearTimeout(timeoutId);
-    };
-  }, [query, searchable, selected]);
 
   // The typed value stays submittable so a handle the typeahead doesn't
   // return (unindexed PDS, proxy outage) — or a raw DID — can't lock the
@@ -164,37 +135,19 @@ export function AtprotoHandleField({
 
   if (selected) {
     return (
-      <div className="grid gap-2">
-        <Label htmlFor={id}>{label}</Label>
-        <Item variant="outline" render={<div />}>
-          <ItemMedia>
-            <AtprotoSuggestionAvatar suggestion={selected} />
-          </ItemMedia>
-          <ItemContent className="gap-0">
-            <ItemTitle>{selected.displayName ?? selected.handle}</ItemTitle>
-            <ItemDescription>{selected.handle}</ItemDescription>
-          </ItemContent>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Choose a different account"
-            disabled={busy || disabled}
-            onClick={clearSelection}
-          >
-            <XIcon size={16} />
-          </Button>
-        </Item>
-        <Button
-          ref={submitRef}
-          variant={submitVariant}
-          size={size}
-          className="w-full"
-          disabled={disabled || busy}
-          onClick={submit}
-        >
-          {busy ? <Loader2 size={16} className="animate-spin" /> : submitLabel}
-        </Button>
-      </div>
+      <AtprotoSelectedAccount
+        id={id}
+        label={label}
+        selected={selected}
+        busy={busy}
+        disabled={disabled}
+        submitLabel={submitLabel}
+        submitVariant={submitVariant}
+        size={size}
+        submitRef={submitRef}
+        onClear={clearSelection}
+        onSubmit={submit}
+      />
     );
   }
 
@@ -235,56 +188,18 @@ export function AtprotoHandleField({
           highlightedRef.current = item ?? undefined;
         }}
       >
-        <div className="relative">
-          <AtSignIcon
-            size={16}
-            className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2"
-          />
-          <ComboboxInput
-            id={id}
-            ref={inputRef}
-            className={clsx("pl-9", size === "lg" && "h-10")}
-            placeholder="name.bsky.social"
-            autoComplete="username"
-            autoCapitalize="none"
-            autoCorrect="off"
-            spellCheck={false}
-            disabled={disabled}
-            // Advertise that the next Escape belongs to this field (it
-            // dismisses the popup or the pending search). A surrounding
-            // Radix dialog's escape listener runs before this element's
-            // handlers ever could, so it checks this attribute to leave
-            // the keystroke alone; see ControlledResponsiveDialog.
-            data-escape-dismisses={
-              open || (searchable && !dismissed) ? "true" : undefined
-            }
-            onFocus={() => setDismissed(false)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                // Selection is required: Enter confirms the highlighted
-                // suggestion (handled by the combobox) and otherwise does
-                // nothing.
-                if (!(open && highlightedRef.current)) e.preventDefault();
-                return;
-              }
-              if (e.key === "Escape") {
-                if (open) return; // The combobox dismisses its own popup.
-                // Gate on intent, not list presence: a query that is (or is
-                // about to be) searching dismisses first even if results are
-                // still in flight, so the same keystroke can't tear the step
-                // down just because the network was slow.
-                if (searchable && !dismissed) {
-                  e.preventDefault();
-                  setDismissed(true);
-                } else if (onCollapse) {
-                  // Second escape (or nothing to dismiss): back to the caller.
-                  e.preventDefault();
-                  onCollapse();
-                }
-              }
-            }}
-          />
-        </div>
+        <AtprotoHandleInput
+          id={id}
+          size={size}
+          disabled={disabled}
+          open={open}
+          searchable={searchable}
+          dismissed={dismissed}
+          setDismissed={setDismissed}
+          onCollapse={onCollapse}
+          highlightedRef={highlightedRef}
+          inputRef={inputRef}
+        />
         <ComboboxContent aria-label="Suggested accounts">
           <ComboboxList>
             {(suggestion: AtprotoActorSuggestion) => (
@@ -305,6 +220,189 @@ export function AtprotoHandleField({
       >
         {busy ? <Loader2 size={16} className="animate-spin" /> : submitLabel}
       </Button>
+    </div>
+  );
+}
+
+function useAtprotoTypeahead(
+  query: string,
+  searchable: boolean,
+  selected: AtprotoActorSuggestion | null,
+  dismissed: boolean,
+) {
+  const [suggestions, setSuggestions] = useState<AtprotoActorSuggestion[]>([]);
+  /** The query the current suggestions answer; stale results never render. */
+  const [suggestionsFor, setSuggestionsFor] = useState("");
+
+  useEffect(() => {
+    if (!searchable || selected !== null) return;
+
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => {
+      void authClient
+        .$fetch<{ actors: AtprotoActorSuggestion[] }>(
+          `${TYPEAHEAD_PATH}?q=${encodeURIComponent(query)}`,
+          { signal: controller.signal },
+        )
+        .then(({ data }) => {
+          setSuggestions(data?.actors ?? []);
+          setSuggestionsFor(query);
+        })
+        .catch(() => {
+          // A real failure degrades silently; an abort just means a newer
+          // query superseded this one, so its results stay.
+          if (!controller.signal.aborted) {
+            setSuggestions([]);
+            setSuggestionsFor(query);
+          }
+        });
+    }, TYPEAHEAD_DEBOUNCE_MS);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timeoutId);
+    };
+  }, [query, searchable, selected]);
+
+  const suggestionsCurrent = searchable && suggestionsFor === query;
+  return suggestionsCurrent && !dismissed ? suggestions : [];
+}
+
+function AtprotoSelectedAccount({
+  id,
+  label,
+  selected,
+  busy,
+  disabled,
+  submitLabel,
+  submitVariant,
+  size,
+  submitRef,
+  onClear,
+  onSubmit,
+}: {
+  id: string;
+  label: string;
+  selected: AtprotoActorSuggestion;
+  busy: boolean;
+  disabled: boolean;
+  submitLabel: string;
+  submitVariant: "outline" | "default";
+  size: "default" | "lg";
+  submitRef: RefObject<HTMLButtonElement | null>;
+  onClear: () => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Item variant="outline" render={<div />}>
+        <ItemMedia>
+          <AtprotoSuggestionAvatar suggestion={selected} />
+        </ItemMedia>
+        <ItemContent className="gap-0">
+          <ItemTitle>{selected.displayName ?? selected.handle}</ItemTitle>
+          <ItemDescription>{selected.handle}</ItemDescription>
+        </ItemContent>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Choose a different account"
+          disabled={busy || disabled}
+          onClick={onClear}
+        >
+          <XIcon size={16} />
+        </Button>
+      </Item>
+      <Button
+        ref={submitRef}
+        variant={submitVariant}
+        size={size}
+        className="w-full"
+        disabled={disabled || busy}
+        onClick={onSubmit}
+      >
+        {busy ? <Loader2 size={16} className="animate-spin" /> : submitLabel}
+      </Button>
+    </div>
+  );
+}
+
+function AtprotoHandleInput({
+  id,
+  size,
+  disabled,
+  open,
+  searchable,
+  dismissed,
+  setDismissed,
+  onCollapse,
+  highlightedRef,
+  inputRef,
+}: {
+  id: string;
+  size: "default" | "lg";
+  disabled: boolean;
+  open: boolean;
+  searchable: boolean;
+  dismissed: boolean;
+  setDismissed: (dismissed: boolean) => void;
+  onCollapse?: () => void;
+  highlightedRef: RefObject<AtprotoActorSuggestion | undefined>;
+  inputRef: RefObject<HTMLInputElement | null>;
+}) {
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      // Selection is required: Enter confirms the highlighted
+      // suggestion (handled by the combobox) and otherwise does
+      // nothing.
+      if (!(open && highlightedRef.current)) e.preventDefault();
+      return;
+    }
+    if (e.key === "Escape") {
+      if (open) return; // The combobox dismisses its own popup.
+      // Gate on intent, not list presence: a query that is (or is
+      // about to be) searching dismisses first even if results are
+      // still in flight, so the same keystroke can't tear the step
+      // down just because the network was slow.
+      if (searchable && !dismissed) {
+        e.preventDefault();
+        setDismissed(true);
+      } else if (onCollapse) {
+        // Second escape (or nothing to dismiss): back to the caller.
+        e.preventDefault();
+        onCollapse();
+      }
+    }
+  };
+
+  return (
+    <div className="relative">
+      <AtSignIcon
+        size={16}
+        className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2"
+      />
+      <ComboboxInput
+        id={id}
+        ref={inputRef}
+        className={clsx("pl-9", size === "lg" && "h-10")}
+        placeholder="name.bsky.social"
+        autoComplete="username"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
+        disabled={disabled}
+        // Advertise that the next Escape belongs to this field (it
+        // dismisses the popup or the pending search). A surrounding
+        // Radix dialog's escape listener runs before this element's
+        // handlers ever could, so it checks this attribute to leave
+        // the keystroke alone; see ControlledResponsiveDialog.
+        data-escape-dismisses={
+          open || (searchable && !dismissed) ? "true" : undefined
+        }
+        onFocus={() => setDismissed(false)}
+        onKeyDown={onKeyDown}
+      />
     </div>
   );
 }

--- a/apps/app/src/components/connections/AtprotoConnection.tsx
+++ b/apps/app/src/components/connections/AtprotoConnection.tsx
@@ -97,54 +97,101 @@ export function AtprotoConnectionListItem({
     >
       <div className="flex flex-col">
         <span className="font-medium">Atmosphere</span>
-        {isLoading ? (
-          <span className="text-muted-foreground text-sm">Loading...</span>
-        ) : !computedStatus.isConfigured ? (
-          <span className="text-muted-foreground text-sm">Not available</span>
-        ) : computedStatus.isConnected ? (
-          <span className="text-muted-foreground text-sm">
-            {computedStatus.handle}
-          </span>
-        ) : computedStatus.needsReconnect ? (
-          // Credentials were lost (revoked at the PDS, failed refresh) but
-          // the sign-in method still exists: the row re-links on click and
-          // keeps its disconnect affordance.
-          <span className="text-muted-foreground text-sm">
-            Reconnect {computedStatus.handle}
-          </span>
-        ) : (
-          <span className="text-muted-foreground text-sm">Not connected</span>
-        )}
+        <AtprotoConnectionStatusLine
+          isLoading={isLoading}
+          status={computedStatus}
+        />
       </div>
-      {isLoading ? (
-        <Loader2Icon className="text-muted-foreground animate-spin" size={20} />
-      ) : !computedStatus.isConfigured ? null : computedStatus.isConnected ||
-        computedStatus.needsReconnect ? (
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            unlinkMutation.mutate(undefined);
-          }}
-          // In the reconnect state the row itself is clickable; keyboard
-          // activation must not bubble into its Enter/Space handler (which
-          // would preventDefault this button and open the link form).
-          onKeyDown={(e) => e.stopPropagation()}
-          disabled={unlinkMutation.isPending}
-        >
-          {unlinkMutation.isPending ? (
-            <Loader2Icon className="animate-spin" size={16} />
-          ) : (
-            <>
-              <UnplugIcon size={16} />
-              <span className="ml-1.5">Disconnect</span>
-            </>
-          )}
-        </Button>
-      ) : (
-        <ChevronRightIcon className="text-muted-foreground" size={20} />
-      )}
+      <AtprotoConnectionAction
+        isLoading={isLoading}
+        status={computedStatus}
+        disconnecting={unlinkMutation.isPending}
+        onDisconnect={() => unlinkMutation.mutate(undefined)}
+      />
     </div>
   );
+}
+
+interface AtprotoConnectionStatus {
+  isConnected: boolean;
+  needsReconnect: boolean;
+  handle: string | null;
+  isConfigured: boolean;
+}
+
+function AtprotoConnectionStatusLine({
+  isLoading,
+  status,
+}: {
+  isLoading: boolean;
+  status: AtprotoConnectionStatus;
+}) {
+  if (isLoading) {
+    return <span className="text-muted-foreground text-sm">Loading...</span>;
+  }
+  if (!status.isConfigured) {
+    return <span className="text-muted-foreground text-sm">Not available</span>;
+  }
+  if (status.isConnected) {
+    return (
+      <span className="text-muted-foreground text-sm">{status.handle}</span>
+    );
+  }
+  if (status.needsReconnect) {
+    // Credentials were lost (revoked at the PDS, failed refresh) but
+    // the sign-in method still exists: the row re-links on click and
+    // keeps its disconnect affordance.
+    return (
+      <span className="text-muted-foreground text-sm">
+        Reconnect {status.handle}
+      </span>
+    );
+  }
+  return <span className="text-muted-foreground text-sm">Not connected</span>;
+}
+
+function AtprotoConnectionAction({
+  isLoading,
+  status,
+  disconnecting,
+  onDisconnect,
+}: {
+  isLoading: boolean;
+  status: AtprotoConnectionStatus;
+  disconnecting: boolean;
+  onDisconnect: () => void;
+}) {
+  if (isLoading) {
+    return (
+      <Loader2Icon className="text-muted-foreground animate-spin" size={20} />
+    );
+  }
+  if (!status.isConfigured) return null;
+  if (status.isConnected || status.needsReconnect) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDisconnect();
+        }}
+        // In the reconnect state the row itself is clickable; keyboard
+        // activation must not bubble into its Enter/Space handler (which
+        // would preventDefault this button and open the link form).
+        onKeyDown={(e) => e.stopPropagation()}
+        disabled={disconnecting}
+      >
+        {disconnecting ? (
+          <Loader2Icon className="animate-spin" size={16} />
+        ) : (
+          <>
+            <UnplugIcon size={16} />
+            <span className="ml-1.5">Disconnect</span>
+          </>
+        )}
+      </Button>
+    );
+  }
+  return <ChevronRightIcon className="text-muted-foreground" size={20} />;
 }

--- a/apps/app/src/components/feed/UserManagementButton.tsx
+++ b/apps/app/src/components/feed/UserManagementButton.tsx
@@ -8,7 +8,7 @@ import {
   Loader2Icon,
   PlugIcon,
 } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useDialogStore } from "./dialogStore";
 import { Button } from "~/components/ui/button";
 import { DropdownMenuSeparator } from "~/components/ui/dropdown-menu";
@@ -138,34 +138,50 @@ function AccountMenuItems({ billingEnabled }: { billingEnabled: boolean }) {
   );
 }
 
-function SignOutMenuItem() {
+function useSignOutAction() {
   const router = useRouter();
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const isSigningOutRef = useRef(false);
   const queryClient = useQueryClient();
   const clearAllUserData = useClearAllUserData();
 
+  const handleSignOut = async () => {
+    if (isSigningOutRef.current) return;
+
+    isSigningOutRef.current = true;
+    setIsSigningOut(true);
+    try {
+      await signOut({
+        fetchOptions: {
+          onSuccess: () => {
+            clearUserDataAfterSignOut({
+              clearQueryCache: () => queryClient.clear(),
+              clearPersistedUserData: clearAllUserData,
+              localStorage: window.localStorage,
+            });
+            void router.navigate({ to: "/auth/sign-in" });
+          },
+        },
+      });
+    } finally {
+      isSigningOutRef.current = false;
+      setIsSigningOut(false);
+    }
+  };
+
+  return { isSigningOut, handleSignOut };
+}
+
+function SignOutMenuItem({
+  isSigningOut,
+  onSignOut,
+}: {
+  isSigningOut: boolean;
+  onSignOut: () => void;
+}) {
   return (
     <ResponsiveDropdownMenuItem asChild>
-      <Button
-        className="w-full"
-        onClick={async () => {
-          await signOut({
-            fetchOptions: {
-              onRequest: () => {
-                setIsSigningOut(true);
-              },
-              onSuccess: () => {
-                clearUserDataAfterSignOut({
-                  clearQueryCache: () => queryClient.clear(),
-                  clearPersistedUserData: clearAllUserData,
-                  localStorage: window.localStorage,
-                });
-                void router.navigate({ to: "/auth/sign-in" });
-              },
-            },
-          });
-        }}
-      >
+      <Button className="w-full" disabled={isSigningOut} onClick={onSignOut}>
         {isSigningOut ? (
           <Loader2Icon className="animate-spin" size={16} />
         ) : (
@@ -183,6 +199,7 @@ export function UserManagementNavItem() {
   } = authClient.useSession();
 
   const { billingEnabled, planName } = useSubscription();
+  const { isSigningOut, handleSignOut } = useSignOutAction();
 
   // A DID-only user carries an internal placeholder address; treat it as
   // having no email rather than surfacing the garbled value.
@@ -216,7 +233,10 @@ export function UserManagementNavItem() {
             planName={planName}
           />
           <AccountMenuItems billingEnabled={billingEnabled} />
-          <SignOutMenuItem />
+          <SignOutMenuItem
+            isSigningOut={isSigningOut}
+            onSignOut={handleSignOut}
+          />
         </ResponsiveDropdown>
       </SidebarMenuItem>
     </SidebarMenu>

--- a/apps/app/src/components/feed/UserManagementButton.tsx
+++ b/apps/app/src/components/feed/UserManagementButton.tsx
@@ -29,13 +29,159 @@ import { useClearAllUserData } from "~/lib/data/atoms";
 import { useSubscription } from "~/lib/data/subscription";
 import { IS_DEMO_INSTANCE } from "~/lib/demo";
 
+function AccountTriggerContent({
+  isPending,
+  name,
+  displayEmail,
+}: {
+  isPending: boolean;
+  name: string | undefined;
+  displayEmail: string | undefined;
+}) {
+  return (
+    <>
+      {isPending && <Loader2Icon className="animate-spin" size={32} />}
+      {!isPending && (
+        <div className="grid flex-1 text-left text-sm leading-tight">
+          <span className="truncate font-medium"> {name || "Account"}</span>
+          {!IS_DEMO_INSTANCE && displayEmail && (
+            <span className="text-muted-foreground truncate text-xs">
+              {displayEmail}
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+function AccountDropdownHeader({
+  name,
+  displayEmail,
+  billingEnabled,
+  planName,
+}: {
+  name: string | undefined;
+  displayEmail: string | undefined;
+  billingEnabled: boolean;
+  planName: ReturnType<typeof useSubscription>["planName"];
+}) {
+  return (
+    <ResponsiveDropdownLabel className="p-0 font-normal">
+      <div className="flex flex-col items-center justify-center pb-4">
+        <h2 className="text-sm font-semibold">{name || "Serial User"}</h2>
+        {!IS_DEMO_INSTANCE && displayEmail && (
+          <p className="text-muted-foreground text-xs">{displayEmail}</p>
+        )}
+        {billingEnabled && (
+          <p className="text-muted-foreground text-xs">{planName} plan</p>
+        )}
+        <Link
+          to="/debug"
+          className="text-muted-foreground hover:text-foreground pt-1 text-xs underline"
+        >
+          View debug
+        </Link>
+      </div>
+    </ResponsiveDropdownLabel>
+  );
+}
+
+function AccountMenuItems({ billingEnabled }: { billingEnabled: boolean }) {
+  const { launchDialog } = useDialogStore();
+
+  return (
+    <>
+      {!IS_DEMO_INSTANCE && (
+        <ResponsiveDropdownMenuItem asChild>
+          <Button
+            variant="outline"
+            className="mb-2 w-full"
+            onClick={() => {
+              launchDialog("connections");
+            }}
+          >
+            <PlugIcon size={16} />
+            <span className="pl-1.5">Connections</span>
+          </Button>
+        </ResponsiveDropdownMenuItem>
+      )}
+      {billingEnabled && (
+        <ResponsiveDropdownMenuItem asChild>
+          <Button
+            variant="outline"
+            className="mb-2 w-full"
+            onClick={() => launchDialog("subscription")}
+          >
+            <CreditCardIcon size={16} />
+            <span className="pl-1.5">Subscription</span>
+          </Button>
+        </ResponsiveDropdownMenuItem>
+      )}
+      {!IS_DEMO_INSTANCE && (
+        <div className="my-4">
+          <DropdownMenuSeparator />
+        </div>
+      )}
+      <ResponsiveDropdownMenuItem asChild>
+        <Button
+          variant="outline"
+          className="mb-2 w-full"
+          onClick={async () => {
+            launchDialog("edit-user-profile");
+          }}
+        >
+          Settings
+        </Button>
+      </ResponsiveDropdownMenuItem>
+    </>
+  );
+}
+
+function SignOutMenuItem() {
+  const router = useRouter();
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const queryClient = useQueryClient();
+  const clearAllUserData = useClearAllUserData();
+
+  return (
+    <ResponsiveDropdownMenuItem asChild>
+      <Button
+        className="w-full"
+        onClick={async () => {
+          await signOut({
+            fetchOptions: {
+              onRequest: () => {
+                setIsSigningOut(true);
+              },
+              onSuccess: () => {
+                clearUserDataAfterSignOut({
+                  clearQueryCache: () => queryClient.clear(),
+                  clearPersistedUserData: clearAllUserData,
+                  localStorage: window.localStorage,
+                });
+                void router.navigate({ to: "/auth/sign-in" });
+              },
+            },
+          });
+        }}
+      >
+        {isSigningOut ? (
+          <Loader2Icon className="animate-spin" size={16} />
+        ) : (
+          "Sign Out"
+        )}
+      </Button>
+    </ResponsiveDropdownMenuItem>
+  );
+}
+
 export function UserManagementNavItem() {
   const {
     data,
     isPending, // loading state
   } = authClient.useSession();
 
-  const { launchDialog } = useDialogStore();
   const { billingEnabled, planName } = useSubscription();
 
   // A DID-only user carries an internal placeholder address; treat it as
@@ -43,11 +189,6 @@ export function UserManagementNavItem() {
   const email = data?.user.email;
   const displayEmail =
     email && !isAtprotoPlaceholderEmail(email) ? email : undefined;
-
-  const router = useRouter();
-  const [isSigningOut, setIsSigningOut] = useState(false);
-  const queryClient = useQueryClient();
-  const clearAllUserData = useClearAllUserData();
 
   return (
     <SidebarMenu>
@@ -59,113 +200,23 @@ export function UserManagementNavItem() {
               size="lg"
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
             >
-              {isPending && <Loader2Icon className="animate-spin" size={32} />}
-              {!isPending && (
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-medium">
-                    {" "}
-                    {data?.user.name || "Account"}
-                  </span>
-                  {!IS_DEMO_INSTANCE && displayEmail && (
-                    <span className="text-muted-foreground truncate text-xs">
-                      {displayEmail}
-                    </span>
-                  )}
-                </div>
-              )}
+              <AccountTriggerContent
+                isPending={isPending}
+                name={data?.user.name}
+                displayEmail={displayEmail}
+              />
               <EllipsisVerticalIcon className="ml-auto size-4" />
             </SidebarMenuButton>
           }
         >
-          <ResponsiveDropdownLabel className="p-0 font-normal">
-            <div className="flex flex-col items-center justify-center pb-4">
-              <h2 className="text-sm font-semibold">
-                {data?.user.name || "Serial User"}
-              </h2>
-              {!IS_DEMO_INSTANCE && displayEmail && (
-                <p className="text-muted-foreground text-xs">{displayEmail}</p>
-              )}
-              {billingEnabled && (
-                <p className="text-muted-foreground text-xs">{planName} plan</p>
-              )}
-              <Link
-                to="/debug"
-                className="text-muted-foreground hover:text-foreground pt-1 text-xs underline"
-              >
-                View debug
-              </Link>
-            </div>
-          </ResponsiveDropdownLabel>
-          {!IS_DEMO_INSTANCE && (
-            <ResponsiveDropdownMenuItem asChild>
-              <Button
-                variant="outline"
-                className="mb-2 w-full"
-                onClick={() => {
-                  launchDialog("connections");
-                }}
-              >
-                <PlugIcon size={16} />
-                <span className="pl-1.5">Connections</span>
-              </Button>
-            </ResponsiveDropdownMenuItem>
-          )}
-          {billingEnabled && (
-            <ResponsiveDropdownMenuItem asChild>
-              <Button
-                variant="outline"
-                className="mb-2 w-full"
-                onClick={() => launchDialog("subscription")}
-              >
-                <CreditCardIcon size={16} />
-                <span className="pl-1.5">Subscription</span>
-              </Button>
-            </ResponsiveDropdownMenuItem>
-          )}
-          {!IS_DEMO_INSTANCE && (
-            <div className="my-4">
-              <DropdownMenuSeparator />
-            </div>
-          )}
-          <ResponsiveDropdownMenuItem asChild>
-            <Button
-              variant="outline"
-              className="mb-2 w-full"
-              onClick={async () => {
-                launchDialog("edit-user-profile");
-              }}
-            >
-              Settings
-            </Button>
-          </ResponsiveDropdownMenuItem>
-          <ResponsiveDropdownMenuItem asChild>
-            <Button
-              className="w-full"
-              onClick={async () => {
-                await signOut({
-                  fetchOptions: {
-                    onRequest: () => {
-                      setIsSigningOut(true);
-                    },
-                    onSuccess: () => {
-                      clearUserDataAfterSignOut({
-                        clearQueryCache: () => queryClient.clear(),
-                        clearPersistedUserData: clearAllUserData,
-                        localStorage: window.localStorage,
-                      });
-                      void router.navigate({ to: "/auth/sign-in" });
-                    },
-                  },
-                });
-              }}
-            >
-              {isSigningOut ? (
-                <Loader2Icon className="animate-spin" size={16} />
-              ) : (
-                "Sign Out"
-              )}
-            </Button>
-          </ResponsiveDropdownMenuItem>
+          <AccountDropdownHeader
+            name={data?.user.name}
+            displayEmail={displayEmail}
+            billingEnabled={billingEnabled}
+            planName={planName}
+          />
+          <AccountMenuItems billingEnabled={billingEnabled} />
+          <SignOutMenuItem />
         </ResponsiveDropdown>
       </SidebarMenuItem>
     </SidebarMenu>

--- a/apps/app/src/components/feed/import/ImportFeedList.tsx
+++ b/apps/app/src/components/feed/import/ImportFeedList.tsx
@@ -1,0 +1,121 @@
+import { ItemGroup } from "@serial/ui";
+import { ImportFeedRow } from "./ImportFeedRow";
+import { compareImportTitles, IMPORT_MODE_OPTIONS } from "./importPageShared";
+import type { RefObject } from "react";
+import type {
+  FailedImportUrls,
+  ImportMode,
+  SetFeedsFoundFromFile,
+  UserFeeds,
+} from "./importPageShared";
+import type { ImportFeedDataItem } from "./utils/shared";
+import { CardRadioGroup } from "~/components/ui/card-radio-group";
+import { Button } from "~/components/ui/button";
+
+function ImportSelectionHeader({
+  channelImportCount,
+  feeds,
+  setFeedsFoundFromFile,
+}: {
+  channelImportCount: number | undefined;
+  feeds: UserFeeds;
+  setFeedsFoundFromFile: SetFeedsFoundFromFile;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <h3 className="font-semibold">Feeds To Import</h3>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          if (channelImportCount === 0) {
+            setFeedsFoundFromFile((prevChannels) => {
+              if (!prevChannels) return prevChannels;
+              return prevChannels.map((channel) => {
+                // Don't enable import for already-added feeds
+                const isAlreadyAdded = feeds.some(
+                  (feed) => feed.url === channel.feedUrl,
+                );
+                if (!isAlreadyAdded) {
+                  channel.shouldImport = true;
+                }
+                return channel;
+              });
+            });
+          } else {
+            setFeedsFoundFromFile((prevChannels) => {
+              if (!prevChannels) return prevChannels;
+              return prevChannels.map((channel) => {
+                channel.shouldImport = false;
+                return channel;
+              });
+            });
+          }
+        }}
+      >
+        {channelImportCount === 0 ? "Select All" : "Deselect All"}
+      </Button>
+    </div>
+  );
+}
+
+export function ImportFeedList({
+  feedsFoundFromFile,
+  feeds,
+  isPostImportScreen,
+  importMode,
+  setImportMode,
+  channelImportCount,
+  failedImportUrls,
+  setFeedsFoundFromFile,
+  bottomRef,
+}: {
+  feedsFoundFromFile: ImportFeedDataItem[];
+  feeds: UserFeeds;
+  isPostImportScreen: boolean;
+  importMode: ImportMode;
+  setImportMode: (mode: ImportMode) => void;
+  channelImportCount: number | undefined;
+  failedImportUrls: FailedImportUrls;
+  setFeedsFoundFromFile: SetFeedsFoundFromFile;
+  bottomRef: RefObject<HTMLDivElement | null>;
+}) {
+  return (
+    <>
+      {!isPostImportScreen &&
+        feedsFoundFromFile.some((f) => f.categories.length > 0) && (
+          <div className="mt-12 grid gap-3">
+            <h3 className="font-semibold">Sections</h3>
+            <CardRadioGroup
+              value={importMode}
+              onValueChange={setImportMode}
+              options={IMPORT_MODE_OPTIONS}
+              orientation="vertical"
+            />
+          </div>
+        )}
+      <div className="mt-12">
+        {!isPostImportScreen && (
+          <ImportSelectionHeader
+            channelImportCount={channelImportCount}
+            feeds={feeds}
+            setFeedsFoundFromFile={setFeedsFoundFromFile}
+          />
+        )}
+        <ItemGroup className="mt-4">
+          {[...feedsFoundFromFile].sort(compareImportTitles).map((channel) => (
+            <ImportFeedRow
+              key={channel.feedUrl}
+              channel={channel}
+              feeds={feeds}
+              isPostImportScreen={isPostImportScreen}
+              failedImportUrls={failedImportUrls}
+              setFeedsFoundFromFile={setFeedsFoundFromFile}
+            />
+          ))}
+        </ItemGroup>
+        <div ref={bottomRef} />
+      </div>
+    </>
+  );
+}

--- a/apps/app/src/components/feed/import/ImportFeedRow.tsx
+++ b/apps/app/src/components/feed/import/ImportFeedRow.tsx
@@ -1,0 +1,135 @@
+import { AlertTriangleIcon } from "lucide-react";
+import { ImportFeedRowActions } from "./ImportFeedRowActions";
+import { getFeedWebsiteUrl } from "./importPageShared";
+import type {
+  FailedImportUrls,
+  SetFeedsFoundFromFile,
+  UserFeeds,
+} from "./importPageShared";
+import type { ImportFeedDataItem } from "./utils/shared";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+import { Badge } from "~/components/ui/badge";
+import { FeedAvatar, FeedListItem } from "~/components/feed/FeedListItem";
+
+function ImportFeedRowMedia({
+  displayTitle,
+  platform,
+  showExistsWarning,
+}: {
+  displayTitle: string;
+  platform: ImportFeedDataItem["platform"];
+  showExistsWarning: boolean;
+}) {
+  if (!showExistsWarning) {
+    return <FeedAvatar title={displayTitle} platform={platform} />;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="pointer-events-auto inline-flex">
+          <FeedAvatar
+            title={displayTitle}
+            platform={platform}
+            fallback={
+              <AlertTriangleIcon size={14} aria-label="Feed already exists" />
+            }
+          />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>Feed already exists</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function ImportFeedRow({
+  channel,
+  feeds,
+  isPostImportScreen,
+  failedImportUrls,
+  setFeedsFoundFromFile,
+}: {
+  channel: ImportFeedDataItem;
+  feeds: UserFeeds;
+  isPostImportScreen: boolean;
+  failedImportUrls: FailedImportUrls;
+  setFeedsFoundFromFile: SetFeedsFoundFromFile;
+}) {
+  const displayTitle = channel.title ?? channel.feedUrl;
+  // Check if feed already exists in the feeds store
+  const isAlreadyAdded = feeds.some((feed) => feed.url === channel.feedUrl);
+  // Check if feed was imported by looking in the feeds store
+  const wasImported = isPostImportScreen && isAlreadyAdded;
+  const websiteUrl = getFeedWebsiteUrl(channel);
+  const setShouldImport = (shouldImport: boolean) => {
+    if (isAlreadyAdded || isPostImportScreen) return;
+
+    setFeedsFoundFromFile((prevChannels) => {
+      if (!prevChannels) return prevChannels;
+
+      return prevChannels.map((previousChannel) =>
+        previousChannel.feedUrl === channel.feedUrl
+          ? { ...previousChannel, shouldImport }
+          : previousChannel,
+      );
+    });
+  };
+
+  return (
+    <FeedListItem
+      title={displayTitle}
+      titleHref={websiteUrl}
+      description={
+        <a
+          href={channel.feedUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="pointer-events-auto relative z-10"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {channel.feedUrl}
+        </a>
+      }
+      platform={channel.platform}
+      variant="outline"
+      size="xs"
+      interactive={!isPostImportScreen && !isAlreadyAdded}
+      disabled={isAlreadyAdded}
+      selected={!isPostImportScreen && channel.shouldImport}
+      onClick={() => setShouldImport(!channel.shouldImport)}
+      media={
+        <ImportFeedRowMedia
+          displayTitle={displayTitle}
+          platform={channel.platform}
+          showExistsWarning={!isPostImportScreen && isAlreadyAdded}
+        />
+      }
+      details={
+        <>
+          {!isPostImportScreen &&
+            channel.categories.map((category) => (
+              <Badge key={category} variant="outline">
+                {category}
+              </Badge>
+            ))}
+        </>
+      }
+      actions={
+        <ImportFeedRowActions
+          channel={channel}
+          feeds={feeds}
+          displayTitle={displayTitle}
+          isAlreadyAdded={isAlreadyAdded}
+          wasImported={wasImported}
+          isPostImportScreen={isPostImportScreen}
+          failedImportUrls={failedImportUrls}
+          setShouldImport={setShouldImport}
+        />
+      }
+    />
+  );
+}

--- a/apps/app/src/components/feed/import/ImportFeedRowActions.tsx
+++ b/apps/app/src/components/feed/import/ImportFeedRowActions.tsx
@@ -1,0 +1,105 @@
+import { CheckIcon, MinusIcon, PauseIcon, PlusIcon, XIcon } from "lucide-react";
+import type { ImportFeedDataItem } from "./utils/shared";
+import type { FailedImportUrls, UserFeeds } from "./importPageShared";
+import { Button } from "~/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+
+function ImportedFeedStatus({
+  feedUrl,
+  feeds,
+}: {
+  feedUrl: string;
+  feeds: Array<{ url: string; isActive: boolean }>;
+}) {
+  const importedFeed = feeds.find((f) => f.url === feedUrl);
+  const isInactive = importedFeed && !importedFeed.isActive;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        {isInactive ? <PauseIcon size={20} /> : <CheckIcon size={20} />}
+      </TooltipTrigger>
+      <TooltipContent>
+        {isInactive ? "Feed inactive" : "Imported Successfully!"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function ImportFeedRowActions({
+  channel,
+  feeds,
+  displayTitle,
+  isAlreadyAdded,
+  wasImported,
+  isPostImportScreen,
+  failedImportUrls,
+  setShouldImport,
+}: {
+  channel: ImportFeedDataItem;
+  feeds: UserFeeds;
+  displayTitle: string;
+  isAlreadyAdded: boolean;
+  wasImported: boolean;
+  isPostImportScreen: boolean;
+  failedImportUrls: FailedImportUrls;
+  setShouldImport: (shouldImport: boolean) => void;
+}) {
+  return (
+    <>
+      {!isPostImportScreen && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant={channel.shouldImport ? "default" : "ghost"}
+              size="icon"
+              className="size-7"
+              aria-label={`${channel.shouldImport ? "Deselect" : "Select"} ${displayTitle}`}
+              disabled={isAlreadyAdded}
+              onClick={() => setShouldImport(!channel.shouldImport)}
+            >
+              {channel.shouldImport ? (
+                <CheckIcon size={16} />
+              ) : (
+                <PlusIcon size={16} />
+              )}
+            </Button>
+          </TooltipTrigger>
+          {!isAlreadyAdded && (
+            <TooltipContent>
+              {channel.shouldImport ? "Deselect" : "Select"} feed
+            </TooltipContent>
+          )}
+        </Tooltip>
+      )}
+      {isPostImportScreen && wasImported && channel.shouldImport && (
+        <ImportedFeedStatus feedUrl={channel.feedUrl} feeds={feeds} />
+      )}
+      {isPostImportScreen &&
+        channel.shouldImport &&
+        failedImportUrls.has(channel.feedUrl) && (
+          <Tooltip>
+            <TooltipTrigger>
+              <XIcon size={20} />
+            </TooltipTrigger>
+            <TooltipContent>Failed to import</TooltipContent>
+          </Tooltip>
+        )}
+      {isPostImportScreen && !channel.shouldImport && (
+        <Tooltip>
+          <TooltipTrigger>
+            <MinusIcon size={20} />
+          </TooltipTrigger>
+          <TooltipContent>
+            This feed was excluded from the import.
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </>
+  );
+}

--- a/apps/app/src/components/feed/import/ImportScreens.tsx
+++ b/apps/app/src/components/feed/import/ImportScreens.tsx
@@ -1,0 +1,58 @@
+import { Link } from "@tanstack/react-router";
+import { ImportDropzone } from "./ImportDropzone";
+import { Button } from "~/components/ui/button";
+import { getGuidesUrl } from "~/lib/constants";
+
+export function ImportInstructions({
+  onSelectFiles,
+}: {
+  onSelectFiles: () => void;
+}) {
+  return (
+    <>
+      <p className="mt-2">Serial supports importing:</p>
+      <ul className="mb-6 list-disc pl-4">
+        <li>
+          <code className="bg-muted text-foreground rounded px-1 py-0.5">
+            subscriptions.csv
+          </code>{" "}
+          files from{" "}
+          <a
+            href={getGuidesUrl("/how-to-export-youtube-subscriptions")}
+            className="underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            a Google Takeout export
+          </a>
+        </li>
+        <li>
+          <code className="bg-muted text-foreground rounded px-1 py-0.5">
+            *.opml
+          </code>{" "}
+          files from another RSS reader&apos;s export
+        </li>
+      </ul>
+      <ImportDropzone
+        inputId="import-file-input"
+        onSelectFile={onSelectFiles}
+      />
+    </>
+  );
+}
+
+export function ImportFinished({ onReset }: { onReset: () => void }) {
+  return (
+    <>
+      <p className="mt-2 mb-4">Import finished! Your list has been added.</p>
+      <div className="flex gap-2">
+        <Link to="/">
+          <Button>Back to home</Button>
+        </Link>
+        <Button variant="outline" onClick={onReset}>
+          Import more
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/apps/app/src/components/feed/import/importPageShared.ts
+++ b/apps/app/src/components/feed/import/importPageShared.ts
@@ -1,0 +1,56 @@
+import type { Dispatch, SetStateAction } from "react";
+import type { CardRadioOption } from "~/components/ui/card-radio-group";
+import type { ImportFeedDataItem } from "./utils/shared";
+import type { useFeeds } from "~/lib/data/feeds";
+import type { useImportResults } from "~/lib/data/loading-machine";
+
+export type ImportMode = "tags" | "views" | "ignore";
+
+export type UserFeeds = ReturnType<typeof useFeeds>["feeds"];
+export type FailedImportUrls = ReturnType<
+  typeof useImportResults
+>["failedImportUrls"];
+export type SetFeedsFoundFromFile = Dispatch<
+  SetStateAction<ImportFeedDataItem[] | null>
+>;
+
+export function getFeedWebsiteUrl(feed: ImportFeedDataItem) {
+  if (feed.websiteUrl) return feed.websiteUrl;
+
+  try {
+    return new URL(feed.feedUrl).origin;
+  } catch {
+    return feed.feedUrl;
+  }
+}
+
+export const IMPORT_MODE_OPTIONS: Array<CardRadioOption<ImportMode>> = [
+  {
+    value: "views",
+    title: "Import sections as Views",
+    description:
+      "Each section in the file becomes a view, and feeds are linked directly to it.",
+  },
+  {
+    value: "tags",
+    title: "Import sections as Tags",
+    description:
+      "Each section in the file becomes a tag, and feeds are tagged with it.",
+  },
+  {
+    value: "ignore",
+    title: "Ignore sections",
+    description:
+      "Import the feeds without preserving any of the section groupings.",
+  },
+];
+
+export function compareImportTitles(
+  a: ImportFeedDataItem,
+  b: ImportFeedDataItem,
+) {
+  if (!a.title && !b.title) return 0;
+  if (!a.title) return -1;
+  if (!b.title) return -1;
+  return a.title.localeCompare(b.title);
+}

--- a/apps/app/src/components/feed/manage/ActiveFeedLimitStatus.tsx
+++ b/apps/app/src/components/feed/manage/ActiveFeedLimitStatus.tsx
@@ -1,0 +1,61 @@
+import type { LaunchDialog } from "./useBulkFeedEditing";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+import { Progress } from "~/components/ui/progress";
+import { IS_DEMO_INSTANCE } from "~/lib/demo";
+
+export function ActiveFeedLimitStatus({
+  billingEnabled,
+  activeFeeds,
+  maxActiveFeeds,
+  planName,
+  launchDialog,
+}: {
+  billingEnabled: boolean;
+  activeFeeds: number;
+  maxActiveFeeds: number;
+  planName: string;
+  launchDialog: LaunchDialog;
+}) {
+  return (
+    <>
+      {(billingEnabled || IS_DEMO_INSTANCE) &&
+        maxActiveFeeds > 0 &&
+        (IS_DEMO_INSTANCE
+          ? activeFeeds <= maxActiveFeeds
+          : activeFeeds < maxActiveFeeds) && (
+          <div className="mt-3 space-y-1.5">
+            <div className="flex items-center justify-between">
+              <p className="text-muted-foreground text-sm">
+                {activeFeeds} / {maxActiveFeeds} feeds active
+              </p>
+            </div>
+            <Progress
+              value={Math.min(100, (activeFeeds / maxActiveFeeds) * 100)}
+            />
+          </div>
+        )}
+      {billingEnabled &&
+        maxActiveFeeds > 0 &&
+        activeFeeds >= maxActiveFeeds && (
+          <Alert className="mt-4">
+            <AlertTitle>Max active feeds reached</AlertTitle>
+            <AlertDescription>
+              The {planName} plan supports a maximum of {maxActiveFeeds} feeds.
+              You can add more than this, but only your active feeds will
+              receive new content.
+              <Button
+                type="button"
+                onClick={() =>
+                  launchDialog("subscription", { subscriptionView: "picker" })
+                }
+                className="mt-4"
+              >
+                Upgrade your plan
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+    </>
+  );
+}

--- a/apps/app/src/components/feed/manage/FeedRowControls.tsx
+++ b/apps/app/src/components/feed/manage/FeedRowControls.tsx
@@ -1,0 +1,73 @@
+import { toast } from "sonner";
+import type { useSetFeedActiveMutation } from "~/lib/data/feeds/mutations";
+import type { ManagedFeed } from "./useBulkFeedEditing";
+import { Badge } from "~/components/ui/badge";
+import { Switch } from "~/components/ui/switch";
+import { IS_DEMO_INSTANCE } from "~/lib/demo";
+
+type SetFeedActive = ReturnType<typeof useSetFeedActiveMutation>["mutate"];
+
+export function FeedRowBadges({
+  ids,
+  namesMap,
+  variant,
+  keyPrefix,
+}: {
+  ids: number[];
+  namesMap: Map<number, string>;
+  variant: "outline" | "secondary";
+  keyPrefix: string;
+}) {
+  if (ids.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {ids.map((id) => {
+        const name = namesMap.get(id);
+        if (!name) return null;
+        return (
+          <Badge key={`${keyPrefix}-${id}`} variant={variant}>
+            {name}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}
+
+export function FeedActiveSwitch({
+  feed,
+  isTogglingActive,
+  setFeedActive,
+  activeFeeds,
+  maxActiveFeeds,
+}: {
+  feed: ManagedFeed;
+  isTogglingActive: boolean;
+  setFeedActive: SetFeedActive;
+  activeFeeds: number;
+  maxActiveFeeds: number;
+}) {
+  return (
+    <Switch
+      checked={feed.isActive}
+      disabled={isTogglingActive}
+      onCheckedChange={(checked) => {
+        if (!checked || activeFeeds < maxActiveFeeds || maxActiveFeeds < 0) {
+          setFeedActive({ feedId: feed.id, isActive: checked });
+        } else {
+          if (IS_DEMO_INSTANCE) {
+            toast.error(
+              "Feed limit reached. This is the limit for the demo instance.",
+            );
+          } else {
+            toast.error(
+              "Feed limit reached. Upgrade your plan to activate more feeds.",
+            );
+          }
+        }
+      }}
+      onClick={(e) => e.stopPropagation()}
+    />
+  );
+}

--- a/apps/app/src/components/feed/manage/ManageFeedsDialogs.tsx
+++ b/apps/app/src/components/feed/manage/ManageFeedsDialogs.tsx
@@ -1,0 +1,159 @@
+import { toast } from "sonner";
+import { feedCountLabel } from "./useBulkFeedEditing";
+import type { Dispatch, SetStateAction } from "react";
+import { ViewCategoriesInput } from "~/components/view-dialog";
+import { Button } from "~/components/ui/button";
+import { ChipCombobox } from "~/components/ui/chip-combobox";
+import { ControlledResponsiveDialog } from "~/components/ui/responsive-dropdown";
+import { Switch } from "~/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+import { useQuickCreateViewMutation } from "~/lib/data/views/mutations";
+
+export function DeleteFeedsDialog({
+  open,
+  onOpenChange,
+  selectedCount,
+  canMutate,
+  isDeletingFeeds,
+  onDelete,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedCount: number;
+  canMutate: boolean;
+  isDeletingFeeds: boolean;
+  onDelete: () => void;
+}) {
+  return (
+    <ControlledResponsiveDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Delete Feeds"
+      description={`Are you sure you want to delete ${feedCountLabel(selectedCount)}? This action cannot be undone.`}
+    >
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          className="flex-1"
+          onClick={() => onOpenChange(false)}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="destructive"
+          className="flex-1"
+          onClick={onDelete}
+          disabled={!canMutate || isDeletingFeeds}
+        >
+          {isDeletingFeeds ? "Deleting..." : "Delete"}
+        </Button>
+      </div>
+    </ControlledResponsiveDialog>
+  );
+}
+
+export function EditFeedsDialog({
+  open,
+  onOpenChange,
+  selectedCount,
+  bulkActiveState,
+  setBulkActiveState,
+  canMutate,
+  isSaving,
+  onSave,
+  customViewOptions,
+  selectedViewIds,
+  setSelectedViewIds,
+  selectedCategoryIds,
+  setSelectedCategoryIds,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedCount: number;
+  bulkActiveState: boolean;
+  setBulkActiveState: (active: boolean) => void;
+  canMutate: boolean;
+  isSaving: boolean;
+  onSave: () => void;
+  customViewOptions: Array<{ id: number; label: string }>;
+  selectedViewIds: number[];
+  setSelectedViewIds: (ids: number[]) => void;
+  selectedCategoryIds: number[];
+  setSelectedCategoryIds: Dispatch<SetStateAction<number[]>>;
+}) {
+  const { mutateAsync: quickCreateView } = useQuickCreateViewMutation();
+
+  return (
+    <ControlledResponsiveDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Edit Feeds"
+      description={`Edit ${feedCountLabel(selectedCount)}.`}
+      headerRight={
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="flex items-center">
+              <Switch
+                checked={bulkActiveState}
+                onCheckedChange={setBulkActiveState}
+              />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            {bulkActiveState ? "Feeds active" : "Feeds inactive"}
+          </TooltipContent>
+        </Tooltip>
+      }
+      footer={
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            className="flex-1"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="flex-1"
+            onClick={onSave}
+            disabled={!canMutate || isSaving}
+          >
+            {isSaving ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      }
+    >
+      <div className="grid gap-4">
+        <ChipCombobox
+          label="Views"
+          placeholder="Search views..."
+          options={customViewOptions}
+          selectedIds={selectedViewIds}
+          onAdd={(id) => setSelectedViewIds([...selectedViewIds, id])}
+          onRemove={(id) =>
+            setSelectedViewIds(selectedViewIds.filter((v) => v !== id))
+          }
+          onCreate={async (name) => {
+            try {
+              const created = await quickCreateView({ name });
+              if (created) {
+                setSelectedViewIds([...selectedViewIds, created.id]);
+              }
+            } catch {
+              toast.error("Failed to create view.");
+            }
+          }}
+          createLabel="Create view"
+        />
+        <ViewCategoriesInput
+          selectedCategories={selectedCategoryIds}
+          setSelectedCategories={setSelectedCategoryIds}
+        />
+      </div>
+    </ControlledResponsiveDialog>
+  );
+}

--- a/apps/app/src/components/feed/manage/useBulkFeedEditing.ts
+++ b/apps/app/src/components/feed/manage/useBulkFeedEditing.ts
@@ -1,0 +1,275 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import type { Dispatch, SetStateAction } from "react";
+import type { useDialogStore } from "~/components/feed/dialogStore";
+import type { useFeeds } from "~/lib/data/feeds";
+import {
+  useBulkAssignFeedCategoryMutation,
+  useBulkRemoveFeedCategoryMutation,
+} from "~/lib/data/feed-categories/mutations";
+import {
+  useBulkDeleteFeedsMutation,
+  useBulkSetActiveMutation,
+} from "~/lib/data/feeds/mutations";
+import {
+  useBulkAssignViewFeedMutation,
+  useBulkRemoveViewFeedMutation,
+} from "~/lib/data/view-feeds/mutations";
+import { IS_DEMO_INSTANCE } from "~/lib/demo";
+
+export type ManagedFeeds = ReturnType<typeof useFeeds>["feeds"];
+export type ManagedFeed = ManagedFeeds[number];
+export type LaunchDialog = ReturnType<
+  typeof useDialogStore.getState
+>["launchDialog"];
+
+export function feedCountLabel(count: number) {
+  return `${count} feed${count > 1 ? "s" : ""}`;
+}
+
+function getSharedIds(feedIds: number[], map: Map<number, number[]>) {
+  if (feedIds.length === 0) return [];
+
+  const firstFeedIds = map.get(feedIds[0]!) ?? [];
+  const idSets = feedIds.map((feedId) => new Set(map.get(feedId) ?? []));
+  return firstFeedIds.filter((id) => idSets.every((idSet) => idSet.has(id)));
+}
+
+function notifyActiveFeedLimitExceeded(
+  overLimit: number,
+  launchDialog: LaunchDialog,
+) {
+  if (IS_DEMO_INSTANCE) {
+    toast.warning(
+      `${overLimit} feed${overLimit > 1 ? "s would" : " would"} exceed the limit of active feeds you can have on the demo instance.`,
+    );
+  } else {
+    toast.warning(
+      `${overLimit} feed${overLimit > 1 ? "s would" : " would"} exceed your plan limit. To unlock more active feeds, you can switch to a higher plan.`,
+      {
+        action: {
+          label: "Upgrade",
+          onClick: () =>
+            launchDialog("subscription", { subscriptionView: "picker" }),
+        },
+      },
+    );
+  }
+}
+
+function collectAssignmentPromises(
+  selectedIds: number[],
+  sharedIds: number[],
+  assign: (id: number) => Promise<void>,
+  remove: (id: number) => Promise<void>,
+) {
+  const selectedIdSet = new Set(selectedIds);
+  const idsToRemove = sharedIds.filter((id) => !selectedIdSet.has(id));
+  return [
+    ...selectedIds.map((id) => assign(id)),
+    ...idsToRemove.map((id) => remove(id)),
+  ];
+}
+
+export function useBulkFeedEditing({
+  canMutate,
+  feeds,
+  selectedFeedIds,
+  setSelectedFeedIds,
+  feedCategoriesMap,
+  feedViewsMap,
+  activeFeeds,
+  maxActiveFeeds,
+  launchDialog,
+}: {
+  canMutate: boolean;
+  feeds: ManagedFeeds;
+  selectedFeedIds: Set<number>;
+  setSelectedFeedIds: Dispatch<SetStateAction<Set<number>>>;
+  feedCategoriesMap: Map<number, number[]>;
+  feedViewsMap: Map<number, number[]>;
+  activeFeeds: number;
+  maxActiveFeeds: number;
+  launchDialog: LaunchDialog;
+}) {
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showEditDialog, setShowEditDialog] = useState(false);
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
+  const [selectedViewIds, setSelectedViewIds] = useState<number[]>([]);
+  const [bulkActiveState, setBulkActiveState] = useState(false);
+
+  const { mutateAsync: bulkSetActive } = useBulkSetActiveMutation();
+  const { mutateAsync: bulkDeleteFeeds, isPending: isDeletingFeeds } =
+    useBulkDeleteFeedsMutation();
+  const { mutateAsync: bulkAssignCategory, isPending: isAssigningCategory } =
+    useBulkAssignFeedCategoryMutation();
+  const { mutateAsync: bulkRemoveCategory, isPending: isRemovingCategory } =
+    useBulkRemoveFeedCategoryMutation();
+  const { mutateAsync: bulkAssignView, isPending: isAssigningView } =
+    useBulkAssignViewFeedMutation();
+  const { mutateAsync: bulkRemoveView, isPending: isRemovingView } =
+    useBulkRemoveViewFeedMutation();
+
+  const handleDelete = () => {
+    if (!canMutate) return;
+    const feedIds = Array.from(selectedFeedIds);
+    const count = feedIds.length;
+    setShowDeleteDialog(false);
+    setSelectedFeedIds(new Set());
+
+    toast.promise(bulkDeleteFeeds({ feedIds }), {
+      loading: `Deleting ${feedCountLabel(count)}...`,
+      success: `Deleted ${feedCountLabel(count)}!`,
+      error: "Failed to delete feeds",
+    });
+  };
+
+  const getSharedCategories = () =>
+    getSharedIds(Array.from(selectedFeedIds), feedCategoriesMap);
+
+  const getSharedViews = () =>
+    getSharedIds(Array.from(selectedFeedIds), feedViewsMap);
+
+  const openEditDialog = () => {
+    setSelectedCategoryIds(getSharedCategories());
+    setSelectedViewIds(getSharedViews());
+    // If all selected feeds are active, show active; otherwise show deactivated
+    const allActive = Array.from(selectedFeedIds).every(
+      (id) => feeds.find((f) => f.id === id)?.isActive,
+    );
+    setBulkActiveState(allActive);
+    setShowEditDialog(true);
+  };
+
+  const handleClear = () => {
+    const feedIds = Array.from(selectedFeedIds);
+    const count = feedIds.length;
+
+    // Get all categories any selected feed currently has
+    const allCurrentCategories = new Set<number>();
+    feedIds.forEach((feedId) => {
+      const categories = feedCategoriesMap.get(feedId) ?? [];
+      categories.forEach((c) => allCurrentCategories.add(c));
+    });
+
+    // Get all views any selected feed currently has
+    const allCurrentViews = new Set<number>();
+    feedIds.forEach((feedId) => {
+      const views = feedViewsMap.get(feedId) ?? [];
+      views.forEach((v) => allCurrentViews.add(v));
+    });
+
+    if (allCurrentCategories.size === 0 && allCurrentViews.size === 0) return;
+
+    const promises: Array<Promise<void>> = [
+      ...Array.from(allCurrentCategories).map((categoryId) =>
+        bulkRemoveCategory({ feedIds, categoryId }),
+      ),
+      ...Array.from(allCurrentViews).map((viewId) =>
+        bulkRemoveView({ feedIds, viewId }),
+      ),
+    ];
+
+    toast.promise(Promise.all(promises), {
+      loading: `Clearing ${feedCountLabel(count)}...`,
+      success: `Cleared ${feedCountLabel(count)}!`,
+      error: "Failed to clear feeds",
+    });
+  };
+
+  const handleEditSave = () => {
+    if (!canMutate) return;
+    const feedIds = Array.from(selectedFeedIds);
+    const count = feedIds.length;
+    const sharedCategories = getSharedCategories();
+    const sharedViews = getSharedViews();
+
+    // Active state
+    const feedsToToggle = feedIds.filter((id) => {
+      const feed = feeds.find((f) => f.id === id);
+      return feed && feed.isActive !== bulkActiveState;
+    });
+
+    if (bulkActiveState && feedsToToggle.length > 0 && maxActiveFeeds >= 0) {
+      const wouldBeActive = activeFeeds + feedsToToggle.length;
+
+      if (wouldBeActive > maxActiveFeeds) {
+        notifyActiveFeedLimitExceeded(
+          wouldBeActive - maxActiveFeeds,
+          launchDialog,
+        );
+        return;
+      }
+    }
+
+    const promises: Array<Promise<void>> = [];
+
+    // Bulk active state toggle
+    if (feedsToToggle.length > 0) {
+      promises.push(
+        bulkSetActive({ feedIds: feedsToToggle, isActive: bulkActiveState }),
+      );
+    }
+
+    // Categories
+    promises.push(
+      ...collectAssignmentPromises(
+        selectedCategoryIds,
+        sharedCategories,
+        (categoryId) => bulkAssignCategory({ feedIds, categoryId }),
+        (categoryId) => bulkRemoveCategory({ feedIds, categoryId }),
+      ),
+    );
+
+    // Views
+    promises.push(
+      ...collectAssignmentPromises(
+        selectedViewIds,
+        sharedViews,
+        (viewId) => bulkAssignView({ feedIds, viewId }),
+        (viewId) => bulkRemoveView({ feedIds, viewId }),
+      ),
+    );
+
+    setSelectedCategoryIds([]);
+    setSelectedViewIds([]);
+    setShowEditDialog(false);
+
+    if (promises.length === 0) {
+      return;
+    }
+
+    toast.promise(Promise.all(promises), {
+      loading: `Updating ${feedCountLabel(count)}...`,
+      success: `Updated ${feedCountLabel(count)}!`,
+      error: "Failed to update feeds",
+    });
+  };
+
+  const isSavingEdit =
+    isAssigningCategory ||
+    isRemovingCategory ||
+    isAssigningView ||
+    isRemovingView;
+  const isClearing = isRemovingCategory || isRemovingView;
+
+  return {
+    showDeleteDialog,
+    setShowDeleteDialog,
+    showEditDialog,
+    setShowEditDialog,
+    selectedCategoryIds,
+    setSelectedCategoryIds,
+    selectedViewIds,
+    setSelectedViewIds,
+    bulkActiveState,
+    setBulkActiveState,
+    isDeletingFeeds,
+    isSavingEdit,
+    isClearing,
+    handleDelete,
+    openEditDialog,
+    handleClear,
+    handleEditSave,
+  };
+}

--- a/apps/app/src/components/feed/manage/useFeedMaps.ts
+++ b/apps/app/src/components/feed/manage/useFeedMaps.ts
@@ -1,0 +1,110 @@
+import { useMemo } from "react";
+import type { ManagedFeeds } from "./useBulkFeedEditing";
+import { useContentCategories } from "~/lib/data/content-categories";
+import { useFeedCategories } from "~/lib/data/feed-categories";
+import { useViewFeeds } from "~/lib/data/view-feeds";
+import { useViews } from "~/lib/data/views";
+import { UNCATEGORIZED_VIEW_ID } from "~/lib/data/views/constants";
+
+export function useFeedMaps() {
+  const { feedCategories } = useFeedCategories();
+  const { contentCategories } = useContentCategories();
+  const { views } = useViews();
+  const { viewFeeds } = useViewFeeds();
+
+  const feedCategoriesMap = useMemo(() => {
+    const map = new Map<number, number[]>();
+    feedCategories.forEach((fc) => {
+      const existing = map.get(fc.feedId) ?? [];
+      existing.push(fc.categoryId);
+      map.set(fc.feedId, existing);
+    });
+    return map;
+  }, [feedCategories]);
+
+  const feedViewsMap = useMemo(() => {
+    const map = new Map<number, number[]>();
+    viewFeeds.forEach((vf) => {
+      const existing = map.get(vf.feedId) ?? [];
+      existing.push(vf.viewId);
+      map.set(vf.feedId, existing);
+    });
+    return map;
+  }, [viewFeeds]);
+
+  const categoryNamesMap = useMemo(() => {
+    const map = new Map<number, string>();
+    contentCategories.forEach((c) => {
+      map.set(c.id, c.name);
+    });
+    return map;
+  }, [contentCategories]);
+
+  const viewNamesMap = useMemo(() => {
+    const map = new Map<number, string>();
+    views
+      .filter((v) => v.id !== UNCATEGORIZED_VIEW_ID)
+      .forEach((v) => {
+        map.set(v.id, v.name);
+      });
+    return map;
+  }, [views]);
+
+  const customViewOptions = useMemo(() => {
+    return views
+      .filter((v) => v.id !== UNCATEGORIZED_VIEW_ID)
+      .map((v) => ({ id: v.id, label: v.name }));
+  }, [views]);
+
+  return {
+    feedCategoriesMap,
+    feedViewsMap,
+    categoryNamesMap,
+    viewNamesMap,
+    customViewOptions,
+  };
+}
+
+export function filterFeeds(
+  feeds: ManagedFeeds,
+  searchQuery: string,
+  maps: {
+    feedCategoriesMap: Map<number, number[]>;
+    feedViewsMap: Map<number, number[]>;
+    categoryNamesMap: Map<number, string>;
+    viewNamesMap: Map<number, string>;
+  },
+) {
+  const { feedCategoriesMap, feedViewsMap, categoryNamesMap, viewNamesMap } =
+    maps;
+  const sorted = [...feeds].sort((a, b) => a.name.localeCompare(b.name));
+  if (!searchQuery.trim()) return sorted;
+
+  const lowercaseQuery = searchQuery.toLowerCase();
+  const matches = (name: string | undefined) =>
+    !!name && name.toLowerCase().includes(lowercaseQuery);
+
+  return sorted.filter((feed) => {
+    if (matches(feed.name)) return true;
+
+    const categoryIds = feedCategoriesMap.get(feed.id);
+    if (categoryIds?.some((id) => matches(categoryNamesMap.get(id)))) {
+      return true;
+    }
+
+    const viewIds = feedViewsMap.get(feed.id);
+    if (viewIds?.some((id) => matches(viewNamesMap.get(id)))) {
+      return true;
+    }
+
+    return false;
+  });
+}
+
+export function sortIdsByName(ids: number[], namesMap: Map<number, string>) {
+  return ids
+    .slice()
+    .sort((a, b) =>
+      (namesMap.get(a) ?? "").localeCompare(namesMap.get(b) ?? ""),
+    );
+}

--- a/apps/app/src/components/feed/read/TruncationAlert.tsx
+++ b/apps/app/src/components/feed/read/TruncationAlert.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import type { useFeeds } from "~/lib/data/feeds";
+import type { useFeedItemValue } from "~/lib/data/store";
+import { useEditFeedMutation } from "~/lib/data/feeds/mutations";
+import { useFeedCategories } from "~/lib/data/feed-categories/store";
+import { useViewFeeds } from "~/lib/data/view-feeds/store";
+import { detectTruncatedContent } from "~/lib/utils/detectTruncatedContent";
+import {
+  hasRespondedToTruncationAlert,
+  setTruncationAlertResponded,
+} from "~/lib/utils/truncationAlert";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
+import { Button } from "~/components/ui/button";
+
+type ReaderFeed = ReturnType<typeof useFeeds>["feeds"][number];
+type ReaderFeedItem = ReturnType<typeof useFeedItemValue>;
+
+export function useTruncationAlert({
+  feed,
+  feedItem,
+  canMutate,
+}: {
+  feed: ReaderFeed | undefined;
+  feedItem: ReaderFeedItem;
+  canMutate: boolean;
+}) {
+  const feedCategories = useFeedCategories();
+  const viewFeeds = useViewFeeds();
+  const { mutate: editFeed } = useEditFeedMutation();
+
+  const [alertDismissed, setAlertDismissed] = useState(false);
+
+  const feedId = feed?.id;
+  const platform = feed?.platform;
+  const hasTruncationAlertResponse = feedId
+    ? hasRespondedToTruncationAlert(feedId)
+    : false;
+
+  const shouldCheckTruncatedContent =
+    !alertDismissed &&
+    platform === "website" &&
+    !!feedId &&
+    !hasTruncationAlertResponse &&
+    !!feedItem;
+  const shouldShowTruncationAlert =
+    shouldCheckTruncatedContent &&
+    feedItem !== undefined &&
+    detectTruncatedContent(feedItem.content, feedItem.contentSnippet);
+
+  const handleAlertResponse = (openLocation: "serial" | "origin") => {
+    if (!feedId || !canMutate) return;
+
+    const categoryIds = feedCategories
+      .filter((fc) => fc.feedId === feedId)
+      .map((fc) => fc.categoryId);
+    const viewIds = viewFeeds
+      .filter((vf) => vf.feedId === feedId)
+      .map((vf) => vf.viewId);
+
+    editFeed({
+      feedId,
+      categoryIds,
+      viewIds,
+      openLocation,
+      name: feed?.name ?? "",
+    });
+
+    setTruncationAlertResponded(feedId);
+    setAlertDismissed(true);
+
+    if (openLocation === "origin" && feedItem?.url) {
+      window.open(feedItem.url, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  return { shouldShowTruncationAlert, handleAlertResponse };
+}
+
+export function TruncationAlert({
+  canMutate,
+  onRespond,
+}: {
+  canMutate: boolean;
+  onRespond: (openLocation: "serial" | "origin") => void;
+}) {
+  return (
+    <div className="w-full px-6">
+      <Alert>
+        <AlertTitle>Possible partial content detected</AlertTitle>
+        <AlertDescription className="mt-2 text-base">
+          It looks like this feed might not be providing all of its content in
+          its feed. Would you like to open future items in the original website?
+        </AlertDescription>
+        <div className="mt-4 flex gap-2">
+          <Button
+            variant="outline"
+            disabled={!canMutate}
+            onClick={() => onRespond("serial")}
+          >
+            No, view in reader
+          </Button>
+          <Button disabled={!canMutate} onClick={() => onRespond("origin")}>
+            Yes, open in website
+          </Button>
+        </div>
+      </Alert>
+    </div>
+  );
+}

--- a/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
+++ b/apps/app/src/components/feed/view-lists/ItemDisplay.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { getBookmarkAddedAt } from "./itemDate";
 import type { ApplicationBookmark } from "~/server/mixed-content/projection";
+import type { ConnectionState } from "~/lib/data/atoms";
 import { KeyboardShortcutDisplay } from "~/components/ButtonWithShortcut";
 import { Button } from "~/components/ui/button";
 import { useFeedItemsSetWatchLaterValueMutation } from "~/lib/data/feed-items/mutations";
@@ -592,6 +593,66 @@ function BookmarkActions({
   );
 }
 
+// Shared offline/open-location link derivation for feed and bookmark rows.
+
+function feedOpensInSerial(feed: { openLocation?: string | null } | undefined) {
+  return feed?.openLocation === "serial" || !feed?.openLocation;
+}
+
+/**
+ * Derives the row link for feed and bookmark items. Offline rows always route
+ * to the local reader; online rows open externally in a new tab when the
+ * content is not rendered in Serial. `relRequiresTarget` preserves the
+ * bookmark behavior of only emitting `rel` alongside an actual `target`,
+ * whereas feed rows keep `rel` for external content even while offline.
+ */
+function deriveItemLink({
+  connectionState,
+  offlineHref,
+  serialHref,
+  externalHref,
+  opensExternally,
+  relRequiresTarget,
+}: {
+  connectionState: ConnectionState;
+  offlineHref: string;
+  serialHref: string;
+  externalHref: string;
+  opensExternally: boolean;
+  relRequiresTarget?: boolean;
+}) {
+  const isOffline = connectionState === "disconnected";
+  const opensInNewTab = !isOffline && opensExternally;
+  const target = opensInNewTab ? ("_blank" as const) : undefined;
+  const rel = (relRequiresTarget ? opensInNewTab : opensExternally)
+    ? ("noopener noreferrer" as const)
+    : undefined;
+  const href = isOffline
+    ? offlineHref
+    : opensExternally
+      ? externalHref
+      : serialHref;
+  return { isOffline, href, target, rel };
+}
+
+function createItemLinkClickHandler({
+  canOpen,
+  target,
+  restorationId,
+}: {
+  canOpen: boolean;
+  target: "_blank" | undefined;
+  restorationId: string;
+}) {
+  return (event: { preventDefault: () => void }) => {
+    if (!canOpen) {
+      event.preventDefault();
+      return;
+    }
+    if (!target) captureRootScrollRestoration(restorationId);
+  };
+}
+
 function BookmarkItemDisplay({
   bookmark,
   size,
@@ -616,72 +677,123 @@ function BookmarkItemDisplay({
     contentType: bookmark.contentType,
     hasBody: capture !== undefined,
   });
-  const isOffline = connectionState === "disconnected";
-  const href = isOffline ? `/read/${bookmark.id}` : destination.href;
-  const target = isOffline
-    ? undefined
-    : destination.external
-      ? "_blank"
-      : undefined;
-  const rel = target ? "noopener noreferrer" : undefined;
-  const isLarge = size === "large";
-  const postedAt = getBookmarkAddedAt(bookmark);
+  const { href, target, rel } = deriveItemLink({
+    connectionState,
+    offlineHref: `/read/${bookmark.id}`,
+    serialHref: destination.href,
+    externalHref: destination.href,
+    opensExternally: destination.external,
+    relRequiresTarget: true,
+  });
+  const handleLinkClick = createItemLinkClickHandler({
+    canOpen,
+    target,
+    restorationId: bookmark.id,
+  });
+  const layoutProps: BookmarkLayoutProps = {
+    bookmark,
+    isLarge: size === "large",
+    isSelected,
+    onSelect,
+    canOpen,
+    href,
+    target,
+    rel,
+    onLinkClick: handleLinkClick,
+    feedName: bookmark.siteName ?? new URL(bookmark.sourceUrl).hostname,
+    postedAt: getBookmarkAddedAt(bookmark),
+  };
 
-  if (grid) {
-    return (
-      <article
-        data-item-id={bookmark.id}
-        data-entity-kind="bookmark"
-        onMouseEnter={onSelect}
+  if (grid) return <BookmarkGridItem {...layoutProps} />;
+  return <BookmarkListItem {...layoutProps} />;
+}
+
+interface BookmarkLayoutProps {
+  bookmark: ApplicationBookmark;
+  isLarge: boolean;
+  isSelected: boolean | undefined;
+  onSelect: (() => void) | undefined;
+  canOpen: boolean;
+  href: string;
+  target: "_blank" | undefined;
+  rel: "noopener noreferrer" | undefined;
+  onLinkClick: (event: { preventDefault: () => void }) => void;
+  feedName: string;
+  postedAt: Date;
+}
+
+function BookmarkGridItem({
+  bookmark,
+  isLarge,
+  isSelected,
+  onSelect,
+  canOpen,
+  href,
+  target,
+  rel,
+  onLinkClick,
+  feedName,
+  postedAt,
+}: BookmarkLayoutProps) {
+  return (
+    <article
+      data-item-id={bookmark.id}
+      data-entity-kind="bookmark"
+      onMouseEnter={onSelect}
+      className={clsx(
+        "group relative flex h-full w-full flex-col",
+        !canOpen && "opacity-50",
+      )}
+    >
+      <Link
+        to={href}
+        target={target}
+        rel={rel}
+        aria-disabled={!canOpen}
+        tabIndex={canOpen ? undefined : -1}
+        onClick={onLinkClick}
         className={clsx(
-          "group relative flex h-full w-full flex-col",
-          !canOpen && "opacity-50",
+          "flex h-full flex-1 flex-col rounded p-2 text-left",
+          isSelected && "md:bg-muted",
+          !canOpen && "cursor-not-allowed",
         )}
       >
-        <Link
-          to={href}
-          target={target}
-          rel={rel}
-          aria-disabled={!canOpen}
-          tabIndex={canOpen ? undefined : -1}
-          onClick={(event) => {
-            if (!canOpen) {
-              event.preventDefault();
-              return;
-            }
-            if (!target) captureRootScrollRestoration(bookmark.id);
-          }}
-          className={clsx(
-            "flex h-full flex-1 flex-col rounded p-2 text-left",
-            isSelected && "md:bg-muted",
-            !canOpen && "cursor-not-allowed",
-          )}
-        >
-          <BookmarkThumbnail
-            bookmark={bookmark}
-            layout={isLarge ? "large-grid" : "grid"}
-          />
-          <div className="flex flex-1 flex-col justify-center pt-2">
-            <ItemTitle title={bookmark.title} lineClamp={isLarge ? 1 : 2} />
-            <ItemMeta
-              author={bookmark.author ?? undefined}
-              feedName={
-                bookmark.siteName ?? new URL(bookmark.sourceUrl).hostname
-              }
-              postedAt={postedAt}
-              className="pt-0.5"
-            />
-          </div>
-        </Link>
-        <BookmarkActions
+        <BookmarkThumbnail
           bookmark={bookmark}
-          layout="grid"
-          isSelected={isSelected}
+          layout={isLarge ? "large-grid" : "grid"}
         />
-      </article>
-    );
-  }
+        <div className="flex flex-1 flex-col justify-center pt-2">
+          <ItemTitle title={bookmark.title} lineClamp={isLarge ? 1 : 2} />
+          <ItemMeta
+            author={bookmark.author ?? undefined}
+            feedName={feedName}
+            postedAt={postedAt}
+            className="pt-0.5"
+          />
+        </div>
+      </Link>
+      <BookmarkActions
+        bookmark={bookmark}
+        layout="grid"
+        isSelected={isSelected}
+      />
+    </article>
+  );
+}
 
+function BookmarkListItem({
+  bookmark,
+  isLarge,
+  isSelected,
+  onSelect,
+  canOpen,
+  href,
+  target,
+  rel,
+  onLinkClick,
+  feedName,
+  postedAt,
+}: BookmarkLayoutProps) {
   return (
     <article
       data-item-id={bookmark.id}
@@ -701,13 +813,7 @@ function BookmarkItemDisplay({
         rel={rel}
         aria-disabled={!canOpen}
         tabIndex={canOpen ? undefined : -1}
-        onClick={(event) => {
-          if (!canOpen) {
-            event.preventDefault();
-            return;
-          }
-          if (!target) captureRootScrollRestoration(bookmark.id);
-        }}
+        onClick={onLinkClick}
         className={clsx(
           "flex w-full flex-1 flex-col gap-4 px-6 pt-4 text-left md:flex-row md:items-center md:rounded md:px-2 md:py-2",
           isLarge ? "pb-1 md:pb-2" : "pb-4 md:h-20 md:py-0",
@@ -730,7 +836,7 @@ function BookmarkItemDisplay({
           )}
           <ItemMeta
             author={bookmark.author ?? undefined}
-            feedName={bookmark.siteName ?? new URL(bookmark.sourceUrl).hostname}
+            feedName={feedName}
             postedAt={postedAt}
           />
         </div>
@@ -773,23 +879,27 @@ function FeedItemDisplay({
     entity: item,
   });
   const shouldOpenInSerial =
-    destination.renderer !== "origin" &&
-    (feed?.openLocation === "serial" || !feed?.openLocation);
+    destination.renderer !== "origin" && feedOpensInSerial(feed);
 
   const canOpen = canOpenContent({
     connectionState,
     contentType: item.contentType,
     hasBody: hasRetainedFeedBody(item, hasRetainedBody),
   });
-  const isOffline = connectionState === "disconnected";
-  const href = isOffline
-    ? `/read/${item.id}`
-    : shouldOpenInSerial
-      ? destination.href
-      : item.url;
-
-  const target = isOffline || shouldOpenInSerial ? undefined : "_blank";
-  const rel = shouldOpenInSerial ? undefined : "noopener noreferrer";
+  const { isOffline, href, target, rel } = deriveItemLink({
+    connectionState,
+    offlineHref: `/read/${item.id}`,
+    serialHref: destination.href,
+    externalHref: item.url,
+    opensExternally: !shouldOpenInSerial,
+  });
+  const preload =
+    canOpen && !target && !isOffline ? ("intent" as const) : undefined;
+  const handleLinkClick = createItemLinkClickHandler({
+    canOpen,
+    target,
+    restorationId: contentId,
+  });
 
   const isLarge = size === "large";
 
@@ -809,16 +919,10 @@ function FeedItemDisplay({
         to={href}
         target={target}
         rel={rel}
-        preload={canOpen && !target && !isOffline ? "intent" : undefined}
+        preload={preload}
         aria-disabled={!canOpen}
         tabIndex={canOpen ? undefined : -1}
-        onClick={(event) => {
-          if (!canOpen) {
-            event.preventDefault();
-            return;
-          }
-          if (!target) captureRootScrollRestoration(contentId);
-        }}
+        onClick={handleLinkClick}
         className={clsx(
           "flex w-full flex-1 flex-col gap-4 px-6 pt-4 text-left md:flex-row md:items-center md:rounded md:px-2 md:py-2",
           isLarge ? "pb-1 md:pb-2" : "pb-4 md:h-20 md:py-0",
@@ -901,23 +1005,27 @@ function FeedGridItemDisplay({
 
   const itemDestination = item.platform === "website" ? "read" : "watch";
 
-  const shouldOpenInSerial =
-    feed?.openLocation === "serial" || !feed?.openLocation;
+  const shouldOpenInSerial = feedOpensInSerial(feed);
 
   const canOpen = canOpenContent({
     connectionState,
     contentType: item.contentType,
     hasBody: hasRetainedFeedBody(item, hasRetainedBody),
   });
-  const isOffline = connectionState === "disconnected";
-  const href = isOffline
-    ? `/read/${item.id}`
-    : shouldOpenInSerial
-      ? `/${itemDestination}/${item.id}`
-      : item.url;
-
-  const target = isOffline || shouldOpenInSerial ? undefined : "_blank";
-  const rel = shouldOpenInSerial ? undefined : "noopener noreferrer";
+  const { isOffline, href, target, rel } = deriveItemLink({
+    connectionState,
+    offlineHref: `/read/${item.id}`,
+    serialHref: `/${itemDestination}/${item.id}`,
+    externalHref: item.url,
+    opensExternally: !shouldOpenInSerial,
+  });
+  const preload =
+    canOpen && !target && !isOffline ? ("intent" as const) : undefined;
+  const handleLinkClick = createItemLinkClickHandler({
+    canOpen,
+    target,
+    restorationId: contentId,
+  });
 
   const isLarge = size === "large";
 
@@ -934,16 +1042,10 @@ function FeedGridItemDisplay({
         to={href}
         target={target}
         rel={rel}
-        preload={canOpen && !target && !isOffline ? "intent" : undefined}
+        preload={preload}
         aria-disabled={!canOpen}
         tabIndex={canOpen ? undefined : -1}
-        onClick={(event) => {
-          if (!canOpen) {
-            event.preventDefault();
-            return;
-          }
-          if (!target) captureRootScrollRestoration(contentId);
-        }}
+        onClick={handleLinkClick}
         className={clsx(
           "flex h-full flex-1 flex-col rounded p-2 text-left",
           isSelected && "md:bg-muted",

--- a/apps/app/src/components/feed/watch/[id]/ContentActions.tsx
+++ b/apps/app/src/components/feed/watch/[id]/ContentActions.tsx
@@ -23,9 +23,7 @@ import { useShortcut } from "~/lib/hooks/useShortcut";
 import { SHORTCUT_KEYS } from "~/lib/constants/shortcuts";
 import { useCanMutate } from "~/lib/data/offline-mutations";
 
-export function ContentActions({ contentID }: { contentID: string }) {
-  const { view } = useView();
-
+function useContentActions(contentID: string) {
   const video = useFeedItemValue(contentID);
   const canMutate = useCanMutate();
 
@@ -37,11 +35,6 @@ export function ContentActions({ contentID }: { contentID: string }) {
   const showInstapaperAction = useShowInstapaperAction(contentID);
   const { mutateAsync: saveToInstapaper, isPending: isSavingToInstapaper } =
     useSaveToInstapaperMutation(contentID);
-
-  const isWatched = video?.isWatched;
-  const isWatchLater = video?.isWatchLater;
-
-  const shouldHideFullscreenActions = useMediaQuery("(min-aspect-ratio: 4/3)");
 
   const toggleWatchLater = async () => {
     if (!video || !canMutate) return;
@@ -78,51 +71,87 @@ export function ContentActions({ contentID }: { contentID: string }) {
     void handleSaveToInstapaper();
   });
 
-  if (!video) return null;
+  return {
+    video,
+    canMutate,
+    isWatched: video?.isWatched,
+    isWatchLater: video?.isWatchLater,
+    showInstapaperAction,
+    isSavingToInstapaper,
+    toggleWatchLater,
+    toggleWatched,
+    handleSaveToInstapaper,
+  };
+}
 
-  if (view === "fullscreen") {
-    if (shouldHideFullscreenActions) return null;
+type ContentActionsState = ReturnType<typeof useContentActions>;
 
-    return (
-      <div className="absolute inset-x-0 bottom-0 z-0 flex w-full items-center justify-center gap-2 p-6">
-        {showInstapaperAction && (
-          <Button
-            variant="outline"
-            onClick={handleSaveToInstapaper}
-            size="icon"
-            disabled={!canMutate || isSavingToInstapaper}
-          >
-            <SendIcon size={16} />
-          </Button>
+function FullscreenContentActions({
+  actions,
+}: {
+  actions: ContentActionsState;
+}) {
+  const {
+    canMutate,
+    isWatched,
+    isWatchLater,
+    showInstapaperAction,
+    isSavingToInstapaper,
+    toggleWatchLater,
+    toggleWatched,
+    handleSaveToInstapaper,
+  } = actions;
+  return (
+    <div className="absolute inset-x-0 bottom-0 z-0 flex w-full items-center justify-center gap-2 p-6">
+      {showInstapaperAction && (
+        <Button
+          variant="outline"
+          onClick={handleSaveToInstapaper}
+          size="icon"
+          disabled={!canMutate || isSavingToInstapaper}
+        >
+          <SendIcon size={16} />
+        </Button>
+      )}
+      <Button
+        variant={isWatchLater ? "secondary" : "outline"}
+        onClick={toggleWatchLater}
+        size="icon"
+        disabled={!canMutate}
+      >
+        {isWatchLater ? (
+          <CheckIcon size={16} />
+        ) : (
+          <BookmarkCheckIcon size={16} />
         )}
-        <Button
-          variant={isWatchLater ? "secondary" : "outline"}
-          onClick={toggleWatchLater}
-          size="icon"
-          disabled={!canMutate}
-        >
-          {isWatchLater ? (
-            <CheckIcon size={16} />
-          ) : (
-            <BookmarkCheckIcon size={16} />
-          )}
-        </Button>
-        <Button
-          variant={isWatched ? "secondary" : "outline"}
-          onClick={toggleWatched}
-          size="icon"
-          disabled={!canMutate}
-        >
-          {isWatched ? (
-            <ArchiveRestoreIcon size={16} />
-          ) : (
-            <ArchiveIcon size={16} />
-          )}
-        </Button>
-      </div>
-    );
-  }
+      </Button>
+      <Button
+        variant={isWatched ? "secondary" : "outline"}
+        onClick={toggleWatched}
+        size="icon"
+        disabled={!canMutate}
+      >
+        {isWatched ? (
+          <ArchiveRestoreIcon size={16} />
+        ) : (
+          <ArchiveIcon size={16} />
+        )}
+      </Button>
+    </div>
+  );
+}
 
+function DefaultContentActions({ actions }: { actions: ContentActionsState }) {
+  const {
+    canMutate,
+    isWatched,
+    isWatchLater,
+    showInstapaperAction,
+    isSavingToInstapaper,
+    toggleWatchLater,
+    toggleWatched,
+    handleSaveToInstapaper,
+  } = actions;
   return (
     <div className="flex w-full items-center justify-center gap-2 p-6">
       {showInstapaperAction && (
@@ -171,4 +200,21 @@ export function ContentActions({ contentID }: { contentID: string }) {
       </ButtonWithShortcut>
     </div>
   );
+}
+
+export function ContentActions({ contentID }: { contentID: string }) {
+  const { view } = useView();
+  const actions = useContentActions(contentID);
+
+  const shouldHideFullscreenActions = useMediaQuery("(min-aspect-ratio: 4/3)");
+
+  if (!actions.video) return null;
+
+  if (view === "fullscreen") {
+    if (shouldHideFullscreenActions) return null;
+
+    return <FullscreenContentActions actions={actions} />;
+  }
+
+  return <DefaultContentActions actions={actions} />;
 }

--- a/apps/app/src/lib/hooks/useScrollEdgeState.ts
+++ b/apps/app/src/lib/hooks/useScrollEdgeState.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react";
+
+export function useScrollEdgeState() {
+  const [isScrolled, setIsScrolled] = useState(false);
+  const [isAtBottom, setIsAtBottom] = useState(false);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!headerRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsScrolled(!entry?.isIntersecting);
+      },
+      { threshold: 0 },
+    );
+
+    observer.observe(headerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!bottomRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsAtBottom(entry?.isIntersecting ?? false);
+      },
+      { threshold: 0 },
+    );
+
+    observer.observe(bottomRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return { headerRef, bottomRef, isScrolled, isAtBottom };
+}

--- a/apps/app/tests/e2e/self-hosted/add-feed.spec.ts
+++ b/apps/app/tests/e2e/self-hosted/add-feed.spec.ts
@@ -265,6 +265,46 @@ test.describe("add feed manually", () => {
     await dialog.getByRole("button", { name: "Save" }).click();
     await expect(page.getByText("Feed updated!")).toBeVisible();
 
+    const feedSidebarItem = page
+      .locator('[data-sidebar="menu-item"]')
+      .filter({ has: page.getByText("CGP Grey", { exact: true }) });
+
+    // Keep a subsequent mutation pending while the sidebar-owned dialog's
+    // portal closes and reopens. Its always-mounted owner must retain the
+    // pending state and prevent a duplicate update until the request settles.
+    let releaseFeedUpdate!: () => void;
+    const feedUpdateCanFinish = new Promise<void>((resolve) => {
+      releaseFeedUpdate = resolve;
+    });
+    let feedUpdateRequests = 0;
+    await page.route("**/api/rpc/feed/update", async (route) => {
+      feedUpdateRequests += 1;
+      await feedUpdateCanFinish;
+      await route.continue();
+    });
+
+    await feedSidebarItem.getByRole("button").nth(1).click();
+    const saveButton = dialog.getByRole("button", { name: /^Sav/ });
+    await saveButton.click();
+    await expect(saveButton).toBeDisabled();
+    await expect(saveButton).toHaveText("Saving...");
+    await dialog.getByRole("button", { name: "Close" }).click();
+    await expect(
+      dialog.getByRole("heading", { name: "Edit Feed" }),
+    ).toHaveCount(0);
+    await feedSidebarItem.getByRole("button").nth(1).click();
+    const reopenedSaveButton = dialog.getByRole("button", {
+      name: "Saving...",
+    });
+    await expect(reopenedSaveButton).toBeDisabled();
+    expect(feedUpdateRequests).toBe(1);
+
+    releaseFeedUpdate();
+    await expect(
+      dialog.getByRole("heading", { name: "Edit Feed" }),
+    ).toHaveCount(0);
+    await page.unroute("**/api/rpc/feed/update");
+
     // Verify the feed appears in the sidebar
     const feedsSection = page.locator('[data-sidebar="group"]').filter({
       has: page.locator('[data-sidebar="group-label"]', { hasText: "Feeds" }),

--- a/apps/app/vitest.config.ts
+++ b/apps/app/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   envDir: "./tests",
   test: {
     include: ["tests/unit/**/*.test.ts"],
-    hookTimeout: process.env.CI ? 15_000 : 10_000,
+    hookTimeout: process.env.CI ? 60_000 : 10_000,
     testTimeout: process.env.CI ? 15_000 : 5_000,
   },
   resolve: {

--- a/apps/www/turbo.json
+++ b/apps/www/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "typecheck": {
+      "dependsOn": ["^typecheck", "build:artifact"]
+    }
+  }
+}

--- a/packages/ui/src/selectable-chip-list.tsx
+++ b/packages/ui/src/selectable-chip-list.tsx
@@ -72,26 +72,7 @@ function measureVisibleCount(container: HTMLElement) {
   return { count, clipHeight: rowCount > MAX_ROWS ? clipBottom : 0 };
 }
 
-export function SelectableChipList({
-  label,
-  options,
-  selectedIds,
-  onToggle,
-  onCreate,
-  createLabel = `Create ${label.toLowerCase()}`,
-  createPlaceholder = `New ${label.toLowerCase().replace(/s$/, "")} name...`,
-  prioritizedIds = new Set(),
-  emptyMessage = `No ${label.toLowerCase()} available`,
-  disabled = false,
-}: SelectableChipListProps) {
-  const [createOpen, setCreateOpen] = useState(false);
-  const [createSearch, setCreateSearch] = useState("");
-  const [isCreating, setIsCreating] = useState(false);
-  const createInputRef = useRef<HTMLInputElement>(null);
-  const sortedOptions = sortSelectableChipOptions(options, prioritizedIds);
-  const selectedSet = new Set(selectedIds);
-  const totalCount = sortedOptions.length;
-  const orderKey = sortedOptions.map((option) => option.id).join(",");
+function useChipRowPagination(totalCount: number, orderKey: string) {
   const [visibleCount, setVisibleCount] = useState(0);
   const [firstPageCount, setFirstPageCount] = useState(0);
   const maxClipHeightRef = useRef(0);
@@ -113,23 +94,6 @@ export function SelectableChipList({
   }
 
   const { offset, currentPage } = pagination;
-  const renderOptions = sortedOptions.slice(offset, offset + RENDER_CHUNK);
-  const hasMore = totalCount > 0 && offset + visibleCount < totalCount;
-  const hasPrevious = offset > 0;
-  const showPagination = hasMore || hasPrevious;
-  const estimatedTotalPages =
-    firstPageCount > 0 ? Math.ceil(totalCount / firstPageCount) : 1;
-  const trimmedCreateSearch = createSearch.trim();
-  const hasExactCreateMatch = options.some(
-    (option) =>
-      option.label.toLowerCase() === trimmedCreateSearch.toLowerCase(),
-  );
-  const canCreate =
-    Boolean(onCreate) &&
-    !disabled &&
-    Boolean(trimmedCreateSearch) &&
-    !hasExactCreateMatch &&
-    !isCreating;
 
   useLayoutEffect(() => {
     if (totalCount !== measuredTotalCountRef.current) {
@@ -180,6 +144,44 @@ export function SelectableChipList({
     }));
   };
 
+  const hasMore = totalCount > 0 && offset + visibleCount < totalCount;
+  const hasPrevious = offset > 0;
+  const estimatedTotalPages =
+    firstPageCount > 0 ? Math.ceil(totalCount / firstPageCount) : 1;
+
+  return {
+    chipContainerRef,
+    offset,
+    currentPage,
+    hasMore,
+    hasPrevious,
+    showPagination: hasMore || hasPrevious,
+    estimatedTotalPages,
+    goForward,
+    goBack,
+  };
+}
+
+function useChipCreateFlow(
+  options: SelectableChipOption[],
+  onCreate: SelectableChipListProps["onCreate"],
+  disabled: boolean,
+) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createSearch, setCreateSearch] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const trimmedCreateSearch = createSearch.trim();
+  const hasExactCreateMatch = options.some(
+    (option) =>
+      option.label.toLowerCase() === trimmedCreateSearch.toLowerCase(),
+  );
+  const canCreate =
+    Boolean(onCreate) &&
+    !disabled &&
+    Boolean(trimmedCreateSearch) &&
+    !hasExactCreateMatch &&
+    !isCreating;
+
   const handleCreate = async () => {
     if (!onCreate || !canCreate) return;
     setIsCreating(true);
@@ -194,6 +196,206 @@ export function SelectableChipList({
     }
   };
 
+  return {
+    createOpen,
+    setCreateOpen,
+    createSearch,
+    setCreateSearch,
+    trimmedCreateSearch,
+    hasExactCreateMatch,
+    canCreate,
+    handleCreate,
+  };
+}
+
+function ChipCreatePopover({
+  label,
+  createLabel,
+  createPlaceholder,
+  disabled,
+  createFlow,
+}: {
+  label: string;
+  createLabel: string;
+  createPlaceholder: string;
+  disabled: boolean;
+  createFlow: ReturnType<typeof useChipCreateFlow>;
+}) {
+  const createInputRef = useRef<HTMLInputElement>(null);
+  const {
+    createOpen,
+    setCreateOpen,
+    createSearch,
+    setCreateSearch,
+    trimmedCreateSearch,
+    hasExactCreateMatch,
+    canCreate,
+    handleCreate,
+  } = createFlow;
+
+  return (
+    <Popover
+      open={createOpen}
+      onOpenChange={(open) => {
+        setCreateOpen(open);
+        if (!open) setCreateSearch("");
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-6"
+          aria-label={createLabel}
+          disabled={disabled}
+        >
+          <PlusIcon size={14} />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[250px] p-0" align="start">
+        <Command
+          shouldFilter={false}
+          className="[&_[cmdk-item]]:pointer-events-auto [&_[cmdk-item]]:opacity-100"
+        >
+          <CommandInput
+            ref={createInputRef}
+            placeholder={createPlaceholder}
+            value={createSearch}
+            onValueChange={setCreateSearch}
+          />
+          <CommandList>
+            {!trimmedCreateSearch && (
+              <CommandEmpty>Enter a name to create.</CommandEmpty>
+            )}
+            {hasExactCreateMatch && (
+              <CommandEmpty>
+                A {label.toLowerCase().replace(/s$/, "")} with this name
+                already exists.
+              </CommandEmpty>
+            )}
+            {canCreate && (
+              <CommandGroup>
+                <CommandItem
+                  value="__create__"
+                  onSelect={() => void handleCreate()}
+                >
+                  <PlusIcon className="mr-2 size-4" />
+                  <span className="truncate">
+                    {createLabel} &quot;{trimmedCreateSearch}&quot;
+                  </span>
+                </CommandItem>
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ChipPaginationControls({
+  label,
+  pagination,
+}: {
+  label: string;
+  pagination: ReturnType<typeof useChipRowPagination>;
+}) {
+  const { currentPage, estimatedTotalPages, hasPrevious, hasMore, goBack, goForward } =
+    pagination;
+
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-muted-foreground text-xs">
+        {currentPage}/{estimatedTotalPages}
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-6"
+        disabled={!hasPrevious}
+        onClick={goBack}
+        aria-label={`Previous ${label.toLowerCase()} page`}
+      >
+        <ChevronLeftIcon size={14} />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-6"
+        disabled={!hasMore}
+        onClick={goForward}
+        aria-label={`Next ${label.toLowerCase()} page`}
+      >
+        <ChevronRightIcon size={14} />
+      </Button>
+    </div>
+  );
+}
+
+function ChipButton({
+  option,
+  isSelected,
+  isPrioritized,
+  disabled,
+  onToggle,
+}: {
+  option: SelectableChipOption;
+  isSelected: boolean;
+  isPrioritized: boolean;
+  disabled: boolean;
+  onToggle: (id: number) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={isSelected}
+      disabled={disabled}
+      onClick={() => onToggle(option.id)}
+      className={cn(
+        badgeVariants({
+          variant: isSelected ? "default" : "outline",
+        }),
+        "max-w-full min-w-0 shrink cursor-pointer [&>svg]:shrink-0",
+        isPrioritized && !isSelected && "border-primary/50",
+        !isPrioritized && !isSelected && "border-dashed",
+      )}
+    >
+      {isSelected ? (
+        <CheckIcon aria-hidden="true" />
+      ) : (
+        <PlusIcon aria-hidden="true" className="text-muted-foreground" />
+      )}
+      <span className="truncate">{option.label}</span>
+    </button>
+  );
+}
+
+export function SelectableChipList({
+  label,
+  options,
+  selectedIds,
+  onToggle,
+  onCreate,
+  createLabel = `Create ${label.toLowerCase()}`,
+  createPlaceholder = `New ${label.toLowerCase().replace(/s$/, "")} name...`,
+  prioritizedIds = new Set(),
+  emptyMessage = `No ${label.toLowerCase()} available`,
+  disabled = false,
+}: SelectableChipListProps) {
+  const sortedOptions = sortSelectableChipOptions(options, prioritizedIds);
+  const selectedSet = new Set(selectedIds);
+  const totalCount = sortedOptions.length;
+  const orderKey = sortedOptions.map((option) => option.id).join(",");
+  const pagination = useChipRowPagination(totalCount, orderKey);
+  const createFlow = useChipCreateFlow(options, onCreate, disabled);
+  const renderOptions = sortedOptions.slice(
+    pagination.offset,
+    pagination.offset + RENDER_CHUNK,
+  );
+
   return (
     <div
       className="grid min-w-0 gap-2"
@@ -204,131 +406,34 @@ export function SelectableChipList({
         <div className="flex items-center gap-2">
           <Label>{label}</Label>
           {onCreate && (
-            <Popover
-              open={createOpen}
-              onOpenChange={(open) => {
-                setCreateOpen(open);
-                if (!open) setCreateSearch("");
-              }}
-            >
-              <PopoverTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-6"
-                  aria-label={createLabel}
-                  disabled={disabled}
-                >
-                  <PlusIcon size={14} />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-[250px] p-0" align="start">
-                <Command
-                  shouldFilter={false}
-                  className="[&_[cmdk-item]]:pointer-events-auto [&_[cmdk-item]]:opacity-100"
-                >
-                  <CommandInput
-                    ref={createInputRef}
-                    placeholder={createPlaceholder}
-                    value={createSearch}
-                    onValueChange={setCreateSearch}
-                  />
-                  <CommandList>
-                    {!trimmedCreateSearch && (
-                      <CommandEmpty>Enter a name to create.</CommandEmpty>
-                    )}
-                    {hasExactCreateMatch && (
-                      <CommandEmpty>
-                        A {label.toLowerCase().replace(/s$/, "")} with this name
-                        already exists.
-                      </CommandEmpty>
-                    )}
-                    {canCreate && (
-                      <CommandGroup>
-                        <CommandItem
-                          value="__create__"
-                          onSelect={() => void handleCreate()}
-                        >
-                          <PlusIcon className="mr-2 size-4" />
-                          <span className="truncate">
-                            {createLabel} &quot;{trimmedCreateSearch}&quot;
-                          </span>
-                        </CommandItem>
-                      </CommandGroup>
-                    )}
-                  </CommandList>
-                </Command>
-              </PopoverContent>
-            </Popover>
+            <ChipCreatePopover
+              label={label}
+              createLabel={createLabel}
+              createPlaceholder={createPlaceholder}
+              disabled={disabled}
+              createFlow={createFlow}
+            />
           )}
         </div>
-        {showPagination && (
-          <div className="flex items-center gap-1">
-            <span className="text-muted-foreground text-xs">
-              {currentPage}/{estimatedTotalPages}
-            </span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="size-6"
-              disabled={!hasPrevious}
-              onClick={goBack}
-              aria-label={`Previous ${label.toLowerCase()} page`}
-            >
-              <ChevronLeftIcon size={14} />
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="size-6"
-              disabled={!hasMore}
-              onClick={goForward}
-              aria-label={`Next ${label.toLowerCase()} page`}
-            >
-              <ChevronRightIcon size={14} />
-            </Button>
-          </div>
+        {pagination.showPagination && (
+          <ChipPaginationControls label={label} pagination={pagination} />
         )}
       </div>
       {totalCount > 0 ? (
         <div
-          ref={chipContainerRef}
+          ref={pagination.chipContainerRef}
           className="relative flex min-w-0 flex-wrap content-start gap-1 overflow-hidden"
         >
-          {renderOptions.map((option) => {
-            const isSelected = selectedSet.has(option.id);
-            const isPrioritized = prioritizedIds.has(option.id);
-            return (
-              <button
-                key={option.id}
-                type="button"
-                aria-pressed={isSelected}
-                disabled={disabled}
-                onClick={() => onToggle(option.id)}
-                className={cn(
-                  badgeVariants({
-                    variant: isSelected ? "default" : "outline",
-                  }),
-                  "max-w-full min-w-0 shrink cursor-pointer [&>svg]:shrink-0",
-                  isPrioritized && !isSelected && "border-primary/50",
-                  !isPrioritized && !isSelected && "border-dashed",
-                )}
-              >
-                {isSelected ? (
-                  <CheckIcon aria-hidden="true" />
-                ) : (
-                  <PlusIcon
-                    aria-hidden="true"
-                    className="text-muted-foreground"
-                  />
-                )}
-                <span className="truncate">{option.label}</span>
-              </button>
-            );
-          })}
+          {renderOptions.map((option) => (
+            <ChipButton
+              key={option.id}
+              option={option}
+              isSelected={selectedSet.has(option.id)}
+              isPrioritized={prioritizedIds.has(option.id)}
+              disabled={disabled}
+              onToggle={onToggle}
+            />
+          ))}
         </div>
       ) : (
         <p className="text-muted-foreground text-sm">{emptyMessage}</p>


### PR DESCRIPTION
- refactor components flagged by react doctor's high-complexity rule (atproto handle field and connection row, manage feeds page, opml import page, feed reader, edit feed dialog, public signup toggle, account dropdown, watch content actions, item display, selectable chip list)
- dedupe the shared offline/open-location link derivation in item display
- use a set for the process-group lookup in the e2e cleanup script
- raise the ci vitest hook timeout to 60s for migration-heavy database setup
- add a package-scoped turbo config so www typecheck and build never sync the astro content layer concurrently